### PR TITLE
feat(link-crawler): add hash and crawledAt to PageIndex

### DIFF
--- a/link-crawler/src/output/writer.ts
+++ b/link-crawler/src/output/writer.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type {
 	CrawlConfig,
@@ -19,8 +20,24 @@ const specPatterns: Record<string, RegExp> = {
 export class OutputWriter {
 	private pageCount = 0;
 	private result: CrawlResult;
+	/** 既存のページ情報（URL→CrawledPage） */
+	private existingPages: Map<string, CrawledPage> = new Map();
 
 	constructor(private config: CrawlConfig) {
+		// 既存のindex.jsonを読み込み
+		const indexPath = join(config.outputDir, "index.json");
+		if (existsSync(indexPath)) {
+			try {
+				const existingResult = JSON.parse(readFileSync(indexPath, "utf-8")) as CrawlResult;
+				for (const page of existingResult.pages) {
+					this.existingPages.set(page.url, page);
+				}
+				console.log(`  📂 既存index.json読み込み: ${existingResult.pages.length}ページ`);
+			} catch {
+				console.log("  ⚠️ 既存index.jsonの読み込みに失敗（新規作成）");
+			}
+		}
+
 		this.result = {
 			crawledAt: new Date().toISOString(),
 			baseUrl: config.startUrl,
@@ -36,6 +53,16 @@ export class OutputWriter {
 		// ディレクトリ作成
 		mkdirSync(join(config.outputDir, "pages"), { recursive: true });
 		mkdirSync(join(config.outputDir, "specs"), { recursive: true });
+	}
+
+	/** コンテンツのハッシュを計算 */
+	private computeHash(content: string): string {
+		return createHash("sha256").update(content, "utf-8").digest("hex");
+	}
+
+	/** 既存ページのハッシュを取得 */
+	getExistingHash(url: string): string | undefined {
+		return this.existingPages.get(url)?.hash;
 	}
 
 	/** API仕様ファイルを検出・保存 */
@@ -73,6 +100,8 @@ export class OutputWriter {
 		const pageNum = String(this.pageCount).padStart(3, "0");
 		const pageFile = `pages/page-${pageNum}.md`;
 		const pagePath = join(this.config.outputDir, pageFile);
+		const pageCrawledAt = new Date().toISOString();
+		const hash = this.computeHash(markdown);
 
 		const frontmatter = [
 			"---",
@@ -80,7 +109,7 @@ export class OutputWriter {
 			`title: "${(metadata.title || title || "").replace(/"/g, '\\"')}"`,
 			metadata.description ? `description: "${metadata.description.replace(/"/g, '\\"')}"` : null,
 			metadata.keywords ? `keywords: "${metadata.keywords}"` : null,
-			`crawledAt: ${new Date().toISOString()}`,
+			`crawledAt: ${pageCrawledAt}`,
 			`depth: ${depth}`,
 			"---",
 			"",
@@ -97,6 +126,8 @@ export class OutputWriter {
 			depth,
 			links,
 			metadata,
+			hash,
+			crawledAt: pageCrawledAt,
 		};
 		this.result.pages.push(page);
 		this.result.totalPages++;

--- a/link-crawler/src/types.ts
+++ b/link-crawler/src/types.ts
@@ -41,6 +41,10 @@ export interface CrawledPage {
 	depth: number;
 	links: string[];
 	metadata: PageMetadata;
+	/** コンテンツのSHA-256ハッシュ（差分検出用） */
+	hash: string;
+	/** このページがクロールされた日時 */
+	crawledAt: string;
 }
 
 /** 検出されたAPI仕様 */

--- a/link-crawler/tests/unit/config.test.ts
+++ b/link-crawler/tests/unit/config.test.ts
@@ -11,9 +11,12 @@ describe("parseConfig", () => {
 		expect(config.sameDomain).toBe(true);
 		expect(config.delay).toBe(500);
 		expect(config.timeout).toBe(30000);
-		expect(config.spa).toBe(false);
 		expect(config.spaWait).toBe(2000);
 		expect(config.headed).toBe(false);
+		expect(config.diff).toBe(false);
+		expect(config.pages).toBe(true);
+		expect(config.merge).toBe(true);
+		expect(config.chunks).toBe(true);
 	});
 
 	it("should parse config with custom options", () => {

--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { OutputWriter } from "../../src/output/writer.js";
+import type { CrawlConfig, CrawlResult, PageMetadata } from "../../src/types.js";
+
+const testOutputDir = "./test-output-writer";
+
+const defaultConfig: CrawlConfig = {
+	startUrl: "https://example.com",
+	maxDepth: 2,
+	outputDir: testOutputDir,
+	sameDomain: true,
+	includePattern: null,
+	excludePattern: null,
+	delay: 500,
+	timeout: 30000,
+	spaWait: 2000,
+	headed: false,
+	diff: false,
+	pages: true,
+	merge: true,
+	chunks: true,
+};
+
+const defaultMetadata: PageMetadata = {
+	title: "Test Page",
+	description: "Test description",
+	keywords: null,
+	author: null,
+	ogTitle: null,
+	ogType: null,
+};
+
+describe("OutputWriter", () => {
+	beforeEach(() => {
+		rmSync(testOutputDir, { recursive: true, force: true });
+	});
+
+	afterEach(() => {
+		rmSync(testOutputDir, { recursive: true, force: true });
+	});
+
+	it("should save page with hash and crawledAt", () => {
+		const writer = new OutputWriter(defaultConfig);
+		const markdown = "# Test Content\n\nThis is test content.";
+
+		const pageFile = writer.savePage(
+			"https://example.com/page1",
+			markdown,
+			1,
+			["https://example.com/page2"],
+			defaultMetadata,
+			"Test Page",
+		);
+
+		expect(pageFile).toBe("pages/page-001.md");
+
+		const result = writer.getResult();
+		expect(result.pages).toHaveLength(1);
+		expect(result.pages[0].hash).toBeDefined();
+		expect(result.pages[0].hash).toHaveLength(64); // SHA-256 hex = 64 chars
+		expect(result.pages[0].crawledAt).toBeDefined();
+		expect(new Date(result.pages[0].crawledAt).getTime()).not.toBeNaN();
+	});
+
+	it("should compute consistent hash for same content", () => {
+		const writer1 = new OutputWriter(defaultConfig);
+		const writer2 = new OutputWriter(defaultConfig);
+		const markdown = "# Same Content";
+
+		writer1.savePage("https://example.com/p1", markdown, 1, [], defaultMetadata, null);
+		writer2.savePage("https://example.com/p2", markdown, 1, [], defaultMetadata, null);
+
+		const hash1 = writer1.getResult().pages[0].hash;
+		const hash2 = writer2.getResult().pages[0].hash;
+
+		expect(hash1).toBe(hash2);
+	});
+
+	it("should read existing index.json", () => {
+		// Create initial index.json
+		mkdirSync(join(testOutputDir, "pages"), { recursive: true });
+		mkdirSync(join(testOutputDir, "specs"), { recursive: true });
+
+		const existingResult: CrawlResult = {
+			crawledAt: "2026-01-01T00:00:00.000Z",
+			baseUrl: "https://example.com",
+			config: { maxDepth: 2, sameDomain: true },
+			totalPages: 1,
+			pages: [
+				{
+					url: "https://example.com/existing",
+					title: "Existing Page",
+					file: "pages/page-001.md",
+					depth: 0,
+					links: [],
+					metadata: defaultMetadata,
+					hash: "abc123",
+					crawledAt: "2026-01-01T00:00:00.000Z",
+				},
+			],
+			specs: [],
+		};
+
+		writeFileSync(
+			join(testOutputDir, "index.json"),
+			JSON.stringify(existingResult, null, 2),
+		);
+
+		// Create new writer that should read existing index
+		const writer = new OutputWriter(defaultConfig);
+
+		const existingHash = writer.getExistingHash("https://example.com/existing");
+		expect(existingHash).toBe("abc123");
+
+		const nonExistingHash = writer.getExistingHash("https://example.com/new");
+		expect(nonExistingHash).toBeUndefined();
+	});
+
+	it("should save index.json with hash and crawledAt fields", () => {
+		const writer = new OutputWriter(defaultConfig);
+		writer.savePage("https://example.com", "# Content", 0, [], defaultMetadata, "Title");
+		writer.saveIndex();
+
+		const indexContent = readFileSync(join(testOutputDir, "index.json"), "utf-8");
+		const result = JSON.parse(indexContent) as CrawlResult;
+
+		expect(result.pages[0].hash).toBeDefined();
+		expect(result.pages[0].crawledAt).toBeDefined();
+	});
+});


### PR DESCRIPTION
## Summary
- Add `hash` (SHA-256) and `crawledAt` fields to `CrawledPage` interface
- Implement `computeHash` method in OutputWriter for content hashing
- Add existing index.json reading on OutputWriter initialization for differential crawling
- Add `getExistingHash` method for differential crawling support
- Add unit tests for OutputWriter with hash functionality
- Fix pre-existing test failure in config.test.ts (spa field was removed)

## Changes
- `src/types.ts`: Add hash, crawledAt fields to CrawledPage
- `src/output/writer.ts`: Add hash computation, existing index loading
- `tests/unit/writer.test.ts`: New test file for OutputWriter
- `tests/unit/config.test.ts`: Fix test for removed spa field

Closes #8