### PR TITLE
chore: update biome.json schema version to 2.3.13

### DIFF
--- a/link-crawler/biome.json
+++ b/link-crawler/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
 	"root": true,
 	"vcs": {
 		"enabled": true,


### PR DESCRIPTION
## Summary
Closes #91

## Changes
- Updated biome.json schema version from 2.0.0 to 2.3.13 to match installed CLI version

## Testing
- Verified with `biome check .` - no schema warnings displayed

## Notes
This change aligns the configuration schema version with the installed Biome CLI version (2.3.13) to resolve the deserialization warning.