### PR TITLE
fix: biome.json のスキーマバージョンが古い（2.0.0 → 2.3.13）

### DIFF
--- a/link-crawler/biome.json
+++ b/link-crawler/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
 	"root": true,
 	"vcs": {
 		"enabled": true,


### PR DESCRIPTION
## Summary
Closes #71

## Changes
- Updated `$schema` version in `link-crawler/biome.json` from 2.0.0 to 2.3.13 to match the installed CLI version

## Testing
- Ran `npm run check` in `link-crawler` directory
- Verified that the schema version warning no longer appears

## Before
```
biome.json:2:13 deserialize
  i The configuration schema version does not match the CLI version 2.3.13
      Expected: 2.3.13
      Found:    2.0.0
```

## After
No schema version warnings displayed.