### PR TITLE
test: tsconfigにtestsディレクトリを含めて型チェック対象にする

### DIFF
--- a/link-crawler/tests/integration/crawler.test.ts
+++ b/link-crawler/tests/integration/crawler.test.ts
@@ -101,6 +101,7 @@ const defaultConfig: CrawlConfig = {
 	pages: true,
 	merge: true,
 	chunks: true,
+	keepSession: false,
 };
 
 describe("CrawlerEngine Integration", () => {

--- a/link-crawler/tests/unit/merger.test.ts
+++ b/link-crawler/tests/unit/merger.test.ts
@@ -24,6 +24,8 @@ const createPage = (
 		ogTitle: null,
 		ogType: null,
 	},
+	hash: "",
+	crawledAt: new Date().toISOString(),
 });
 
 describe("Merger", () => {

--- a/link-crawler/tests/unit/parser/links.test.ts
+++ b/link-crawler/tests/unit/parser/links.test.ts
@@ -98,6 +98,7 @@ describe("shouldCrawl", () => {
 		pages: true,
 		merge: true,
 		chunks: true,
+		keepSession: false,
 	};
 
 	it("should return true for unvisited URL", () => {
@@ -197,6 +198,7 @@ describe("extractLinks", () => {
 		pages: true,
 		merge: true,
 		chunks: true,
+		keepSession: false,
 	};
 
 	it("should extract links from HTML", () => {

--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -21,6 +21,7 @@ const defaultConfig: CrawlConfig = {
 	pages: true,
 	merge: true,
 	chunks: true,
+	keepSession: false,
 };
 
 const defaultMetadata: PageMetadata = {

--- a/link-crawler/tsconfig.json
+++ b/link-crawler/tsconfig.json
@@ -13,6 +13,6 @@
 		"lib": ["ESNext"],
 		"types": ["bun"]
 	},
-	"include": ["src/**/*"],
+	"include": ["src/**/*", "tests/**/*"],
 	"exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
Closes #179

## Changes
- Added `tests/**/*` to `tsconfig.json` include array
- Fixed missing `keepSession` property in test configs
- Fixed missing `hash` and `crawledAt` properties in merger test

## Testing
- `bun run typecheck` now checks both src and tests directories
- All 258 existing tests pass
- No type errors in test files