### PR TITLE
refactor: Hasher.loadHashes と IndexManager.loadExistingIndex の重複ロジック統合

### DIFF
--- a/link-crawler/src/diff/hasher.ts
+++ b/link-crawler/src/diff/hasher.ts
@@ -1,18 +1,9 @@
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
 
 /** ページハッシュマップ型 */
 export interface PageHash {
 	url: string;
 	hash: string;
-}
-
-/** index.json構造（ハッシュ読み込み用） */
-interface IndexJson {
-	pages?: Array<{
-		url: string;
-		hash?: string;
-	}>;
 }
 
 /**
@@ -26,31 +17,16 @@ export function computeHash(content: string): string {
 
 /**
  * ハッシュ管理クラス
- * 既存のindex.jsonからハッシュを読み込み、差分検知を行う
+ * 差分検知を行う
  */
 export class Hasher {
-	private hashes = new Map<string, string>();
+	private hashes: Map<string, string>;
 
 	/**
-	 * index.jsonからハッシュを読み込む
-	 * @param indexPath index.jsonのパス
+	 * @param existingHashes 既存のハッシュMap（URL → hash）
 	 */
-	async loadHashes(indexPath: string): Promise<void> {
-		try {
-			const content = await readFile(indexPath, "utf8");
-			const data: IndexJson = JSON.parse(content);
-
-			if (data.pages) {
-				for (const page of data.pages) {
-					if (page.hash) {
-						this.hashes.set(page.url, page.hash);
-					}
-				}
-			}
-		} catch {
-			// ファイルが存在しない場合は空のまま
-			this.hashes.clear();
-		}
+	constructor(existingHashes: Map<string, string> = new Map()) {
+		this.hashes = new Map(existingHashes);
 	}
 
 	/**

--- a/link-crawler/src/output/index-manager.ts
+++ b/link-crawler/src/output/index-manager.ts
@@ -60,6 +60,20 @@ export class IndexManager {
 	}
 
 	/**
+	 * 既存の全ハッシュを取得
+	 * @returns URL → ハッシュのMap
+	 */
+	getExistingHashes(): Map<string, string> {
+		const hashes = new Map<string, string>();
+		for (const [url, page] of this.existingPages) {
+			if (page.hash) {
+				hashes.set(url, page.hash);
+			}
+		}
+		return hashes;
+	}
+
+	/**
 	 * 既存ページ数を取得
 	 */
 	getExistingPageCount(): number {

--- a/link-crawler/tests/unit/index-manager.test.ts
+++ b/link-crawler/tests/unit/index-manager.test.ts
@@ -178,6 +178,107 @@ describe("IndexManager", () => {
 		});
 	});
 
+	describe("getExistingHashes", () => {
+		it("should return map of all existing hashes", async () => {
+			const indexData = {
+				crawledAt: "2025-01-01T00:00:00.000Z",
+				baseUrl: "https://example.com",
+				config: {},
+				totalPages: 2,
+				pages: [
+					{
+						url: "https://example.com/page1",
+						title: "Page 1",
+						file: "pages/page-001.md",
+						depth: 0,
+						links: [],
+						metadata: { title: "Page 1", description: null, keywords: null, author: null, ogTitle: null, ogType: null },
+						hash: "hash1",
+						crawledAt: "2025-01-01T00:00:00.000Z",
+					},
+					{
+						url: "https://example.com/page2",
+						title: "Page 2",
+						file: "pages/page-002.md",
+						depth: 1,
+						links: [],
+						metadata: { title: "Page 2", description: null, keywords: null, author: null, ogTitle: null, ogType: null },
+						hash: "hash2",
+						crawledAt: "2025-01-01T00:00:00.000Z",
+					},
+				],
+				specs: [],
+			};
+			await writeFile(join(testDir, "index.json"), JSON.stringify(indexData));
+
+			const manager = new IndexManager(testDir, "https://example.com", {
+				maxDepth: 2,
+				sameDomain: true,
+			});
+
+			const hashes = manager.getExistingHashes();
+
+			expect(hashes.size).toBe(2);
+			expect(hashes.get("https://example.com/page1")).toBe("hash1");
+			expect(hashes.get("https://example.com/page2")).toBe("hash2");
+		});
+
+		it("should skip pages without hash", async () => {
+			const indexData = {
+				crawledAt: "2025-01-01T00:00:00.000Z",
+				baseUrl: "https://example.com",
+				config: {},
+				totalPages: 2,
+				pages: [
+					{
+						url: "https://example.com/page1",
+						title: "Page 1",
+						file: "pages/page-001.md",
+						depth: 0,
+						links: [],
+						metadata: { title: "Page 1", description: null, keywords: null, author: null, ogTitle: null, ogType: null },
+						hash: "hash1",
+						crawledAt: "2025-01-01T00:00:00.000Z",
+					},
+					{
+						url: "https://example.com/page2",
+						title: "Page 2",
+						file: "pages/page-002.md",
+						depth: 1,
+						links: [],
+						metadata: { title: "Page 2", description: null, keywords: null, author: null, ogTitle: null, ogType: null },
+						// no hash
+						crawledAt: "2025-01-01T00:00:00.000Z",
+					},
+				],
+				specs: [],
+			};
+			await writeFile(join(testDir, "index.json"), JSON.stringify(indexData));
+
+			const manager = new IndexManager(testDir, "https://example.com", {
+				maxDepth: 2,
+				sameDomain: true,
+			});
+
+			const hashes = manager.getExistingHashes();
+
+			expect(hashes.size).toBe(1);
+			expect(hashes.get("https://example.com/page1")).toBe("hash1");
+			expect(hashes.has("https://example.com/page2")).toBe(false);
+		});
+
+		it("should return empty map when no existing index", () => {
+			const manager = new IndexManager(testDir, "https://example.com", {
+				maxDepth: 2,
+				sameDomain: true,
+			});
+
+			const hashes = manager.getExistingHashes();
+
+			expect(hashes.size).toBe(0);
+		});
+	});
+
 	describe("getExistingPageCount", () => {
 		it("should return count of existing pages", async () => {
 			const indexData = {


### PR DESCRIPTION
## Summary
Closes #187

## Changes
- Removed  method - responsibility moved to 
- Updated  constructor to accept existing hashes Map
- Added  method to provide hashes
- Updated  to pass hashes from  to 
- Updated all related tests

## Benefits
- Eliminates duplicate  file reading
- Clear separation of concerns:  handles file I/O,  handles diff logic
-  is now a pure logic class, easier to test

## Testing
- All 286 tests pass
- Biome check passes
- TypeScript typecheck passes

Refs #187