### PR TITLE
docs: fix link paths in docs/link-crawler/README.md

### DIFF
--- a/docs/link-crawler/README.md
+++ b/docs/link-crawler/README.md
@@ -45,7 +45,7 @@ ln -s /path/to/link-crawler ~/.pi/agent/skills/link-crawler
 
 | ドキュメント | 内容 |
 |-------------|------|
-| [設計書](../docs/link-crawler/design.md) | アーキテクチャ・データ構造・モジュール設計 |
-| [CLI仕様](../docs/link-crawler/cli-spec.md) | オプション・使用例・出力形式 |
-| [開発ガイド](../docs/link-crawler/development.md) | 開発環境・コーディング規約 |
-| [SKILL.md](./SKILL.md) | piエージェント向けスキル定義 |
+| [設計書](./design.md) | アーキテクチャ・データ構造・モジュール設計 |
+| [CLI仕様](./cli-spec.md) | オプション・使用例・出力形式 |
+| [開発ガイド](./development.md) | 開発環境・コーディング規約 |
+| [SKILL.md](../../link-crawler/SKILL.md) | piエージェント向けスキル定義 |


### PR DESCRIPTION
## Summary
Closes #44

## Changes
- Fix design.md link: ../docs/link-crawler/design.md → ./design.md
- Fix cli-spec.md link: ../docs/link-crawler/cli-spec.md → ./cli-spec.md  
- Fix development.md link: ../docs/link-crawler/development.md → ./development.md
- Fix SKILL.md link: ./SKILL.md → ../../link-crawler/SKILL.md

## Verification
All linked files have been confirmed to exist:
- ✅ docs/link-crawler/design.md
- ✅ docs/link-crawler/cli-spec.md
- ✅ docs/link-crawler/development.md
- ✅ link-crawler/SKILL.md