### PR TITLE
docs(link-crawler): align CrawlConfig property names with implementation

### DIFF
--- a/docs/link-crawler/design.md
+++ b/docs/link-crawler/design.md
@@ -215,9 +215,9 @@ interface CrawlConfig {
   wait: number;
   headed: boolean;
   diff: boolean;
-  outputPages: boolean;
-  outputMerge: boolean;
-  outputChunks: boolean;
+  pages: boolean;
+  merge: boolean;
+  chunks: boolean;
 }
 
 /** クロール済みページ */

--- a/docs/link-crawler/issues.md
+++ b/docs/link-crawler/issues.md
@@ -47,7 +47,7 @@
 **概要**: 新設計に合わせて型定義を更新
 
 **タスク**:
-- [ ] `CrawlConfig` に `diff`, `outputPages`, `outputMerge`, `outputChunks` 追加
+- [ ] `CrawlConfig` に `diff`, `pages`, `merge`, `chunks` 追加
 - [ ] `CrawledPage` に `hash` フィールド追加
 - [ ] `PageIndex` 型を追加（index.json用）
 - [ ] 不要な `spa` フィールドを削除


### PR DESCRIPTION
## Summary
Closes #111

## Changes
- Updated `docs/link-crawler/design.md`: Changed `outputPages/outputMerge/outputChunks` to `pages/merge/chunks` in CrawlConfig interface
- Updated `docs/link-crawler/issues.md`: Updated Issue #2 task list to reflect the correct property names

## Reasoning
The implementation in `link-crawler/src/types.ts` already uses the shorter `pages`, `merge`, `chunks` property names. This change aligns the design document with the existing implementation to prevent type errors when developers reference the design doc.

## Verification
```bash
# Design doc matches implementation
grep -A3 'diff: boolean' docs/link-crawler/design.md link-crawler/src/types.ts
```