### PR TITLE
fix: implement --version option in CLI

### DIFF
--- a/link-crawler/src/crawl.ts
+++ b/link-crawler/src/crawl.ts
@@ -24,6 +24,7 @@ program
 	.option("--no-merge", "Skip merged output file")
 	.option("--chunks", "Enable chunked output files", false)
 	.option("--keep-session", "Keep .playwright-cli directory after crawl (for debugging)", false)
+	.version("2.0.0")
 	.parse();
 
 const options = program.opts();


### PR DESCRIPTION
## Summary
Closes #184

## Changes
- Added `.version("2.0.0")` to the Commander.js program chain in `link-crawler/src/crawl.ts`
- Version is synced with package.json version

## Verification
- `--version` and `-V` options now display `2.0.0`
- `--help` now shows the `-V, --version` option in the help output
- Documentation and implementation are now consistent

## Testing
- Manual testing confirmed:
  - `bun crawl.ts --version` outputs `2.0.0`
  - `bun crawl.ts -V` outputs `2.0.0`
  - `bun crawl.ts --help` shows the version option