### PR TITLE
chore: add coverage/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ node_modules/
 
 # Build output
 dist/
+
+# Coverage
+coverage/


### PR DESCRIPTION
## Summary
Closes #199

## Changes
- Added `coverage/` to `.gitignore` to prevent test coverage output directories from being tracked in Git
- This prevents unnecessary files from cluttering PR diffs and the repository

## Testing
- Verified `coverage/` is now in `.gitignore`
- No existing `coverage/` directory to remove