### PR TITLE
style: Biomeフォーマット警告を修正（import順序整理）

### DIFF
--- a/docs/plans/issue-154-plan.md
+++ b/docs/plans/issue-154-plan.md
@@ -1,0 +1,60 @@
+# 実装計画: Issue #154
+
+## 概要
+Biomeフォーマット警告を修正し、import順序を整理する。
+
+## 問題
+以下のファイルでBiomeのformatとorganizeImportsの警告が検出されていました：
+
+1. **`src/crawl.ts`** - importの順序が不適切
+2. **`src/crawler/fetcher.ts`** - importの順序が不適切、フォーマット
+3. **`src/constants.ts`** - 配列のフォーマット（改行）
+4. **`src/crawler/index.ts`** - importの順序、未使用import、フォーマット
+5. **`src/crawler/logger.ts`** - 未使用import、フォーマット
+6. **`src/crawler/post-processor.ts`** - フォーマット
+7. **`src/output/index-manager.ts`** - フォーマット
+8. **`src/output/writer.ts`** - importの順序、フォーマット
+9. **`src/utils/runtime.ts`** - 未使用import
+
+## 実装ステップ
+
+1. **依存関係のインストール**
+   ```bash
+   npm install
+   ```
+
+2. **Biomeチェックの実行**
+   ```bash
+   npx biome check src/
+   ```
+
+3. **自動修正の適用**
+   ```bash
+   npx biome check --write .
+   npx biome check --write --unsafe src/
+   ```
+
+4. **テストの実行**
+   ```bash
+   npm run test
+   ```
+
+## 変更内容
+
+- **9ファイル**が修正されました
+- **14の警告**が解決されました
+- Import順序が整理され、コードスタイルが統一されました
+
+## テスト結果
+
+すべてのテストがパスしました：
+- **テストファイル**: 12 passed
+- **テスト数**: 243 passed
+
+## 検証方法
+
+```bash
+cd link-crawler
+npx biome check src/
+# 期待: 警告が0件
+```

--- a/link-crawler/src/constants.ts
+++ b/link-crawler/src/constants.ts
@@ -54,11 +54,7 @@ export const SPEC_PATTERNS: Record<string, RegExp> = {
 /** パス候補 */
 export const PATHS = {
 	/** Node.js実行ファイルの候補 */
-	NODE_PATHS: [
-		"/opt/homebrew/bin/node",
-		"/usr/local/bin/node",
-		"node",
-	],
+	NODE_PATHS: ["/opt/homebrew/bin/node", "/usr/local/bin/node", "node"],
 	/** Playwright CLIの候補 */
 	PLAYWRIGHT_PATHS: [
 		"/opt/homebrew/bin/playwright-cli",

--- a/link-crawler/src/crawl.ts
+++ b/link-crawler/src/crawl.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env bun
 import { program } from "commander";
 import { parseConfig } from "./config.js";
-import { Crawler } from "./crawler/index.js";
-import { CrawlError, DependencyError, FetchError, TimeoutError, ConfigError } from "./errors.js";
 import { EXIT_CODES } from "./constants.js";
+import { Crawler } from "./crawler/index.js";
+import { ConfigError, CrawlError, DependencyError, FetchError, TimeoutError } from "./errors.js";
 
 program
 	.name("crawl")

--- a/link-crawler/src/crawler/fetcher.ts
+++ b/link-crawler/src/crawler/fetcher.ts
@@ -1,9 +1,9 @@
 import { existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { DependencyError, FetchError, TimeoutError } from "../errors.js";
 import { PATHS, PATTERNS } from "../constants.js";
-import type { RuntimeAdapter } from "../utils/runtime.js";
+import { DependencyError, FetchError, TimeoutError } from "../errors.js";
 import type { CrawlConfig, Fetcher, FetchResult } from "../types.js";
+import type { RuntimeAdapter } from "../utils/runtime.js";
 import { createRuntimeAdapter } from "../utils/runtime.js";
 
 /** Playwright CLIのパスを検索する設定 */
@@ -108,7 +108,9 @@ export class PlaywrightFetcher implements Fetcher {
 			// タイムアウト用のPromiseを作成
 			const timeoutPromise = new Promise<never>((_, reject) => {
 				setTimeout(() => {
-					reject(new TimeoutError(`Request timeout after ${this.config.timeout}ms`, this.config.timeout));
+					reject(
+						new TimeoutError(`Request timeout after ${this.config.timeout}ms`, this.config.timeout),
+					);
 				}, this.config.timeout);
 			});
 
@@ -158,10 +160,7 @@ export function parseCliOutput(output: string): string {
 			return JSON.parse(`"${resultMatch[1]}"`);
 		} catch {
 			// パース失敗時はエスケープを手動で解除
-			return resultMatch[1]
-				.replace(/\\n/g, "\n")
-				.replace(/\\"/g, '"')
-				.replace(/\\\\/g, "\\");
+			return resultMatch[1].replace(/\\n/g, "\n").replace(/\\"/g, '"').replace(/\\\\/g, "\\");
 		}
 	}
 	// フォールバック: そのまま返す

--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -1,14 +1,14 @@
 import { join } from "node:path";
 import { JSDOM } from "jsdom";
+import { FILENAME } from "../constants.js";
 import { computeHash, Hasher } from "../diff/hasher.js";
+import { OutputWriter } from "../output/writer.js";
 import { htmlToMarkdown } from "../parser/converter.js";
 import { extractContent, extractMetadata } from "../parser/extractor.js";
 import { extractLinks } from "../parser/links.js";
-import { OutputWriter } from "../output/writer.js";
+import type { CrawlConfig, Fetcher } from "../types.js";
 import { CrawlLogger } from "./logger.js";
 import { PostProcessor } from "./post-processor.js";
-import { FILENAME } from "../constants.js";
-import type { CrawlConfig, CrawledPage, Fetcher } from "../types.js";
 
 /** クローラーエンジン */
 export class Crawler {
@@ -73,11 +73,7 @@ export class Crawler {
 		await this.postProcessor.process(result.pages, this.pageContents);
 
 		// 完了ログ
-		this.logger.logComplete(
-			result.totalPages,
-			result.specs.length,
-			indexPath,
-		);
+		this.logger.logComplete(result.totalPages, result.specs.length, indexPath);
 	}
 
 	/** 再帰クロール */

--- a/link-crawler/src/crawler/logger.ts
+++ b/link-crawler/src/crawler/logger.ts
@@ -1,4 +1,4 @@
-import type { CrawlConfig, CrawledPage } from "../types.js";
+import type { CrawlConfig } from "../types.js";
 
 /**
  * クロールログ出力クラス
@@ -48,12 +48,7 @@ export class CrawlLogger {
 	}
 
 	/** ページ保存ログ */
-	logPageSaved(
-		file: string,
-		depth: number,
-		linkCount: number,
-		cached = false,
-	): void {
+	logPageSaved(file: string, depth: number, linkCount: number, cached = false): void {
 		const indent = "  ".repeat(depth);
 		const action = cached ? "Cached" : "Saved";
 		console.log(`${indent}  ✓ ${action}: ${file} (${linkCount} links found)`);

--- a/link-crawler/src/crawler/post-processor.ts
+++ b/link-crawler/src/crawler/post-processor.ts
@@ -28,10 +28,7 @@ export class PostProcessor {
 	 * @param pages クロール済みページ一覧
 	 * @param pageContents ページ内容のMap (--no-pages時に使用)
 	 */
-	async process(
-		pages: CrawledPage[],
-		pageContents?: Map<string, string>,
-	): Promise<void> {
+	async process(pages: CrawledPage[], pageContents?: Map<string, string>): Promise<void> {
 		if (pages.length === 0) {
 			this.logger.logPostProcessingSkipped();
 			return;
@@ -42,7 +39,7 @@ export class PostProcessor {
 		// ページ内容を読み込む (--no-pages時はメモリから取得)
 		const contents = this.config.pages
 			? this.loadPageContentsFromDisk(pages)
-			: pageContents ?? new Map<string, string>();
+			: (pageContents ?? new Map<string, string>());
 
 		let fullMdContent = "";
 
@@ -77,10 +74,7 @@ export class PostProcessor {
 	 * @param pageContents ページ内容のMap
 	 * @returns 結合されたMarkdown文字列
 	 */
-	private buildFullMarkdown(
-		pages: CrawledPage[],
-		pageContents: Map<string, string>,
-	): string {
+	private buildFullMarkdown(pages: CrawledPage[], pageContents: Map<string, string>): string {
 		const sections: string[] = [];
 
 		for (const page of pages) {
@@ -113,9 +107,7 @@ export class PostProcessor {
 	 * @param pages クロール済みページ一覧
 	 * @returns ページ内容のMap
 	 */
-	private loadPageContentsFromDisk(
-		pages: CrawledPage[],
-	): Map<string, string> {
+	private loadPageContentsFromDisk(pages: CrawledPage[]): Map<string, string> {
 		const contents = new Map<string, string>();
 
 		for (const page of pages) {

--- a/link-crawler/src/output/index-manager.ts
+++ b/link-crawler/src/output/index-manager.ts
@@ -40,9 +40,7 @@ export class IndexManager {
 		const indexPath = join(this.outputDir, "index.json");
 		if (existsSync(indexPath)) {
 			try {
-				const existingResult = JSON.parse(
-					readFileSync(indexPath, "utf-8"),
-				) as CrawlResult;
+				const existingResult = JSON.parse(readFileSync(indexPath, "utf-8")) as CrawlResult;
 				for (const page of existingResult.pages) {
 					this.existingPages.set(page.url, page);
 				}

--- a/link-crawler/src/output/writer.ts
+++ b/link-crawler/src/output/writer.ts
@@ -1,9 +1,9 @@
+import { createHash } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { createHash } from "node:crypto";
+import { FILENAME, SPEC_PATTERNS } from "../constants.js";
 import type { CrawlConfig, CrawledPage, PageMetadata } from "../types.js";
 import { IndexManager } from "./index-manager.js";
-import { SPEC_PATTERNS, FILENAME } from "../constants.js";
 
 /** コンテンツのSHA256ハッシュを計算 */
 function computeHash(content: string): string {
@@ -32,14 +32,10 @@ export class OutputWriter {
 	private indexManager: IndexManager;
 
 	constructor(private config: CrawlConfig) {
-		this.indexManager = new IndexManager(
-			config.outputDir,
-			config.startUrl,
-			{
-				maxDepth: config.maxDepth,
-				sameDomain: config.sameDomain,
-			},
-		);
+		this.indexManager = new IndexManager(config.outputDir, config.startUrl, {
+			maxDepth: config.maxDepth,
+			sameDomain: config.sameDomain,
+		});
 
 		// ディレクトリ作成
 		mkdirSync(join(config.outputDir, FILENAME.PAGES_DIR), { recursive: true });

--- a/link-crawler/src/utils/runtime.ts
+++ b/link-crawler/src/utils/runtime.ts
@@ -1,5 +1,3 @@
-import { DependencyError } from "../errors.js";
-
 /** プロセス実行結果 */
 export interface SpawnResult {
 	success: boolean;


### PR DESCRIPTION
## Summary
Closes #154

## Changes
- import順序を整理（organizeImports）
- 配列・関数パラメータのフォーマットを修正
- 未使用importを削除
- 9ファイルのスタイル警告を修正

## Testing
- [x] Biomeチェックで警告が0件になることを確認
- [x] 全243件のテストがパスすることを確認

## Verification
```bash
cd link-crawler
npx biome check src/
# 警告なし
```