### PR TITLE
feat: add Hasher module with unit tests

### DIFF
--- a/link-crawler/src/diff/hasher.ts
+++ b/link-crawler/src/diff/hasher.ts
@@ -1,0 +1,65 @@
+import { createHash } from "node:crypto";
+
+/**
+ * コンテンツのSHA256ハッシュを計算
+ */
+export function computeHash(content: string): string {
+	return createHash("sha256").update(content).digest("hex");
+}
+
+/**
+ * 差分検知用Hasher
+ */
+export class Hasher {
+	private existingHashes: Map<string, string>;
+
+	constructor(existingHashes?: Map<string, string>) {
+		this.existingHashes = existingHashes ?? new Map();
+	}
+
+	/**
+	 * index.jsonからHasherを生成
+	 */
+	static fromIndexJson(indexData: { pages?: Array<{ url: string; hash: string }> } | null): Hasher {
+		const hashes = new Map<string, string>();
+		if (indexData?.pages) {
+			for (const page of indexData.pages) {
+				if (page.url && page.hash) {
+					hashes.set(page.url, page.hash);
+				}
+			}
+		}
+		return new Hasher(hashes);
+	}
+
+	/**
+	 * URLのコンテンツが変更されたかを判定
+	 * @returns true: 新規または変更あり, false: 変更なし
+	 */
+	isChanged(url: string, content: string): boolean {
+		const newHash = computeHash(content);
+		const existingHash = this.existingHashes.get(url);
+
+		// 新規URL
+		if (existingHash === undefined) {
+			return true;
+		}
+
+		// ハッシュ比較
+		return existingHash !== newHash;
+	}
+
+	/**
+	 * 登録されているURLのハッシュを取得
+	 */
+	getHash(url: string): string | undefined {
+		return this.existingHashes.get(url);
+	}
+
+	/**
+	 * 登録されているURL数を取得
+	 */
+	get size(): number {
+		return this.existingHashes.size;
+	}
+}

--- a/link-crawler/tests/unit/hasher.test.ts
+++ b/link-crawler/tests/unit/hasher.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import { computeHash, Hasher } from "../../src/diff/hasher.js";
+
+describe("computeHash", () => {
+	it("should return consistent hash for same content", () => {
+		const content = "Hello, World!";
+		const hash1 = computeHash(content);
+		const hash2 = computeHash(content);
+
+		expect(hash1).toBe(hash2);
+	});
+
+	it("should return different hashes for different content", () => {
+		const hash1 = computeHash("Content A");
+		const hash2 = computeHash("Content B");
+
+		expect(hash1).not.toBe(hash2);
+	});
+
+	it("should return valid SHA256 hex string", () => {
+		const hash = computeHash("test");
+
+		// SHA256 produces 64 character hex string
+		expect(hash).toMatch(/^[a-f0-9]{64}$/);
+	});
+
+	it("should handle empty string", () => {
+		const hash = computeHash("");
+
+		expect(hash).toMatch(/^[a-f0-9]{64}$/);
+	});
+
+	it("should handle unicode content", () => {
+		const hash1 = computeHash("日本語テスト");
+		const hash2 = computeHash("日本語テスト");
+
+		expect(hash1).toBe(hash2);
+		expect(hash1).toMatch(/^[a-f0-9]{64}$/);
+	});
+});
+
+describe("Hasher", () => {
+	describe("constructor", () => {
+		it("should create empty hasher without arguments", () => {
+			const hasher = new Hasher();
+
+			expect(hasher.size).toBe(0);
+		});
+
+		it("should create hasher with existing hashes", () => {
+			const existingHashes = new Map([
+				["https://example.com/page1", "hash1"],
+				["https://example.com/page2", "hash2"],
+			]);
+			const hasher = new Hasher(existingHashes);
+
+			expect(hasher.size).toBe(2);
+		});
+	});
+
+	describe("fromIndexJson", () => {
+		it("should create hasher from index.json data", () => {
+			const indexData = {
+				pages: [
+					{ url: "https://example.com/page1", hash: "abc123" },
+					{ url: "https://example.com/page2", hash: "def456" },
+				],
+			};
+			const hasher = Hasher.fromIndexJson(indexData);
+
+			expect(hasher.size).toBe(2);
+			expect(hasher.getHash("https://example.com/page1")).toBe("abc123");
+		});
+
+		it("should handle null input", () => {
+			const hasher = Hasher.fromIndexJson(null);
+
+			expect(hasher.size).toBe(0);
+		});
+
+		it("should handle empty pages array", () => {
+			const hasher = Hasher.fromIndexJson({ pages: [] });
+
+			expect(hasher.size).toBe(0);
+		});
+
+		it("should handle missing pages property", () => {
+			const hasher = Hasher.fromIndexJson({});
+
+			expect(hasher.size).toBe(0);
+		});
+	});
+
+	describe("isChanged", () => {
+		it("should return true for new URL", () => {
+			const hasher = new Hasher();
+
+			const result = hasher.isChanged(
+				"https://example.com/new-page",
+				"Some content",
+			);
+
+			expect(result).toBe(true);
+		});
+
+		it("should return false for same content (same hash)", () => {
+			const content = "Existing content";
+			const hash = computeHash(content);
+			const existingHashes = new Map([
+				["https://example.com/page1", hash],
+			]);
+			const hasher = new Hasher(existingHashes);
+
+			const result = hasher.isChanged("https://example.com/page1", content);
+
+			expect(result).toBe(false);
+		});
+
+		it("should return true for modified content (different hash)", () => {
+			const originalContent = "Original content";
+			const hash = computeHash(originalContent);
+			const existingHashes = new Map([
+				["https://example.com/page1", hash],
+			]);
+			const hasher = new Hasher(existingHashes);
+
+			const modifiedContent = "Modified content";
+			const result = hasher.isChanged(
+				"https://example.com/page1",
+				modifiedContent,
+			);
+
+			expect(result).toBe(true);
+		});
+
+		it("should be case-sensitive for URL matching", () => {
+			const content = "Some content";
+			const hash = computeHash(content);
+			const existingHashes = new Map([
+				["https://example.com/Page1", hash],
+			]);
+			const hasher = new Hasher(existingHashes);
+
+			// Different case = new URL
+			const result = hasher.isChanged("https://example.com/page1", content);
+
+			expect(result).toBe(true);
+		});
+	});
+
+	describe("getHash", () => {
+		it("should return hash for existing URL", () => {
+			const existingHashes = new Map([
+				["https://example.com/page1", "abc123"],
+			]);
+			const hasher = new Hasher(existingHashes);
+
+			expect(hasher.getHash("https://example.com/page1")).toBe("abc123");
+		});
+
+		it("should return undefined for non-existing URL", () => {
+			const hasher = new Hasher();
+
+			expect(hasher.getHash("https://example.com/unknown")).toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION
## 概要
Hasherモジュールのユニットテストを追加します。

## 変更内容
- `src/diff/hasher.ts`: Hasherモジュールを実装
  - `computeHash(content: string)`: SHA256ハッシュ計算
  - `Hasher.fromIndexJson()`: index.jsonからハッシュ読み込み
  - `Hasher.isChanged(url, content)`: 変更検知
- `tests/unit/hasher.test.ts`: 17件のユニットテスト
  - computeHashのテスト（同一性、一意性）
  - Hasher.isChangedのテスト（新規URL、同一ハッシュ、異なるハッシュ）

## テスト結果
```
17 passed (17)
```

Closes #6