### PR TITLE
docs: install.sh の改行コード・実行権限の確認

### DIFF
--- a/docs/link-crawler/README.md
+++ b/docs/link-crawler/README.md
@@ -22,6 +22,21 @@
 
 ## クイックスタート
 
+### 方法1: install.sh を使用（推奨）
+
+```bash
+cd link-crawler
+./install.sh
+
+# クロール実行
+bun run dev https://docs.example.com -d 2
+
+# 出力確認
+cat .context/full.md
+```
+
+### 方法2: 手動インストール
+
 ```bash
 cd link-crawler
 bun install

--- a/docs/plans/issue-148-plan.md
+++ b/docs/plans/issue-148-plan.md
@@ -1,0 +1,56 @@
+# Issue #148 Implementation Plan
+
+## Overview
+Verify and document the `link-crawler/install.sh` script's executable permissions and line endings.
+
+## Current Status Analysis
+
+### install.sh Status
+| Check Item | Status | Details |
+|------------|--------|---------|
+| Execution Permission | ✅ OK | `-rwxr-xr-x` already set |
+| Line Endings | ✅ OK | LF (Unix format) confirmed via `od -c` |
+| Shebang | ✅ OK | `#!/bin/bash` present |
+
+### Files to Modify
+1. `docs/link-crawler/README.md` - Add `./install.sh` usage instructions
+
+## Implementation Steps
+
+### Step 1: Verify install.sh (No changes needed)
+- [x] Execution permission: Already set with `chmod +x`
+- [x] Line endings: Already LF format
+- [x] Shebang: Already `#!/bin/bash`
+
+### Step 2: Update Documentation
+- [ ] Add `install.sh` usage section to `docs/link-crawler/README.md`
+- [ ] Keep existing manual instructions as alternative
+
+## Testing Plan
+
+### Manual Verification
+```bash
+# Verify permissions
+ls -la link-crawler/install.sh
+
+# Verify line endings
+file link-crawler/install.sh
+
+# Test execution
+cd link-crawler
+./install.sh --help 2>/dev/null || echo "Script is executable"
+```
+
+## Risks and Mitigation
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Documentation inconsistency | Low | Review README after changes |
+| Broken markdown formatting | Low | Preview markdown before commit |
+
+## Completion Criteria
+
+- [x] install.sh has executable permissions
+- [x] install.sh uses LF line endings
+- [x] install.sh has correct shebang
+- [ ] README.md documents install.sh usage


### PR DESCRIPTION
## Summary
Closes #148

## Changes
- Verified install.sh has executable permissions (already set with `chmod +x`)
- Verified install.sh uses LF line endings (Unix format)
- Verified install.sh has correct shebang (`#!/bin/bash`)
- Added install.sh usage instructions to README.md as the recommended installation method
- Kept manual installation instructions as alternative method

## Testing
- Checked file permissions: `ls -la link-crawler/install.sh`
- Checked line endings: `file link-crawler/install.sh` and `od -c`
- Reviewed README.md changes for proper markdown formatting

## Verification Results
| Check Item | Status |
|------------|--------|
| Execution Permission | ✅ `-rwxr-xr-x` |
| Line Endings | ✅ LF (Unix) |
| Shebang | ✅ `#!/bin/bash` |
| Documentation Updated | ✅ README.md |