### PR TITLE
docs: development.mdの統合テスト説明が実態と乖離

### DIFF
--- a/docs/link-crawler/development.md
+++ b/docs/link-crawler/development.md
@@ -57,8 +57,8 @@ link-crawler/
 │   │   ├── chunker.test.ts
 │   │   ├── converter.test.ts
 │   │   └── links.test.ts
-│   └── integration/             # 統合テスト（未実装）
-│       └── .gitkeep
+│   └── integration/             # 統合テスト
+│       └── crawler.test.ts      # 13テスト
 │
 ├── vitest.config.ts             # Vitest設定
 ├── package.json
@@ -300,23 +300,17 @@ Content`;
 ### 5.4 統合テスト例
 
 ```typescript
-// tests/integration/crawler.test.ts
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { Crawler } from "../../src/crawler";
+// tests/integration/crawler.test.ts を参照
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Crawler } from "../../src/crawler/index.js";
+import type { CrawlConfig, Fetcher, FetchResult } from "../../src/types.js";
 
-describe("Crawler", () => {
-  it("ページをクロールしてMarkdownに変換", async () => {
-    // モックFetcherを使用
-    const mockFetcher = {
-      fetch: vi.fn().mockResolvedValue({
-        html: "<html><body><h1>Test</h1><p>Content</p></body></html>",
-        finalUrl: "https://example.com",
-      }),
-      close: vi.fn(),
-    };
-
-    // テスト実行
-    // ...
+describe("CrawlerEngine Integration", () => {
+  describe("E2E-style crawling with mock Fetcher", () => {
+    it("should crawl single page and generate output files", async () => {
+      // モックFetcherを使用したE2Eテスト
+      // ...
+    });
   });
 });
 ```

--- a/docs/link-crawler/issues.md
+++ b/docs/link-crawler/issues.md
@@ -274,10 +274,10 @@
 **概要**: CrawlerEngine全体の統合テスト
 
 **タスク**:
-- [ ] `tests/integration/crawler.test.ts` を作成
-- [ ] モックFetcherを使用したE2E風テスト
-- [ ] 差分クロールの動作確認テスト
-- [ ] 出力ファイル生成確認テスト
+- [x] `tests/integration/crawler.test.ts` を作成
+- [x] モックFetcherを使用したE2E風テスト
+- [x] 差分クロールの動作確認テスト
+- [x] 出力ファイル生成確認テスト
 
 **依存**: Phase 1-4 完了後
 


### PR DESCRIPTION
## Summary
Closes #217

## Changes
- Updated directory structure in development.md to show crawler.test.ts instead of .gitkeep
- Changed integration test section from "を作成" to "を参照"
- Marked Issue #12 as completed in issues.md (integration tests are now implemented)

## Verification
- Confirmed tests/integration/crawler.test.ts exists with 13 tests
- Updated documentation reflects the actual project state