### PR TITLE
docs: SKILL.md のテスト実行コマンドを bun run test に統一

### DIFF
--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -28,7 +28,7 @@ bun install
 ## テスト実行
 
 ```bash
-npm run test
+bun run test
 ```
 
 ---


### PR DESCRIPTION
## Summary
Closes #147

## Changes
- Changed test command from `npm run test` to `bun run test` in link-crawler/SKILL.md

## Testing
- Verified with: `grep "run test" link-crawler/SKILL.md` returns `bun run test`