### PR TITLE
docs: design.mdのCrawlConfig型定義を実装に合わせて更新

### DIFF
--- a/docs/link-crawler/design.md
+++ b/docs/link-crawler/design.md
@@ -210,12 +210,13 @@ interface CrawlConfig {
   excludePattern: RegExp | null;
   delay: number;
   timeout: number;
-  wait: number;
+  spaWait: number;
   headed: boolean;
   diff: boolean;
   pages: boolean;
   merge: boolean;
   chunks: boolean;
+  keepSession: boolean;
 }
 
 /** クロール済みページ */
@@ -366,7 +367,7 @@ class PlaywrightFetcher {
     await $`playwright-cli open ${url} --session ${this.sessionId} ${headedFlag}`;
 
     // レンダリング待機
-    await Bun.sleep(this.config.wait);
+    await Bun.sleep(this.config.spaWait);
 
     // コンテンツ取得
     const html = await $`playwright-cli eval "document.documentElement.outerHTML" --session ${this.sessionId}`;


### PR DESCRIPTION
## Summary
Closes #177

## Changes
- Rename `wait` to `spaWait` in CrawlConfig interface to match implementation
- Add missing `keepSession: boolean` field to CrawlConfig interface
- Update code example to use `this.config.spaWait` instead of `this.config.wait`

## Verification
- [x] design.mdの型定義を実装に合わせて更新
- [x] `wait` → `spaWait` に修正
- [x] `keepSession: boolean` を追加

## Testing
- Verified type definitions match between docs/link-crawler/design.md and link-crawler/src/types.ts