### PR TITLE
chore: テストカバレッジレポートのJSON出力設定追加

### DIFF
--- a/link-crawler/vitest.config.ts
+++ b/link-crawler/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
 		include: ["tests/**/*.test.ts"],
 		coverage: {
 			provider: "v8",
-			reporter: ["text", "html"],
+			reporter: ["text", "html", "json-summary"],
 			include: ["src/**/*.ts"],
 			exclude: ["src/crawl.ts"],
 		},


### PR DESCRIPTION
## Summary
Closes #219

## Changes
- Added `json-summary` reporter to vitest.config.ts coverage configuration
- Changed from `["text", "html"]` to `["text", "html", "json-summary"]`

## Testing
- All 342 tests passed successfully
- Verified coverage-summary.json is generated in coverage directory
- Coverage report: 95.54% lines covered

## Verification
```bash
cd link-crawler
npx vitest run --coverage
cat coverage/coverage-summary.json | jq ".total.lines.pct"
# Output: 95.54
```

This enables CI/CD environments to:
- Check coverage thresholds programmatically
- Track coverage history over time
- Display coverage changes in PR comments