### PR TITLE
feat(link-crawler): add Merger module for full.md generation

### DIFF
--- a/link-crawler/src/output/merger.ts
+++ b/link-crawler/src/output/merger.ts
@@ -1,0 +1,90 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { CrawledPage } from "../types.js";
+
+/**
+ * ページ結合クラス
+ * 全ページを結合してfull.mdを生成
+ */
+export class Merger {
+	constructor(private outputDir: string) {}
+
+	/**
+	 * ページを結合してMarkdownを生成
+	 * @param pages クロール済みページ一覧
+	 * @returns 結合されたMarkdown文字列
+	 */
+	merge(pages: CrawledPage[]): string {
+		if (pages.length === 0) {
+			return "";
+		}
+
+		const sections = pages.map((page) => {
+			const title = page.title || page.url;
+			const header = `# ${title}`;
+			const urlLine = `> Source: ${page.url}`;
+			// コンテンツは実際のファイルから読み込むのではなく、
+			// ここではヘッダー情報のみを生成
+			// 実際のコンテンツはwriteFullで読み込む
+			return { header, urlLine, page };
+		});
+
+		return sections.map((s) => `${s.header}\n\n${s.urlLine}\n`).join("\n---\n\n");
+	}
+
+	/**
+	 * Markdownから先頭のH1タイトルを除去
+	 * frontmatterがある場合は考慮する
+	 * @param markdown Markdown文字列
+	 * @returns タイトル除去後のMarkdown
+	 */
+	stripTitle(markdown: string): string {
+		// frontmatterをスキップ
+		let content = markdown;
+		if (content.startsWith("---")) {
+			const endIndex = content.indexOf("---", 3);
+			if (endIndex !== -1) {
+				content = content.slice(endIndex + 3).trimStart();
+			}
+		}
+
+		// 先頭のH1を除去
+		const lines = content.split("\n");
+		if (lines.length > 0 && lines[0].startsWith("# ")) {
+			lines.shift();
+			// タイトル後の空行も除去
+			while (lines.length > 0 && lines[0].trim() === "") {
+				lines.shift();
+			}
+		}
+
+		return lines.join("\n");
+	}
+
+	/**
+	 * full.mdを出力
+	 * @param pages クロール済みページ一覧
+	 * @param pageContents ページ内容のMap (file -> markdown)
+	 * @returns 出力ファイルパス
+	 */
+	writeFull(pages: CrawledPage[], pageContents: Map<string, string>): string {
+		const sections: string[] = [];
+
+		for (const page of pages) {
+			const title = page.title || page.url;
+			const header = `# ${title}`;
+			const urlLine = `> Source: ${page.url}`;
+
+			const rawContent = pageContents.get(page.file) || "";
+			const content = this.stripTitle(rawContent);
+
+			sections.push(`${header}\n\n${urlLine}\n\n${content}`);
+		}
+
+		const fullContent = sections.join("\n\n---\n\n");
+		const outputPath = join(this.outputDir, "full.md");
+		writeFileSync(outputPath, fullContent);
+
+		return outputPath;
+	}
+}

--- a/link-crawler/tests/unit/merger.test.ts
+++ b/link-crawler/tests/unit/merger.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Merger } from "../../src/output/merger.js";
+import type { CrawledPage, PageMetadata } from "../../src/types.js";
+
+const testOutputDir = "./test-output-merger";
+
+const createPage = (
+	url: string,
+	title: string | null,
+	file: string,
+): CrawledPage => ({
+	url,
+	title,
+	file,
+	depth: 0,
+	links: [],
+	metadata: {
+		title,
+		description: null,
+		keywords: null,
+		author: null,
+		ogTitle: null,
+		ogType: null,
+	},
+});
+
+describe("Merger", () => {
+	beforeEach(() => {
+		mkdirSync(testOutputDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(testOutputDir, { recursive: true, force: true });
+	});
+
+	describe("stripTitle", () => {
+		it("should remove H1 title from markdown", () => {
+			const merger = new Merger(testOutputDir);
+			const markdown = "# Page Title\n\nSome content here.";
+
+			const result = merger.stripTitle(markdown);
+
+			expect(result).toBe("Some content here.");
+		});
+
+		it("should handle markdown without H1", () => {
+			const merger = new Merger(testOutputDir);
+			const markdown = "Some content without title.";
+
+			const result = merger.stripTitle(markdown);
+
+			expect(result).toBe("Some content without title.");
+		});
+
+		it("should skip frontmatter and remove H1", () => {
+			const merger = new Merger(testOutputDir);
+			const markdown = `---
+url: https://example.com
+title: "Test"
+---
+
+# Page Title
+
+Content after title.`;
+
+			const result = merger.stripTitle(markdown);
+
+			expect(result).toBe("Content after title.");
+		});
+
+		it("should remove multiple blank lines after title", () => {
+			const merger = new Merger(testOutputDir);
+			const markdown = "# Title\n\n\n\nContent";
+
+			const result = merger.stripTitle(markdown);
+
+			expect(result).toBe("Content");
+		});
+	});
+
+	describe("merge", () => {
+		it("should return empty string for empty pages", () => {
+			const merger = new Merger(testOutputDir);
+
+			const result = merger.merge([]);
+
+			expect(result).toBe("");
+		});
+
+		it("should merge multiple pages with headers", () => {
+			const merger = new Merger(testOutputDir);
+			const pages = [
+				createPage("https://example.com/page1", "Page 1", "pages/page-001.md"),
+				createPage("https://example.com/page2", "Page 2", "pages/page-002.md"),
+			];
+
+			const result = merger.merge(pages);
+
+			expect(result).toContain("# Page 1");
+			expect(result).toContain("> Source: https://example.com/page1");
+			expect(result).toContain("# Page 2");
+			expect(result).toContain("> Source: https://example.com/page2");
+			expect(result).toContain("---");
+		});
+
+		it("should use URL as title if title is null", () => {
+			const merger = new Merger(testOutputDir);
+			const pages = [
+				createPage("https://example.com/untitled", null, "pages/page-001.md"),
+			];
+
+			const result = merger.merge(pages);
+
+			expect(result).toContain("# https://example.com/untitled");
+		});
+	});
+
+	describe("writeFull", () => {
+		it("should write full.md file", () => {
+			const merger = new Merger(testOutputDir);
+			const pages = [
+				createPage("https://example.com/page1", "Page 1", "pages/page-001.md"),
+			];
+			const pageContents = new Map([
+				["pages/page-001.md", "# Page 1\n\nThis is content."],
+			]);
+
+			const outputPath = merger.writeFull(pages, pageContents);
+
+			expect(outputPath).toBe(join(testOutputDir, "full.md"));
+			const content = readFileSync(outputPath, "utf-8");
+			expect(content).toContain("# Page 1");
+			expect(content).toContain("> Source: https://example.com/page1");
+			expect(content).toContain("This is content.");
+		});
+
+		it("should merge multiple pages with separators", () => {
+			const merger = new Merger(testOutputDir);
+			const pages = [
+				createPage("https://example.com/page1", "Page 1", "pages/page-001.md"),
+				createPage("https://example.com/page2", "Page 2", "pages/page-002.md"),
+			];
+			const pageContents = new Map([
+				["pages/page-001.md", "# Page 1\n\nContent 1"],
+				["pages/page-002.md", "# Page 2\n\nContent 2"],
+			]);
+
+			const outputPath = merger.writeFull(pages, pageContents);
+
+			const content = readFileSync(outputPath, "utf-8");
+			expect(content).toContain("---");
+			expect(content).toContain("Content 1");
+			expect(content).toContain("Content 2");
+		});
+	});
+});


### PR DESCRIPTION
## Summary
Mergerモジュールを実装し、全ページを結合してfull.mdを生成する機能を追加

## Changes
- `src/output/merger.ts` を新規作成
- `Merger` クラスを実装
  - `merge(pages: CrawledPage[]): string` - ページ結合
  - `stripTitle(markdown: string): string` - 重複タイトル除去
  - `writeFull(pages, pageContents): string` - full.md出力
- ページを `# タイトル` 形式で結合、`---` で区切り
- frontmatterとH1タイトルの重複を自動除去
- 包括的なユニットテストを追加（9テスト全パス）

## Testing
```
✓ tests/unit/merger.test.ts (9 tests)
```

Closes #9