### PR TITLE
docs: CLI仕様書とコードの--chunksオプション不整合を修正

### DIFF
--- a/docs/link-crawler/cli-spec.md
+++ b/docs/link-crawler/cli-spec.md
@@ -46,7 +46,7 @@ crawl <url> [options]
 | `--output <dir>` | `-o` | `./.context` | 出力ディレクトリ |
 | `--no-pages` | | | ページ単位ファイル出力を無効化 |
 | `--no-merge` | | | 結合ファイル(full.md)出力を無効化 |
-| `--no-chunks` | | | チャンク分割出力を無効化 |
+| `--chunks` | | `false` | チャンク分割出力を有効化 |
 
 ### 3.5 ヘルプ
 
@@ -96,13 +96,13 @@ crawl https://docs.example.com --include "/guide/" --exclude "/internal/"
 
 ```bash
 # AIコンテキスト用: 結合ファイルのみ
-crawl https://docs.example.com --no-pages --no-chunks
+crawl https://docs.example.com --no-pages
 
 # ページ単位のみ
-crawl https://docs.example.com --no-merge --no-chunks
+crawl https://docs.example.com --no-merge
 
 # チャンクのみ
-crawl https://docs.example.com --no-pages --no-merge
+crawl https://docs.example.com --no-pages --no-merge --chunks
 ```
 
 ### 4.5 デバッグ・調整

--- a/docs/plans/issue-152-plan.md
+++ b/docs/plans/issue-152-plan.md
@@ -1,0 +1,30 @@
+# 実装計画書: Issue #152
+
+## 概要
+
+CLI仕様書（`docs/link-crawler/cli-spec.md`）と実装コード（`link-crawler/src/crawl.ts`）で `--chunks` オプションのデフォルト値が矛盾している問題を修正する。
+
+## 影響範囲
+
+- `docs/link-crawler/cli-spec.md` - ドキュメント修正のみ
+
+## 実装ステップ
+
+1. **オプションテーブルの修正** (3.4 出力制御)
+   - `--no-chunks` → `--chunks` に変更
+   - デフォルト値 `false` を追加
+   - 説明を「チャンク分割出力を無効化」→「チャンク分割出力を有効化」に変更
+
+2. **使用例セクションの修正** (4.4 出力形式制御)
+   - `crawl https://docs.example.com --no-pages --no-chunks` の例を修正
+   - `--chunks` を使わない例に変更（`--no-pages` のみにする）
+
+## テスト方針
+
+- `bun run link-crawler/src/crawl.ts --help` で `--chunks` が表示されることを確認
+- `--no-chunks` は表示されないことを確認
+
+## リスクと対策
+
+- **リスク**: なし（ドキュメント修正のみ）
+- **対策**: 実際のコード動作と一致させることでリスクを低減


### PR DESCRIPTION
## Summary
Closes #152

## Changes
- CLI仕様書の`--no-chunks`を`--chunks`に修正（実装コードと一致させる）
- デフォルト値`false`を明記
- 使用例セクションの`--no-chunks`を削除し、正しいオプション名を使用

## Testing
- `bun run link-crawler/src/crawl.ts --help | grep chunks` で `--chunks` が表示されることを確認
- `--no-chunks` は存在しないことを確認

## 受け入れ条件
- [x] CLI仕様書が実際のコードの動作と一致する
- [x] `--chunks` オプションのデフォルト値が明記されている
- [x] 使用例が正しいオプション名を使用している