### PR TITLE
chore(link-crawler): Biome スキーマバージョンを 2.3.x に更新

### DIFF
--- a/link-crawler/biome.json
+++ b/link-crawler/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
 	"root": true,
 	"vcs": {
 		"enabled": true,


### PR DESCRIPTION
## Summary
Closes #102

## Changes
- Updated Biome schema version from 2.0.0 to 2.3.13 in `link-crawler/biome.json`
- Fixes schema version mismatch warning that appeared when running Biome CLI 2.3.13

## Testing
- Ran `npx biome check .` in link-crawler directory
- Verified no schema version mismatch warning appears
- The remaining 3 errors are pre-existing code style issues unrelated to this change