### PR TITLE
test(link-crawler): add Chunker unit tests (#12)

### DIFF
--- a/link-crawler/src/output/chunker.ts
+++ b/link-crawler/src/output/chunker.ts
@@ -1,0 +1,80 @@
+/**
+ * チャンク（分割されたコンテンツ）の型定義
+ */
+export interface Chunk {
+	/** チャンクのタイトル（h1のテキスト） */
+	title: string;
+	/** チャンクの内容（h1を除いた本文） */
+	content: string;
+}
+
+/**
+ * Chunkerクラス
+ * Markdownコンテンツをh1境界で分割する
+ */
+export class Chunker {
+	/**
+	 * Markdownをh1境界で分割してチャンク配列を生成
+	 * @param markdown 分割対象のMarkdown文字列
+	 * @returns チャンク配列
+	 */
+	chunk(markdown: string): Chunk[] {
+		// 空の場合は空配列を返す
+		if (!markdown.trim()) {
+			return [];
+		}
+
+		// h1パターンで分割（行頭の# ）
+		const lines = markdown.split("\n");
+		const chunks: Chunk[] = [];
+		let currentTitle = "";
+		let currentContent: string[] = [];
+
+		for (const line of lines) {
+			// h1行を検出（行頭が# で、次がスペース）
+			if (line.startsWith("# ")) {
+				// 既存のチャンクがあれば保存
+				if (currentContent.length > 0 || currentTitle) {
+					chunks.push({
+						title: currentTitle || "Untitled",
+						content: currentContent.join("\n").trim(),
+					});
+				}
+				// 新しいチャンクを開始
+				currentTitle = line.slice(2).trim(); // "# " を除去
+				currentContent = [];
+			} else {
+				currentContent.push(line);
+			}
+		}
+
+		// 最後のチャンクを追加
+		if (currentContent.length > 0 || currentTitle) {
+			chunks.push({
+				title: currentTitle || "Untitled",
+				content: currentContent.join("\n").trim(),
+			});
+		}
+
+		return chunks;
+	}
+
+	/**
+	 * h1がない場合は全体を1つのチャンクとして返す
+	 * @param markdown Markdown文字列
+	 * @returns チャンク配列（h1がない場合は単一要素）
+	 */
+	chunkOrDefault(markdown: string): Chunk[] {
+		const chunks = this.chunk(markdown);
+		// h1がない場合（chunksが空または先頭にUntitledがある場合）、全体を1つにまとめる
+		if (chunks.length === 0) {
+			return [
+				{
+					title: "Untitled",
+					content: markdown.trim(),
+				},
+			];
+		}
+		return chunks;
+	}
+}

--- a/link-crawler/tests/unit/chunker.test.ts
+++ b/link-crawler/tests/unit/chunker.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import { Chunker } from "../../src/output/chunker.js";
+
+describe("Chunker", () => {
+	describe("chunk", () => {
+		it("should split content at h1 boundaries", () => {
+			const chunker = new Chunker();
+			const markdown = `# First Section
+
+This is the content of the first section.
+
+It has multiple paragraphs.
+
+# Second Section
+
+This is the content of the second section.
+
+# Third Section
+
+Final section content.`;
+
+			const chunks = chunker.chunk(markdown);
+
+			expect(chunks).toHaveLength(3);
+			expect(chunks[0].title).toBe("First Section");
+			expect(chunks[0].content).toBe(
+				"This is the content of the first section.\n\nIt has multiple paragraphs.",
+			);
+			expect(chunks[1].title).toBe("Second Section");
+			expect(chunks[1].content).toBe("This is the content of the second section.");
+			expect(chunks[2].title).toBe("Third Section");
+			expect(chunks[2].content).toBe("Final section content.");
+		});
+
+		it("should handle markdown without h1", () => {
+			const chunker = new Chunker();
+			const markdown = `This is content without any h1 header.
+
+It has multiple paragraphs.
+
+## h2 Header
+
+Some content under h2.`;
+
+			const chunks = chunker.chunk(markdown);
+
+			expect(chunks).toHaveLength(1);
+			expect(chunks[0].title).toBe("Untitled");
+			expect(chunks[0].content).toBe(markdown.trim());
+		});
+
+		it("should handle multiple h1 headers", () => {
+			const chunker = new Chunker();
+			const markdown = `# Introduction
+
+Intro content here.
+
+# Getting Started
+
+Getting started content.
+
+# API Reference
+
+API documentation.
+
+# Conclusion
+
+Conclusion content.`;
+
+			const chunks = chunker.chunk(markdown);
+
+			expect(chunks).toHaveLength(4);
+			expect(chunks[0].title).toBe("Introduction");
+			expect(chunks[1].title).toBe("Getting Started");
+			expect(chunks[2].title).toBe("API Reference");
+			expect(chunks[3].title).toBe("Conclusion");
+		});
+
+		it("should handle empty markdown", () => {
+			const chunker = new Chunker();
+			const markdown = "";
+
+			const chunks = chunker.chunk(markdown);
+
+			expect(chunks).toHaveLength(0);
+		});
+
+		it("should handle whitespace-only markdown", () => {
+			const chunker = new Chunker();
+			const markdown = "   \n\n   \n";
+
+			const chunks = chunker.chunk(markdown);
+
+			expect(chunks).toHaveLength(0);
+		});
+
+		it("should handle h1 with special characters in title", () => {
+			const chunker = new Chunker();
+			const markdown = `# Section: "Special" Characters
+
+Content here.
+
+# Section with : colon
+
+More content.`;
+
+			const chunks = chunker.chunk(markdown);
+
+			expect(chunks).toHaveLength(2);
+			expect(chunks[0].title).toBe('Section: "Special" Characters');
+			expect(chunks[1].title).toBe("Section with : colon");
+		});
+
+		it("should not confuse h2, h3 with h1", () => {
+			const chunker = new Chunker();
+			const markdown = `# Main Title
+
+## Subsection
+
+### Sub-subsection
+
+Content here.
+
+# Another Main Title
+
+More content.`;
+
+			const chunks = chunker.chunk(markdown);
+
+			expect(chunks).toHaveLength(2);
+			expect(chunks[0].title).toBe("Main Title");
+			expect(chunks[0].content).toContain("## Subsection");
+			expect(chunks[0].content).toContain("### Sub-subsection");
+			expect(chunks[1].title).toBe("Another Main Title");
+		});
+
+		it("should trim trailing whitespace from content", () => {
+			const chunker = new Chunker();
+			const markdown = `# Title
+
+Content line 1
+
+Content line 2
+
+`;
+
+			const chunks = chunker.chunk(markdown);
+
+			expect(chunks).toHaveLength(1);
+			expect(chunks[0].content).toBe("Content line 1\n\nContent line 2");
+		});
+	});
+
+	describe("chunkOrDefault", () => {
+		it("should return chunks normally when h1 exists", () => {
+			const chunker = new Chunker();
+			const markdown = `# Section 1
+
+Content 1
+
+# Section 2
+
+Content 2`;
+
+			const chunks = chunker.chunkOrDefault(markdown);
+
+			expect(chunks).toHaveLength(2);
+			expect(chunks[0].title).toBe("Section 1");
+			expect(chunks[1].title).toBe("Section 2");
+		});
+
+		it("should wrap entire content when no h1 exists", () => {
+			const chunker = new Chunker();
+			const markdown = `## h2 Header
+
+Paragraph 1
+
+Paragraph 2`;
+
+			const chunks = chunker.chunkOrDefault(markdown);
+
+			expect(chunks).toHaveLength(1);
+			expect(chunks[0].title).toBe("Untitled");
+			expect(chunks[0].content).toBe(markdown.trim());
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Implement Chunker module and its unit tests for issue #12.

## Changes

- **Chunker Module** (`src/output/chunker.ts`):
  - `chunk()`: Split markdown content at h1 boundaries
  - `chunkOrDefault()`: Returns single chunk when no h1 exists
  - Handles edge cases: empty content, whitespace, special characters

- **Unit Tests** (`tests/unit/chunker.test.ts`):
  - h1 boundary splitting test
  - Content without h1 test
  - Multiple h1 headers test
  - Edge case tests (empty, whitespace, h2/h3 handling)

## Test Results

All 45 tests pass including 10 new Chunker tests.

Closes #12