### PR TITLE
docs: design.mdの型名をtypes.tsと整合させる（PageIndex→CrawledPage）

### DIFF
--- a/docs/link-crawler/design.md
+++ b/docs/link-crawler/design.md
@@ -247,8 +247,8 @@ interface PageMetadata {
   ogType: string | null;
 }
 
-/** 保存済みページ情報 (index.json用) */
-interface PageIndex {
+/** クロール済みページ情報 */
+interface CrawledPage {
   url: string;
   title: string | null;
   file: string;
@@ -265,7 +265,7 @@ interface CrawlResult {
   baseUrl: string;
   config: Partial<CrawlConfig>;
   totalPages: number;
-  pages: PageIndex[];
+  pages: CrawledPage[];
   specs: DetectedSpec[];
 }
 


### PR DESCRIPTION
## Summary
Closes #211

## Changes
- design.md内の`PageIndex`を`CrawledPage`に変更
- コメントを「保存済みページ情報」→「クロール済みページ情報」に変更
- CrawlResultインターフェースの`pages: PageIndex[]`を`pages: CrawledPage[]`に変更

## Testing
- `grep -c "PageIndex" docs/link-crawler/design.md` → 0 を確認
- `grep -c "CrawledPage" docs/link-crawler/design.md` → 6 を確認
- 設計書と実装（types.ts）の型名が一致することを確認