### PR TITLE
fix: biome.json スキーマバージョンを CLI バージョンと一致させる

### DIFF
--- a/link-crawler/biome.json
+++ b/link-crawler/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
 	"root": true,
 	"vcs": {
 		"enabled": true,


### PR DESCRIPTION
## Summary
Closes #60

## Changes
- Updated `$schema` version in `link-crawler/biome.json` from 2.0.0 to 2.3.13
- This resolves the schema version mismatch warning that was displayed when running Biome CLI

## Testing
- Ran `npx biome check` in `link-crawler/` directory
- Confirmed no schema version warnings are displayed
- All checks pass successfully