### PR TITLE
docs: fix depth field description in cli-spec.md

### DIFF
--- a/docs/link-crawler/cli-spec.md
+++ b/docs/link-crawler/cli-spec.md
@@ -193,7 +193,7 @@ crawl https://docs.example.com --delay 2000
 | `url` | string | ページURL |
 | `title` | string \| null | ページタイトル |
 | `file` | string | 出力ファイルパス（pages/以下） |
-| `depth` | number | クロール深度（開始URL=1） |
+| `depth` | number | クロール深度（開始URL=0） |
 | `links` | string[] | ページから抽出されたリンク一覧 |
 | `metadata` | object | ページメタデータ |
 | `metadata.title` | string \| null | メタタグから抽出したタイトル |


### PR DESCRIPTION
## Summary
Closes #216

## Changes
- Fixed depth field description from '開始URL=1' to '開始URL=0' in cli-spec.md
- This makes the documentation consistent with the actual code behavior where start URL has depth 0

## Verification
- Code: `crawl(this.config.startUrl, 0)` in src/crawler/index.ts confirms depth starts at 0
- Documentation now correctly reflects this behavior