### PR TITLE
fix(link-crawler): 未使用変数 merger の削除

### DIFF
--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -99,7 +99,6 @@ export class Crawler {
 			}
 		} else if (this.config.chunks) {
 			// mergeなしでchunksのみの場合は、メモリから結合内容を生成
-			const merger = new Merger(this.config.outputDir);
 			fullMdContent = this.buildFullMarkdown(pages, pageContents);
 		}
 


### PR DESCRIPTION
## Summary
Closes #101

## Changes
- Removed unused `merger` variable from `src/crawler/index.ts` (line 102)
- This fixes Biome lint error: `lint/correctness/noUnusedVariables`

## Testing
- ✅ `npx biome check src/crawler/index.ts` passes with no errors
- ✅ All 52 tests pass

## Before
```typescript
} else if (this.config.chunks) {
  // mergeなしでchunksのみの場合は、メモリから結合内容を生成
  const merger = new Merger(this.config.outputDir);  // ← 未使用
  fullMdContent = this.buildFullMarkdown(pages, pageContents);
}
```

## After
```typescript
} else if (this.config.chunks) {
  // mergeなしでchunksのみの場合は、メモリから結合内容を生成
  fullMdContent = this.buildFullMarkdown(pages, pageContents);
}
```