### PR TITLE
docs: README.mdとSKILL.mdのオプション説明に「--keep-session」が未記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ bun run link-crawler/src/crawl.ts https://docs.example.com --include "/api/"
 | `--diff` | | `false` | 差分クロール |
 | `--include <pattern>` | | | 含めるURL（正規表現） |
 | `--exclude <pattern>` | | | 除外するURL（正規表現） |
+| `--keep-session` | | `false` | デバッグ用: .playwright-cliディレクトリを保持 |
 
 ### 出力形式
 

--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -59,6 +59,7 @@ bun run link-crawler/src/crawl.ts <url> [options]
 | `--wait <ms>` | | `2000` | レンダリング待機時間 |
 | `--headed` | | `false` | ブラウザ表示 |
 | `--timeout <sec>` | | `30` | リクエストタイムアウト |
+| `--keep-session` | | `false` | デバッグ用: .playwright-cliディレクトリを保持 |
 
 ### スコープ制御
 


### PR DESCRIPTION
## Summary
Closes #186

## Changes
- Added  option to README.md options table
- Added  option to link-crawler/SKILL.md options table

## Details
The  option keeps the .playwright-cli directory after crawl for debugging purposes. This option was already implemented in the CLI but was missing from the documentation.

## Testing
- Verified both files now contain the  option documentation
- Documentation matches the  output