### PR TITLE
docs: SKILL.mdの相対リンクパスが不正

### DIFF
--- a/docs/link-crawler/README.md
+++ b/docs/link-crawler/README.md
@@ -45,7 +45,7 @@ ln -s /path/to/link-crawler ~/.pi/agent/skills/link-crawler
 
 | ドキュメント | 内容 |
 |-------------|------|
-| [設計書](../docs/link-crawler/design.md) | アーキテクチャ・データ構造・モジュール設計 |
-| [CLI仕様](../docs/link-crawler/cli-spec.md) | オプション・使用例・出力形式 |
-| [開発ガイド](../docs/link-crawler/development.md) | 開発環境・コーディング規約 |
-| [SKILL.md](./SKILL.md) | piエージェント向けスキル定義 |
+| [設計書](./design.md) | アーキテクチャ・データ構造・モジュール設計 |
+| [CLI仕様](./cli-spec.md) | オプション・使用例・出力形式 |
+| [開発ガイド](./development.md) | 開発環境・コーディング規約 |
+| [SKILL.md](../../link-crawler/SKILL.md) | piエージェント向けスキル定義 |

--- a/docs/plans/issue-54-plan.md
+++ b/docs/plans/issue-54-plan.md
@@ -1,0 +1,43 @@
+# Issue #54 Implementation Plan
+
+## Summary
+Fix incorrect relative link paths in `docs/link-crawler/README.md`.
+
+## Issue Analysis
+
+### Current State
+The `docs/link-crawler/README.md` file contains 4 incorrect relative links:
+
+1. `[設計書](../docs/link-crawler/design.md)` → should be `./design.md`
+2. `[CLI仕様](../docs/link-crawler/cli-spec.md)` → should be `./cli-spec.md`
+3. `[開発ガイド](../docs/link-crawler/development.md)` → should be `./development.md`
+4. `[SKILL.md](./SKILL.md)` → should be `../../link-crawler/SKILL.md`
+
+### File Structure
+```
+docs/link-crawler/
+├── README.md          # File being fixed
+├── design.md          # Same directory → ./design.md
+├── cli-spec.md        # Same directory → ./cli-spec.md
+├── development.md     # Same directory → ./development.md
+└── issues.md
+
+link-crawler/
+├── SKILL.md           # Located here, not in docs/ → ../../link-crawler/SKILL.md
+```
+
+## Implementation Steps
+
+1. **Verify file existence** - Confirm all target files exist
+2. **Edit README.md** - Fix all 4 link paths
+3. **Verify fix** - Check links point to existing files
+
+## Testing Plan
+
+- Verify all 4 links point to existing files
+- Test that GitHub will resolve the links correctly
+
+## Risk Assessment
+
+- **Risk**: None - simple documentation fix
+- **Rollback**: Easy - revert the commit


### PR DESCRIPTION
## Summary
Closes #54

## Changes
- Fixed incorrect relative link paths in docs/link-crawler/README.md:
  - `../docs/link-crawler/design.md` → `./design.md`
  - `../docs/link-crawler/cli-spec.md` → `./cli-spec.md`
  - `../docs/link-crawler/development.md` → `./development.md`
  - `./SKILL.md` → `../../link-crawler/SKILL.md`

## Testing
- Verified all 4 link targets exist:
  - design.md ✓
  - cli-spec.md ✓
  - development.md ✓
  - ../../link-crawler/SKILL.md ✓