### PR TITLE
feat(link-crawler): implement Chunker module for #11

### DIFF
--- a/link-crawler/src/output/chunker.ts
+++ b/link-crawler/src/output/chunker.ts
@@ -1,0 +1,101 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Markdownチャンク分割クラス
+ * full.mdをH1見出しベースでチャンク分割
+ */
+export class Chunker {
+	constructor(private outputDir: string) {}
+
+	/**
+	 * MarkdownをH1見出しで分割
+	 * @param fullMarkdown 結合されたMarkdown文字列
+	 * @returns 分割されたチャンクの配列
+	 */
+	chunk(fullMarkdown: string): string[] {
+		if (!fullMarkdown.trim()) {
+			return [];
+		}
+
+		// H1見出し（# ）で分割
+		// ただし、frontmatter内の#は除外
+		const chunks: string[] = [];
+		const lines = fullMarkdown.split("\n");
+		let currentChunk: string[] = [];
+		let inFrontmatter = false;
+		let isFirstH1 = true;
+
+		for (const line of lines) {
+			// frontmatterの検出
+			if (line.trim() === "---") {
+				inFrontmatter = !inFrontmatter;
+				currentChunk.push(line);
+				continue;
+			}
+
+			// frontmatter内は無条件で追加
+			if (inFrontmatter) {
+				currentChunk.push(line);
+				continue;
+			}
+
+			// H1見出しの検出（行頭が"# "）
+			if (line.startsWith("# ")) {
+				if (!isFirstH1 && currentChunk.length > 0) {
+					// 前のチャンクを保存
+					chunks.push(currentChunk.join("\n").trim());
+					currentChunk = [];
+				}
+				isFirstH1 = false;
+			}
+
+			currentChunk.push(line);
+		}
+
+		// 最後のチャンクを追加
+		if (currentChunk.length > 0) {
+			chunks.push(currentChunk.join("\n").trim());
+		}
+
+		return chunks.filter((chunk) => chunk.length > 0);
+	}
+
+	/**
+	 * チャンクをファイルに出力
+	 * @param chunks チャンクの配列
+	 * @returns 出力されたファイルパスの配列
+	 */
+	writeChunks(chunks: string[]): string[] {
+		if (chunks.length === 0) {
+			return [];
+		}
+
+		// chunksディレクトリ作成
+		const chunksDir = join(this.outputDir, "chunks");
+		mkdirSync(chunksDir, { recursive: true });
+
+		const outputPaths: string[] = [];
+
+		for (let i = 0; i < chunks.length; i++) {
+			const chunkNum = String(i + 1).padStart(3, "0");
+			const chunkFile = `chunk-${chunkNum}.md`;
+			const chunkPath = join(chunksDir, chunkFile);
+
+			writeFileSync(chunkPath, chunks[i]);
+			outputPaths.push(chunkPath);
+		}
+
+		return outputPaths;
+	}
+
+	/**
+	 * full.mdを読み込んでチャンク分割し、ファイルに出力
+	 * @param fullMarkdown 結合されたMarkdown文字列
+	 * @returns 出力されたファイルパスの配列
+	 */
+	chunkAndWrite(fullMarkdown: string): string[] {
+		const chunks = this.chunk(fullMarkdown);
+		return this.writeChunks(chunks);
+	}
+}

--- a/link-crawler/tests/unit/chunker.test.ts
+++ b/link-crawler/tests/unit/chunker.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Chunker } from "../../src/output/chunker.js";
+
+const testOutputDir = "./test-output-chunker";
+
+describe("Chunker", () => {
+	beforeEach(() => {
+		mkdirSync(testOutputDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(testOutputDir, { recursive: true, force: true });
+	});
+
+	describe("chunk", () => {
+		it("should return empty array for empty markdown", () => {
+			const chunker = new Chunker(testOutputDir);
+			const result = chunker.chunk("");
+			expect(result).toEqual([]);
+		});
+
+		it("should return single chunk for markdown without H1", () => {
+			const chunker = new Chunker(testOutputDir);
+			const markdown = "Some content without heading.\n\nMore content.";
+			const result = chunker.chunk(markdown);
+			expect(result).toHaveLength(1);
+			expect(result[0]).toBe(markdown);
+		});
+
+		it("should split markdown by H1 headings", () => {
+			const chunker = new Chunker(testOutputDir);
+			const markdown = `# First Section
+
+Content of first section.
+
+# Second Section
+
+Content of second section.`;
+
+			const result = chunker.chunk(markdown);
+
+			expect(result).toHaveLength(2);
+			expect(result[0]).toContain("# First Section");
+			expect(result[0]).toContain("Content of first section.");
+			expect(result[1]).toContain("# Second Section");
+			expect(result[1]).toContain("Content of second section.");
+		});
+
+		it("should handle multiple H1 headings", () => {
+			const chunker = new Chunker(testOutputDir);
+			const markdown = `# Section 1
+Content 1
+# Section 2
+Content 2
+# Section 3
+Content 3`;
+
+			const result = chunker.chunk(markdown);
+
+			expect(result).toHaveLength(3);
+			expect(result[0]).toContain("# Section 1");
+			expect(result[1]).toContain("# Section 2");
+			expect(result[2]).toContain("# Section 3");
+		});
+
+		it("should not split by H2 or lower headings", () => {
+			const chunker = new Chunker(testOutputDir);
+			const markdown = `# Main Section
+
+## Sub Section
+
+Content here.
+
+### Deep Section
+
+More content.
+
+# Another Main Section
+
+Final content.`;
+
+			const result = chunker.chunk(markdown);
+
+			expect(result).toHaveLength(2);
+			expect(result[0]).toContain("## Sub Section");
+			expect(result[0]).toContain("### Deep Section");
+			expect(result[1]).toContain("# Another Main Section");
+		});
+
+		it("should handle frontmatter correctly", () => {
+			const chunker = new Chunker(testOutputDir);
+			const markdown = `---
+title: Test Document
+---
+
+# First Section
+
+Content.
+
+# Second Section
+
+More content.`;
+
+			const result = chunker.chunk(markdown);
+
+			expect(result).toHaveLength(2);
+			expect(result[0]).toContain("---");
+			expect(result[0]).toContain("title: Test Document");
+			expect(result[0]).toContain("# First Section");
+		});
+
+		it("should trim whitespace from chunks", () => {
+			const chunker = new Chunker(testOutputDir);
+			const markdown = `
+# Section
+
+Content.
+
+# Another Section
+
+More content.
+`;
+
+			const result = chunker.chunk(markdown);
+
+			expect(result).toHaveLength(2);
+			expect(result[0]).not.toMatch(/^\s/);
+			expect(result[0]).not.toMatch(/\s$/);
+		});
+	});
+
+	describe("writeChunks", () => {
+		it("should return empty array for empty chunks", () => {
+			const chunker = new Chunker(testOutputDir);
+			const result = chunker.writeChunks([]);
+			expect(result).toEqual([]);
+		});
+
+		it("should write chunks with 3-digit zero padding", () => {
+			const chunker = new Chunker(testOutputDir);
+			const chunks = ["# Chunk 1", "# Chunk 2", "# Chunk 3"];
+
+			const result = chunker.writeChunks(chunks);
+
+			expect(result).toHaveLength(3);
+			expect(result[0]).toContain("chunk-001.md");
+			expect(result[1]).toContain("chunk-002.md");
+			expect(result[2]).toContain("chunk-003.md");
+		});
+
+		it("should write chunk content to files", () => {
+			const chunker = new Chunker(testOutputDir);
+			const chunks = ["# First Chunk\n\nContent 1", "# Second Chunk\n\nContent 2"];
+
+			chunker.writeChunks(chunks);
+
+			const content1 = readFileSync(join(testOutputDir, "chunks", "chunk-001.md"), "utf-8");
+			const content2 = readFileSync(join(testOutputDir, "chunks", "chunk-002.md"), "utf-8");
+
+			expect(content1).toBe("# First Chunk\n\nContent 1");
+			expect(content2).toBe("# Second Chunk\n\nContent 2");
+		});
+
+		it("should create chunks directory", () => {
+			const chunker = new Chunker(testOutputDir);
+			chunker.writeChunks(["# Test"]);
+
+			const stats = readFileSync(join(testOutputDir, "chunks", "chunk-001.md"));
+			expect(stats).toBeDefined();
+		});
+	});
+
+	describe("chunkAndWrite", () => {
+		it("should chunk and write in one operation", () => {
+			const chunker = new Chunker(testOutputDir);
+			const markdown = `# Section 1
+
+Content 1.
+
+# Section 2
+
+Content 2.`;
+
+			const result = chunker.chunkAndWrite(markdown);
+
+			expect(result).toHaveLength(2);
+			expect(result[0]).toContain("chunk-001.md");
+			expect(result[1]).toContain("chunk-002.md");
+
+			const content1 = readFileSync(result[0], "utf-8");
+			expect(content1).toContain("# Section 1");
+		});
+
+		it("should return empty array for empty markdown", () => {
+			const chunker = new Chunker(testOutputDir);
+			const result = chunker.chunkAndWrite("");
+			expect(result).toEqual([]);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
Implement Chunker module to split full.md by H1 headings.

## Changes
- Add `src/output/chunker.ts` - Chunker class implementation
  - `chunk(fullMarkdown: string): string[]` - splits markdown by H1 headings
  - `writeChunks(chunks: string[]): string[]` - writes chunks to files
  - `chunkAndWrite(fullMarkdown: string): string[]` - combined operation
- Add comprehensive unit tests in `tests/unit/chunker.test.ts` (13 tests)

## Output Format
Chunks are saved as `chunks/chunk-001.md`, `chunks/chunk-002.md`, etc. with 3-digit zero padding.

## Testing
All 48 tests pass including the new chunker tests.

## Related Issue
Closes #11