### PR TITLE
feat: add GitHub Actions CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+defaults:
+  run:
+    working-directory: link-crawler
+
+jobs:
+  lint:
+    name: Lint (Biome)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun run check
+
+  typecheck:
+    name: Type Check (TypeScript)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun run typecheck
+
+  test:
+    name: Test (Vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun run test


### PR DESCRIPTION
## Summary
Add GitHub Actions CI workflow for the link-crawler project.

## Changes
- Create `.github/workflows/ci.yml` with three parallel jobs:
  - **Lint (Biome)**: Runs `bun run check`
  - **Type Check (TypeScript)**: Runs `bun run typecheck`
  - **Test (Vitest)**: Runs `bun run test`

## CI Triggers
- Push to `main` branch
- Pull requests targeting `main` branch

## Notes
- Uses Bun environment via `oven-sh/setup-bun@v2`
- Jobs run in parallel for faster feedback
- All commands run in the `link-crawler` directory

⚠️ **Note**: There is a pre-existing test failure in `tests/unit/config.test.ts` related to the `spa` option that was removed in a recent refactor (commit 79a7530). This should be fixed in a separate PR.

Closes #24