### PR TITLE
fix: install.shのplaywright-cliバージョン取得を堅牢化

### DIFF
--- a/link-crawler/install.sh
+++ b/link-crawler/install.sh
@@ -60,8 +60,11 @@ echo ""
 # 3. playwright-cli のインストール
 echo "3️⃣  playwright-cli のチェック..."
 if command -v playwright-cli &> /dev/null; then
-    PLAYWRIGHT_VERSION=$(playwright-cli --version 2>/dev/null || echo "unknown")
-    ok "playwright-cli $PLAYWRIGHT_VERSION がインストール済み"
+    if PLAYWRIGHT_VERSION=$(playwright-cli --version 2>&1); then
+        ok "playwright-cli ${PLAYWRIGHT_VERSION} がインストール済み"
+    else
+        warn "playwright-cli のバージョン取得に失敗しましたが、コマンドは存在します"
+    fi
 else
     warn "playwright-cli がインストールされていません。インストール中..."
     npm install -g @playwright/cli


### PR DESCRIPTION
## Summary
Closes #220

## Changes
- playwright-cli のバージョン取得を if 文によるエラーハンドリングに変更
- stderr もキャプチャして失敗を正しく検出 (2>&1)
- エラー時に「unknown」と表示せず、明確な警告メッセージを表示

## Testing
- [x] 正常時: バージョン番号が正しく表示される
- [x] バージョン取得失敗時: 明確な警告メッセージが表示される
- [x] コマンド不在時: インストール処理が実行される