### PR TITLE
docs: README.mdに--chunksと--same-domainオプションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ bun run link-crawler/src/crawl.ts https://docs.example.com --include "/api/"
 | `--diff` | | `false` | 差分クロール |
 | `--no-pages` | | | ページ単位出力無効 |
 | `--no-merge` | | | 結合ファイル無効 |
+| `--same-domain` | | `true` | 同一ドメインのみフォロー |
+| `--no-same-domain` | | | クロスドメインリンクもフォロー |
+| `--chunks` | | `false` | チャンク出力を有効化 |
 | `--include <pattern>` | | | 含めるURL（正規表現） |
 | `--exclude <pattern>` | | | 除外するURL（正規表現） |
 | `--keep-session` | | `false` | デバッグ用: .playwright-cliディレクトリを保持 |


### PR DESCRIPTION
## Summary
Closes #208

## Changes
- README.mdのオプション表に以下のオプションを追加:
  - `--same-domain` / `--no-same-domain`: 同一ドメインのみフォロー設定
  - `--chunks`: チャンク出力を有効化
- SKILL.mdとREADME.mdのドキュメント間の整合性を確保

## Testing
- README.mdに`--chunks`と`--same-domain`が追加されたことを確認
- grepで両方のオプションが表示されることを検証