### PR TITLE
docs: 設計書とソースコードの設定プロパティ名の不一致を修正

### DIFF
--- a/docs/link-crawler/design.md
+++ b/docs/link-crawler/design.md
@@ -215,9 +215,9 @@ interface CrawlConfig {
   wait: number;
   headed: boolean;
   diff: boolean;
-  outputPages: boolean;
-  outputMerge: boolean;
-  outputChunks: boolean;
+  pages: boolean;
+  merge: boolean;
+  chunks: boolean;
 }
 
 /** クロール済みページ */


### PR DESCRIPTION
## Summary
Closes #41

## Changes
- 設計書（docs/link-crawler/design.md）のプロパティ名を実装に合わせて修正
  -  → 
  -  → 
  -  → 

## Testing
- 設計書と実装のプロパティ名が一致することを確認済み
-  コマンドで不整合がないことを検証済み