### PR TITLE
fix: add node_modules/ and dist/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@
 # Playwright cli
 .playwright-cli/
 .context/
+
+# Dependencies
+node_modules/
+
+# Build output
+dist/

--- a/docs/plans/issue-171-plan.md
+++ b/docs/plans/issue-171-plan.md
@@ -1,0 +1,25 @@
+# Issue #171 Implementation Plan
+
+## 概要
+`.gitignore` に `node_modules/` と `dist/` を明示的に追加する。
+
+## 影響範囲
+- `.gitignore` (1箇所)
+
+## 実装ステップ
+1. `.gitignore` ファイルを読み込む
+2. 以下のエントリを追加:
+   - `node_modules/` - Dependencies
+   - `dist/` - Build output
+3. 変更をコミット
+
+## テスト方針
+- `git status` で `node_modules/` と `dist/` が untracked に表示されないことを確認
+
+## リスクと対策
+- リスク: 既存の `.pi` シンボリックリンクでカバーされている可能性がある
+- 対策: 明示的な記載により、将来のリスクを防止
+
+## 完了条件
+- [ ] `node_modules/` を `.gitignore` に追加
+- [ ] `dist/` を `.gitignore` に追加


### PR DESCRIPTION
## Summary
Closes #171

## Changes
- Added  to .gitignore (Dependencies)
- Added  to .gitignore (Build output)

## Testing
- Verified .gitignore entries are correctly formatted
- Both entries follow existing comment style in the file

## Notes
This change explicitly adds node_modules/ and dist/ to prevent accidental commits of dependency directories and build outputs.
