### PR TITLE
fix: frontmatter終了後に空行を追加

### DIFF
--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -238,7 +238,9 @@ export class Crawler {
 					"---",
 					"",
 					"",
-				].join("\n");
+				]
+					.filter((line) => line !== null)
+					.join("\n");
 				this.pageContents.set(pageFile, frontmatter + markdown);
 				// writerにもページ情報を追加（ファイルは書き込まない）
 				this.writer.registerPage(url, pageFile, depth, links, metadata, title, hash);

--- a/link-crawler/src/output/writer.ts
+++ b/link-crawler/src/output/writer.ts
@@ -168,7 +168,7 @@ export class OutputWriter {
 			"",
 			"",
 		]
-			.filter(Boolean)
+			.filter((line) => line !== null)
 			.join("\n");
 
 		writeFileSync(pagePath, frontmatter + markdown);

--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -130,6 +130,27 @@ describe("OutputWriter", () => {
 		expect(result.pages[0].crawledAt).toBeDefined();
 	});
 
+	it("should add blank line after frontmatter closing ---", () => {
+		const writer = new OutputWriter(defaultConfig);
+		const markdown = "## Introduction\n\nThis is content.";
+
+		writer.savePage(
+			"https://example.com/page1",
+			markdown,
+			1,
+			[],
+			defaultMetadata,
+			"Test Page",
+		);
+
+		const pagePath = join(testOutputDir, "pages/page-001-test-page.md");
+		const content = readFileSync(pagePath, "utf-8");
+
+		// Verify that there's a blank line between frontmatter and content
+		// The frontmatter should end with "---\n\n" followed by content
+		expect(content).toMatch(/---\n\n## Introduction/);
+	});
+
 	describe("filename with title", () => {
 		it("should include slugified title in filename", () => {
 			const writer = new OutputWriter(defaultConfig);


### PR DESCRIPTION
## Summary
Closes #135

## Changes
- Change `.filter(Boolean)` to `.filter((line) => line !== null)` in writer.ts
- Change `.filter(Boolean)` to `.filter((line) => line !== null)` in crawler/index.ts (--no-pages mode)
- Add test to verify blank line after frontmatter

## Problem
The `.filter(Boolean)` was removing empty strings ("" is falsy), which removed the intentional blank lines after the frontmatter closing ---.

## Solution
Use `.filter((line) => line !== null)` to only filter out null values (optional fields) while preserving empty strings that create blank lines.

## Testing
- Added new test: "should add blank line after frontmatter closing ---"
- All existing tests pass

Refs #135