### PR TITLE
fix: constants.ts の OUTPUT_DIR デフォルト値とドキュメントの不整合

### DIFF
--- a/link-crawler/src/config.ts
+++ b/link-crawler/src/config.ts
@@ -5,7 +5,7 @@ export function parseConfig(options: Record<string, unknown>, startUrl: string):
 	return {
 		startUrl,
 		maxDepth: Math.min(Number(options.depth) || DEFAULTS.MAX_DEPTH, DEFAULTS.MAX_DEPTH_LIMIT),
-		outputDir: String(options.output || "./.context"),
+		outputDir: String(options.output || DEFAULTS.OUTPUT_DIR),
 		sameDomain: options.sameDomain !== false,
 		includePattern: options.include ? new RegExp(String(options.include)) : null,
 		excludePattern: options.exclude ? new RegExp(String(options.exclude)) : null,

--- a/link-crawler/src/constants.ts
+++ b/link-crawler/src/constants.ts
@@ -5,7 +5,7 @@ export const DEFAULTS = {
 	/** 最大深度上限 */
 	MAX_DEPTH_LIMIT: 10,
 	/** 出力ディレクトリ */
-	OUTPUT_DIR: "./crawled",
+	OUTPUT_DIR: "./.context",
 	/** リクエスト間の遅延(ms) */
 	DELAY_MS: 500,
 	/** デフォルトタイムアウト(秒) */


### PR DESCRIPTION
## Summary
Closes #144

## Changes
-  の  を  に修正（ から変更）
-  が  を参照するよう修正（ハードコード  から変更）

## Testing
-  のテストがパスすることを確認
- bun test v1.3.5 (1e86cebd) で config 関連のテストが正常に動作

## 検証結果
```bash
$ grep -n "OUTPUT_DIR\|\.context\|crawled" src/constants.ts src/config.ts
src/constants.ts:8:  OUTPUT_DIR: "./.context",
src/config.ts:8:  outputDir: String(options.output || DEFAULTS.OUTPUT_DIR),
```