### PR TITLE
refactor: 未使用importを削除（Biome lint警告）

### DIFF
--- a/link-crawler/src/crawler/logger.ts
+++ b/link-crawler/src/crawler/logger.ts
@@ -1,4 +1,4 @@
-import type { CrawlConfig, CrawledPage } from "../types.js";
+import type { CrawlConfig } from "../types.js";
 
 /**
  * クロールログ出力クラス

--- a/link-crawler/src/utils/runtime.ts
+++ b/link-crawler/src/utils/runtime.ts
@@ -1,5 +1,3 @@
-import { DependencyError } from "../errors.js";
-
 /** プロセス実行結果 */
 export interface SpawnResult {
 	success: boolean;


### PR DESCRIPTION
## Summary
Closes #153

## Changes
- Remove unused `CrawledPage` import from `src/crawler/logger.ts`
- Remove unused `DependencyError` import from `src/utils/runtime.ts`

## Testing
- ✅ Biome lint noUnusedImports warning resolved for the two target files
- ✅ TypeScript compilation passed (`npm run typecheck`)
- ✅ All 243 tests passed (`npm run test`)