### PR TITLE
feat(link-crawler): add Hasher module for SHA256 diff detection

### DIFF
--- a/link-crawler/src/diff/hasher.ts
+++ b/link-crawler/src/diff/hasher.ts
@@ -1,0 +1,78 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+/** ページハッシュマップ型 */
+export interface PageHash {
+	url: string;
+	hash: string;
+}
+
+/** index.json構造（ハッシュ読み込み用） */
+interface IndexJson {
+	pages?: Array<{
+		url: string;
+		hash?: string;
+	}>;
+}
+
+/**
+ * コンテンツのSHA256ハッシュを計算
+ * @param content ハッシュ計算対象の文字列
+ * @returns SHA256ハッシュ（16進数文字列）
+ */
+export function computeHash(content: string): string {
+	return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+/**
+ * ハッシュ管理クラス
+ * 既存のindex.jsonからハッシュを読み込み、差分検知を行う
+ */
+export class Hasher {
+	private hashes = new Map<string, string>();
+
+	/**
+	 * index.jsonからハッシュを読み込む
+	 * @param indexPath index.jsonのパス
+	 */
+	async loadHashes(indexPath: string): Promise<void> {
+		try {
+			const content = await readFile(indexPath, "utf8");
+			const data: IndexJson = JSON.parse(content);
+
+			if (data.pages) {
+				for (const page of data.pages) {
+					if (page.hash) {
+						this.hashes.set(page.url, page.hash);
+					}
+				}
+			}
+		} catch {
+			// ファイルが存在しない場合は空のまま
+			this.hashes.clear();
+		}
+	}
+
+	/**
+	 * URLのコンテンツが変更されたかを判定
+	 * @param url 対象URL
+	 * @param newHash 新しいハッシュ値
+	 * @returns 変更があればtrue、なければfalse
+	 */
+	isChanged(url: string, newHash: string): boolean {
+		const existingHash = this.hashes.get(url);
+		if (existingHash === undefined) {
+			return true; // 新規ページは変更扱い
+		}
+		return existingHash !== newHash;
+	}
+
+	/**
+	 * 既存のハッシュを取得
+	 * @param url 対象URL
+	 * @returns ハッシュ値、存在しなければundefined
+	 */
+	getHash(url: string): string | undefined {
+		return this.hashes.get(url);
+	}
+}

--- a/link-crawler/src/diff/index.ts
+++ b/link-crawler/src/diff/index.ts
@@ -1,0 +1,1 @@
+export { computeHash, Hasher, type PageHash } from "./hasher.js";

--- a/link-crawler/tests/unit/hasher.test.ts
+++ b/link-crawler/tests/unit/hasher.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFile, mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { computeHash, Hasher } from "../../src/diff/hasher.js";
+
+describe("computeHash", () => {
+	it("should compute SHA256 hash of content", () => {
+		const hash = computeHash("hello world");
+		// SHA256 hash of "hello world"
+		expect(hash).toBe(
+			"b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+		);
+	});
+
+	it("should return different hash for different content", () => {
+		const hash1 = computeHash("content1");
+		const hash2 = computeHash("content2");
+		expect(hash1).not.toBe(hash2);
+	});
+
+	it("should return same hash for same content", () => {
+		const hash1 = computeHash("same content");
+		const hash2 = computeHash("same content");
+		expect(hash1).toBe(hash2);
+	});
+
+	it("should handle empty string", () => {
+		const hash = computeHash("");
+		expect(hash).toBe(
+			"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		);
+	});
+
+	it("should handle unicode content", () => {
+		const hash = computeHash("こんにちは世界");
+		expect(hash).toHaveLength(64); // SHA256 = 256 bits = 64 hex chars
+	});
+});
+
+describe("Hasher", () => {
+	const testDir = join(process.cwd(), "test-temp-hasher");
+	let hasher: Hasher;
+
+	beforeEach(async () => {
+		hasher = new Hasher();
+		await mkdir(testDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(testDir, { recursive: true, force: true });
+	});
+
+	describe("loadHashes", () => {
+		it("should load hashes from index.json", async () => {
+			const indexData = {
+				pages: [
+					{ url: "https://example.com/page1", hash: "hash1" },
+					{ url: "https://example.com/page2", hash: "hash2" },
+				],
+			};
+			await writeFile(
+				join(testDir, "index.json"),
+				JSON.stringify(indexData),
+			);
+
+			await hasher.loadHashes(join(testDir, "index.json"));
+
+			expect(hasher.getHash("https://example.com/page1")).toBe("hash1");
+			expect(hasher.getHash("https://example.com/page2")).toBe("hash2");
+		});
+
+		it("should handle missing file gracefully", async () => {
+			await hasher.loadHashes(join(testDir, "nonexistent.json"));
+
+			expect(hasher.getHash("https://example.com")).toBeUndefined();
+		});
+
+		it("should handle pages without hash", async () => {
+			const indexData = {
+				pages: [
+					{ url: "https://example.com/page1", hash: "hash1" },
+					{ url: "https://example.com/page2" }, // no hash
+				],
+			};
+			await writeFile(
+				join(testDir, "index.json"),
+				JSON.stringify(indexData),
+			);
+
+			await hasher.loadHashes(join(testDir, "index.json"));
+
+			expect(hasher.getHash("https://example.com/page1")).toBe("hash1");
+			expect(hasher.getHash("https://example.com/page2")).toBeUndefined();
+		});
+
+		it("should handle empty pages array", async () => {
+			const indexData = { pages: [] };
+			await writeFile(
+				join(testDir, "index.json"),
+				JSON.stringify(indexData),
+			);
+
+			await hasher.loadHashes(join(testDir, "index.json"));
+
+			expect(hasher.getHash("https://example.com")).toBeUndefined();
+		});
+
+		it("should handle index without pages key", async () => {
+			const indexData = { baseUrl: "https://example.com" };
+			await writeFile(
+				join(testDir, "index.json"),
+				JSON.stringify(indexData),
+			);
+
+			await hasher.loadHashes(join(testDir, "index.json"));
+
+			expect(hasher.getHash("https://example.com")).toBeUndefined();
+		});
+	});
+
+	describe("isChanged", () => {
+		beforeEach(async () => {
+			const indexData = {
+				pages: [{ url: "https://example.com/existing", hash: "oldhash" }],
+			};
+			await writeFile(
+				join(testDir, "index.json"),
+				JSON.stringify(indexData),
+			);
+			await hasher.loadHashes(join(testDir, "index.json"));
+		});
+
+		it("should return true for new URL", () => {
+			expect(hasher.isChanged("https://example.com/new", "newhash")).toBe(
+				true,
+			);
+		});
+
+		it("should return true when hash is different", () => {
+			expect(
+				hasher.isChanged("https://example.com/existing", "differenthash"),
+			).toBe(true);
+		});
+
+		it("should return false when hash is same", () => {
+			expect(hasher.isChanged("https://example.com/existing", "oldhash")).toBe(
+				false,
+			);
+		});
+	});
+
+	describe("getHash", () => {
+		it("should return undefined for unknown URL", () => {
+			expect(hasher.getHash("https://unknown.com")).toBeUndefined();
+		});
+
+		it("should return hash for known URL", async () => {
+			const indexData = {
+				pages: [{ url: "https://example.com/known", hash: "knownhash" }],
+			};
+			await writeFile(
+				join(testDir, "index.json"),
+				JSON.stringify(indexData),
+			);
+			await hasher.loadHashes(join(testDir, "index.json"));
+
+			expect(hasher.getHash("https://example.com/known")).toBe("knownhash");
+		});
+	});
+});


### PR DESCRIPTION
## Summary
Implements GitHub Issue #5: Hasher module for SHA256 hash computation and diff detection.

## Changes
- Add `src/diff/hasher.ts` with:
  - `computeHash(content: string): string` - Computes SHA256 hash of content
  - `Hasher` class with:
    - `loadHashes(indexPath: string)` - Load existing hashes from index.json
    - `isChanged(url: string, newHash: string): boolean` - Check if content changed
    - `getHash(url: string): string | undefined` - Get existing hash for URL
- Add `src/diff/index.ts` for module exports
- Add comprehensive unit tests (15 test cases)

## Testing
All 15 new tests pass:
```
✓ tests/unit/hasher.test.ts (15 tests) 10ms
```

## Files Changed
- `link-crawler/src/diff/hasher.ts` (new)
- `link-crawler/src/diff/index.ts` (new)
- `link-crawler/tests/unit/hasher.test.ts` (new)

Closes #5