### PR TITLE
docs: remove duplicate --keep-session option from SKILL.md

### DIFF
--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -59,7 +59,6 @@ bun run link-crawler/src/crawl.ts <url> [options]
 | `--wait <ms>` | | `2000` | レンダリング待機時間 |
 | `--headed` | | `false` | ブラウザ表示 |
 | `--timeout <sec>` | | `30` | リクエストタイムアウト |
-| `--keep-session` | | `false` | デバッグ用: .playwright-cliディレクトリを保持 |
 
 ### スコープ制御
 


### PR DESCRIPTION
## Summary
Closes #200

## Changes
- Removed duplicate `--keep-session` entry from the クロール制御 section
- The option remains in the 差分・出力 section where it belongs (it's an output-related option)

## Verification
```bash
grep -n "keep-session" link-crawler/SKILL.md
# Result: 1 entry only (line 80)
```