### PR TITLE
docs: 設計書と実装の不整合 - index-writer.tsが存在しない

### DIFF
--- a/docs/link-crawler/design.md
+++ b/docs/link-crawler/design.md
@@ -94,10 +94,9 @@ link-crawler/
 │   │   └── hasher.ts           # SHA256ハッシュ・差分検知
 │   │
 │   └── output/
-│       ├── writer.ts           # ページ書き込み
+│       ├── writer.ts           # ページ書き込み + index.json 生成
 │       ├── merger.ts           # full.md 生成
-│       ├── chunker.ts          # chunks/*.md 生成
-│       └── index-writer.ts     # index.json 生成
+│       └── chunker.ts          # chunks/*.md 生成
 │
 ├── package.json
 ├── tsconfig.json
@@ -115,10 +114,9 @@ link-crawler/
 | `Converter` | Markdown変換 | ContentHTML | Markdown |
 | `LinksParser` | リンク抽出 | HTML | URLs |
 | `Hasher` | ハッシュ計算・比較 | Content | Hash, Changed |
-| `PageWriter` | ページ保存 | Page | File |
+| `PageWriter` | ページ保存、index.json 生成 | Page | File, index.json |
 | `Merger` | 全ページ結合 | Pages | full.md |
 | `Chunker` | チャンク分割 | full.md | chunks/*.md |
-| `IndexWriter` | メタデータ保存 | CrawlResult | index.json |
 
 ---
 

--- a/docs/link-crawler/development.md
+++ b/docs/link-crawler/development.md
@@ -46,10 +46,9 @@ link-crawler/
 │   │   └── hasher.ts           # SHA256ハッシュ・差分検知
 │   │
 │   └── output/
-│       ├── writer.ts           # ページ書き込み
+│       ├── writer.ts           # ページ書き込み + index.json 生成
 │       ├── merger.ts           # full.md 生成
-│       ├── chunker.ts          # chunks/*.md 生成
-│       └── index-writer.ts     # index.json 生成
+│       └── chunker.ts          # chunks/*.md 生成
 │
 ├── tests/                       # テストファイル
 │   ├── unit/                    # ユニットテスト
@@ -189,7 +188,7 @@ try {
 
 | 対象 | 規則 | 例 |
 |------|------|-----|
-| ファイル | kebab-case | `index-writer.ts` |
+| ファイル | kebab-case | `writer.ts` |
 | クラス | PascalCase | `CrawlerEngine` |
 | 関数・変数 | camelCase | `fetchPage` |
 | 定数 | UPPER_SNAKE_CASE | `MAX_DEPTH` |

--- a/docs/plans/issue-53-plan.md
+++ b/docs/plans/issue-53-plan.md
@@ -1,0 +1,58 @@
+# Issue #53 実装計画
+
+## 概要
+
+設計書と実装の不整合を修正する。
+設計書には `index-writer.ts` が存在するように記載されているが、実際には `writer.ts` に `saveIndex()` メソッドとして実装されている。
+
+## 選択した修正方針
+
+**オプションA**: 設計書を修正（推奨）
+
+理由:
+- 現在の実装はシンプルで機能的に問題ない
+- `saveIndex()` は `writer.ts` の `OutputWriter` クラスの一部として適切に機能している
+- 過度なモジュール分割は避けるべき（YAGNI原則）
+
+## 影響範囲
+
+| ファイル | 変更内容 |
+|----------|----------|
+| `docs/link-crawler/design.md` | `index-writer.ts` を `writer.ts` に統合されている旨を反映 |
+| `docs/link-crawler/development.md` | 同上 |
+
+## 実装ステップ
+
+1. `design.md` のモジュール構成図を修正
+   - `index-writer.ts` の行を削除
+   - `writer.ts` の説明に index.json 生成を追加
+
+2. `design.md` のモジュール責務テーブルを修正
+   - `IndexWriter` の行を削除
+   - `PageWriter` の責務に index.json 生成を追加
+
+3. `development.md` のプロジェクト構成を修正
+   - `index-writer.ts` の行を削除
+   - `writer.ts` の説明に index.json 生成を追加
+
+## テスト方針
+
+検証コマンド:
+```bash
+grep -r "index-writer" docs/
+# 期待: 言及がないか、writer.tsに統合されている旨の説明がある
+```
+
+## リスクと対策
+
+| リスク | 対策 |
+|--------|------|
+| 誤って実装側を変更する | 実装計画を確認し、必ず設計書のみを修正 |
+| 他のドキュメントへの言及が残る | grep で全文検索して確認 |
+
+## 完了条件
+
+- [ ] `design.md` から `index-writer.ts` の記載が削除されている
+- [ ] `development.md` から `index-writer.ts` の記載が削除されている
+- [ ] `writer.ts` の説明に index.json 生成が含まれている
+- [ ] grep で `index-writer` の言及がないことを確認


### PR DESCRIPTION
## Summary
Closes #53

設計書と実装の不整合を修正しました。

## Changes
- design.md: モジュール構成からindex-writer.tsを削除
- design.md: PageWriterの責務にindex.json生成を追加  
- development.md: プロジェクト構成からindex-writer.tsを削除
- development.md: 命名規則の例をwriter.tsに変更

## Background
設計書にはindex-writer.tsが存在するように記載されていましたが、
実際にはwriter.tsのOutputWriterクラスにsaveIndex()メソッドとして実装されていました。

シンプルな構成を維持するため、設計書を実装に合わせて修正しました（Option A）。

## Verification
