### PR TITLE
feat: chunks生成をデフォルト無効化し、--chunksオプションで有効化

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,13 @@ bun run link-crawler/src/crawl.ts https://docs.example.com -o ./docs -d 3 --diff
 ### AIコンテキスト用（結合ファイルのみ）
 
 ```bash
-# full.mdのみ出力（ページ・チャンク出力無効）
-bun run link-crawler/src/crawl.ts https://docs.example.com --no-pages --no-chunks
+# デフォルトでは full.md のみ出力
+bun run link-crawler/src/crawl.ts https://docs.example.com
 # → crawled/full.md に全ページが結合されて出力
+
+# 必要な時だけ chunks を有効化
+bun run link-crawler/src/crawl.ts https://docs.example.com --chunks
+# → crawled/full.md + crawled/chunks/*.md
 ```
 
 ### 特定パスのみクロール

--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -69,7 +69,7 @@ bun run link-crawler/src/crawl.ts <url> [options]
 | `--diff` | | `false` | 差分クロール |
 | `--no-pages` | | | ページ単位出力無効 |
 | `--no-merge` | | | 結合ファイル無効 |
-| `--no-chunks` | | | チャンク出力無効 |
+| `--chunks` | | `false` | チャンク出力を有効化 |
 
 ---
 
@@ -98,9 +98,13 @@ bun run link-crawler/src/crawl.ts https://docs.example.com -o ./docs -d 3 --diff
 ### AIコンテキスト用
 
 ```bash
-# 結合ファイルのみ取得
-bun run link-crawler/src/crawl.ts https://docs.example.com --no-pages --no-chunks
+# デフォルトでは full.md のみ出力
+bun run link-crawler/src/crawl.ts https://docs.example.com
 # → crawled/full.md のみ出力
+
+# 必要な時だけ chunks を有効化
+bun run link-crawler/src/crawl.ts https://docs.example.com --chunks
+# → crawled/full.md + crawled/chunks/*.md
 ```
 
 ---
@@ -155,7 +159,7 @@ Bun.spawn([nodePath, cliPath, "open", url, "--session", sessionId])
 crawled/
 ├── index.json    # メタデータ・ハッシュ
 ├── full.md       # 全ページ結合 ★ AIコンテキスト用
-├── chunks/       # 見出しベース分割
+├── chunks/       # 見出しベース分割 (--chunks 有効時のみ)
 │   └── chunk-001.md
 ├── pages/        # ページ単位
 │   └── page-001.md

--- a/link-crawler/src/config.ts
+++ b/link-crawler/src/config.ts
@@ -15,7 +15,7 @@ export function parseConfig(options: Record<string, unknown>, startUrl: string):
 		diff: Boolean(options.diff),
 		pages: options.pages !== false,
 		merge: options.merge !== false,
-		chunks: options.chunks !== false,
+		chunks: options.chunks === true,
 		keepSession: Boolean(options.keepSession),
 	};
 }

--- a/link-crawler/src/crawl.ts
+++ b/link-crawler/src/crawl.ts
@@ -20,7 +20,7 @@ program
 	.option("--diff", "Show diff from previous crawl", false)
 	.option("--no-pages", "Skip individual page output")
 	.option("--no-merge", "Skip merged output file")
-	.option("--no-chunks", "Skip chunked output files")
+	.option("--chunks", "Enable chunked output files", false)
 	.option("--keep-session", "Keep .playwright-cli directory after crawl (for debugging)", false)
 	.parse();
 

--- a/link-crawler/tests/unit/config.test.ts
+++ b/link-crawler/tests/unit/config.test.ts
@@ -16,7 +16,7 @@ describe("parseConfig", () => {
 		expect(config.diff).toBe(false);
 		expect(config.pages).toBe(true);
 		expect(config.merge).toBe(true);
-		expect(config.chunks).toBe(true);
+		expect(config.chunks).toBe(false);
 		expect(config.keepSession).toBe(false);
 	});
 


### PR DESCRIPTION
## Summary
Closes #136

## Changes
- config.ts: chunksのデフォルト値をtrueからfalseに変更
- crawl.ts: --no-chunksオプションを--chunksオプションに変更（デフォルトfalse）
- SKILL.md: オプション表と使用例を更新
- README.md: AIコンテキスト用の使用例を更新
- config.test.ts: デフォルト値テストの期待値を更新

## 理由
- 多くのユースケースではfull.mdだけで十分で、chunksは不要
- ストレージ節約：同じ内容の重複を避ける
- シンプルな出力：デフォルトで必要最小限のファイルのみ生成

## Testing
- unit/config.test.tsがパスすることを確認
- デフォルト値がfalse、--chunksオプションでtrueになることを確認