### PR TITLE
docs: fix hash format in documentation to match implementation

### DIFF
--- a/docs/link-crawler/cli-spec.md
+++ b/docs/link-crawler/cli-spec.md
@@ -159,7 +159,7 @@ crawled/
       "url": "https://docs.example.com/getting-started",
       "title": "Getting Started",
       "file": "pages/page-001.md",
-      "hash": "sha256:a1b2c3d4e5f6...",
+      "hash": "a1b2c3d4e5f6...",
       "depth": 1,
       "crawledAt": "2026-02-01T14:00:01.000Z"
     }
@@ -230,7 +230,7 @@ npm install...
 ---
 url: https://docs.example.com/getting-started
 title: "Getting Started"
-hash: "sha256:a1b2c3d4e5f6..."
+hash: "a1b2c3d4e5f6..."
 crawledAt: 2026-02-01T14:00:01.000Z
 depth: 1
 ---

--- a/docs/link-crawler/design.md
+++ b/docs/link-crawler/design.md
@@ -320,7 +320,7 @@ crawled/
       "url": "https://docs.example.com/getting-started",
       "title": "Getting Started",
       "file": "pages/page-001.md",
-      "hash": "sha256:a1b2c3d4e5f6...",
+      "hash": "a1b2c3d4e5f6...",
       "depth": 1,
       "crawledAt": "2026-02-01T14:00:01.000Z"
     }


### PR DESCRIPTION
## Summary
Closes #42

## Changes
- Removed `sha256:` prefix from hash examples in `docs/link-crawler/cli-spec.md`
  - Line 162: index.json example
  - Line 233: pages frontmatter example
- Removed `sha256:` prefix from hash example in `docs/link-crawler/design.md`
  - Line 323: index.json schema example

## Verification
- Ran `grep -n "sha256:" docs/link-crawler/*.md` to confirm no more prefixes exist
- All hash examples now match the actual implementation in `hasher.ts`