### PR TITLE
docs: README.md の前提条件に playwright-cli の正確なインストールコマンドを記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ### 前提条件
 
 - [Bun](https://bun.sh/) 1.0以上
-- [playwright-cli](https://playwright.dev/): `npm install -g @playwright/cli`
+- [playwright-cli](https://www.npmjs.com/package/@playwright/cli): `npm install -g @playwright/cli`
 
 ### セットアップ
 

--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -23,7 +23,7 @@ description: 技術ドキュメントサイトをクロールし、AIコンテ�
 ## 前提条件
 
 - Bun インストール済み
-- playwright-cli: `npm install -g @playwright/cli`
+- [playwright-cli](https://www.npmjs.com/package/@playwright/cli): `npm install -g @playwright/cli`
 
 ## セットアップ
 


### PR DESCRIPTION
## Summary
Closes #202

## Changes
- Fixed playwright-cli link from playwright.dev to npm package page
- Updated README.md and SKILL.md to reference correct npm package URL

## Verification
- The @playwright/cli package exists on npm and provides playwright-cli binary
- Installation command `npm install -g @playwright/cli` is correct
- Link now points to https://www.npmjs.com/package/@playwright/cli instead of https://playwright.dev/