### PR TITLE
feat: デフォルト出力先を .context/<サイト名>/ に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,18 @@ Next.jsのドキュメントをクロールして
 ### 基本的なクロール
 
 ```bash
-# 深度2で指定URLをクロール
-bun run link-crawler/src/crawl.ts https://docs.example.com -d 2
+# 深度2で指定URLをクロール（自動的に .context/<サイト名>/ に出力）
+bun run link-crawler/src/crawl.ts https://nextjs.org/docs -d 2
+# → .context/nextjs-docs/ に出力
+
+bun run link-crawler/src/crawl.ts https://docs.python.org/3/ -d 2
+# → .context/python-3/ に出力
 ```
 
 ### 出力先を指定
 
 ```bash
-# 出力ディレクトリを指定してクロール
+# カスタムディレクトリを指定してクロール
 bun run link-crawler/src/crawl.ts https://docs.example.com -o ./my-docs -d 3
 ```
 
@@ -92,11 +96,11 @@ bun run link-crawler/src/crawl.ts https://docs.example.com -o ./docs -d 3 --diff
 ```bash
 # デフォルトでは full.md のみ出力
 bun run link-crawler/src/crawl.ts https://docs.example.com
-# → .context/full.md に全ページが結合されて出力
+# → .context/example-docs/full.md に全ページが結合されて出力
 
 # 必要な時だけ chunks を有効化
 bun run link-crawler/src/crawl.ts https://docs.example.com --chunks
-# → .context/full.md + .context/chunks/*.md
+# → .context/example-docs/full.md + .context/example-docs/chunks/*.md
 ```
 
 ### 特定パスのみクロール
@@ -115,7 +119,7 @@ bun run link-crawler/src/crawl.ts https://docs.example.com --include "/api/"
 | `--wait <ms>` | | `2000` | レンダリング待機時間 |
 | `--timeout <sec>` | | `30` | リクエストタイムアウト（秒） |
 | `--headed` | | `false` | ブラウザ表示 |
-| `--output <dir>` | `-o` | `./.context` | 出力先 |
+| `--output <dir>` | `-o` | `./.context/<サイト名>/` | 出力先（サイト名は自動生成） |
 | `--diff` | | `false` | 差分クロール |
 | `--no-pages` | | | ページ単位出力無効 |
 | `--no-merge` | | | 結合ファイル無効 |
@@ -130,10 +134,11 @@ bun run link-crawler/src/crawl.ts https://docs.example.com --include "/api/"
 
 ```
 .context/
-├── index.json    # メタデータ・ハッシュ
-├── full.md       # 全ページ結合 ★ AIコンテキスト用
-├── chunks/       # 見出しベース分割
-└── pages/        # ページ単位
+└── <サイト名>/    # URLから自動生成（例: nextjs-docs, python-3）
+    ├── index.json    # メタデータ・ハッシュ
+    ├── full.md       # 全ページ結合 ★ AIコンテキスト用
+    ├── chunks/       # 見出しベース分割
+    └── pages/        # ページ単位
 ```
 
 ## 詳細ドキュメント

--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -72,7 +72,7 @@ bun run link-crawler/src/crawl.ts <url> [options]
 
 | オプション | 短縮 | デフォルト | 説明 |
 |-----------|------|-----------|------|
-| `--output <dir>` | `-o` | `./.context` | 出力先 |
+| `--output <dir>` | `-o` | `./.context/<サイト名>/` | 出力先（サイト名は自動生成） |
 | `--diff` | | `false` | 差分クロール |
 | `--no-pages` | | | ページ単位出力無効 |
 | `--no-merge` | | | 結合ファイル無効 |
@@ -86,11 +86,13 @@ bun run link-crawler/src/crawl.ts <url> [options]
 ### 基本
 
 ```bash
-# 深度2でクロール
-bun run link-crawler/src/crawl.ts https://docs.example.com -d 2
+# 深度2でクロール（自動的に .context/<サイト名>/ に出力）
+bun run link-crawler/src/crawl.ts https://nextjs.org/docs -d 2
+# → .context/nextjs-docs/ に出力
 
 # 特定パスのみ
 bun run link-crawler/src/crawl.ts https://docs.example.com --include "/api/"
+# → .context/example-docs/ に出力
 ```
 
 ### 差分クロール
@@ -108,11 +110,11 @@ bun run link-crawler/src/crawl.ts https://docs.example.com -o ./docs -d 3 --diff
 ```bash
 # デフォルトでは full.md のみ出力
 bun run link-crawler/src/crawl.ts https://docs.example.com
-# → .context/full.md のみ出力
+# → .context/example-docs/full.md のみ出力
 
 # 必要な時だけ chunks を有効化
 bun run link-crawler/src/crawl.ts https://docs.example.com --chunks
-# → .context/full.md + .context/chunks/*.md
+# → .context/example-docs/full.md + .context/example-docs/chunks/*.md
 ```
 
 ---
@@ -165,14 +167,15 @@ Bun.spawn([nodePath, cliPath, "open", url, "--session", sessionId])
 
 ```
 .context/
-├── index.json    # メタデータ・ハッシュ
-├── full.md       # 全ページ結合 ★ AIコンテキスト用
-├── chunks/       # 見出しベース分割 (--chunks 有効時のみ)
-│   └── chunk-001.md
-├── pages/        # ページ単位
-│   └── page-001.md
-└── specs/        # API仕様
-    └── openapi.yaml
+└── <サイト名>/    # URLから自動生成（例: nextjs-docs, python-3）
+    ├── index.json    # メタデータ・ハッシュ
+    ├── full.md       # 全ページ結合 ★ AIコンテキスト用
+    ├── chunks/       # 見出しベース分割 (--chunks 有効時のみ)
+    │   └── chunk-001.md
+    ├── pages/        # ページ単位
+    │   └── page-001.md
+    └── specs/        # API仕様
+        └── openapi.yaml
 ```
 
 #### 個別ページファイルの frontmatter 構造
@@ -329,7 +332,7 @@ h1見出しを境界として分割。長大ドキュメントの分割に利用
 bun run link-crawler/src/crawl.ts https://docs.example.com -d 3
 
 # 2. LLMに読み込ませる
-cat .context/full.md | llm "この技術について要約して"
+cat .context/example-docs/full.md | llm "この技術について要約して"
 ```
 
 ### 設計相談

--- a/link-crawler/src/config.ts
+++ b/link-crawler/src/config.ts
@@ -1,11 +1,16 @@
 import { DEFAULTS } from "./constants.js";
 import type { CrawlConfig } from "./types.js";
+import { generateSiteName } from "./utils/site-name.js";
 
 export function parseConfig(options: Record<string, unknown>, startUrl: string): CrawlConfig {
+	// Generate site-specific output directory if not specified
+	const defaultOutputDir = `./.context/${generateSiteName(startUrl)}`;
+	const outputDir = String(options.output || defaultOutputDir);
+
 	return {
 		startUrl,
 		maxDepth: Math.min(Number(options.depth) || DEFAULTS.MAX_DEPTH, DEFAULTS.MAX_DEPTH_LIMIT),
-		outputDir: String(options.output || DEFAULTS.OUTPUT_DIR),
+		outputDir,
 		sameDomain: options.sameDomain !== false,
 		includePattern: options.include ? new RegExp(String(options.include)) : null,
 		excludePattern: options.exclude ? new RegExp(String(options.exclude)) : null,

--- a/link-crawler/src/crawl.ts
+++ b/link-crawler/src/crawl.ts
@@ -10,7 +10,7 @@ program
 	.description("Crawl technical documentation sites recursively")
 	.argument("<url>", "Starting URL to crawl")
 	.option("-d, --depth <num>", "Maximum crawl depth", "1")
-	.option("-o, --output <dir>", "Output directory", "./.context")
+	.option("-o, --output <dir>", "Output directory (default: ./.context/<site-name>/)")
 	.option("--same-domain", "Only follow same-domain links", true)
 	.option("--no-same-domain", "Follow cross-domain links")
 	.option("--include <pattern>", "Include URL pattern (regex)")

--- a/link-crawler/src/utils/site-name.ts
+++ b/link-crawler/src/utils/site-name.ts
@@ -1,0 +1,48 @@
+/**
+ * Generate a site name from a URL for use in directory naming
+ *
+ * Examples:
+ * - https://nextjs.org/docs → nextjs-docs
+ * - https://www.example.com → example
+ * - https://docs.example.com/api → example-api
+ *
+ * @param url - The URL to generate a site name from
+ * @returns A filesystem-safe site name
+ */
+export function generateSiteName(url: string): string {
+	try {
+		const parsed = new URL(url);
+		let hostname = parsed.hostname;
+
+		// Remove 'www.' prefix
+		hostname = hostname.replace(/^www\./, "");
+
+		// Remove known subdomains (docs, api, www, etc.)
+		hostname = hostname.replace(/^(docs?|api|www|blog|dev|stage|staging)\./, "");
+
+		// Remove multi-part TLDs (.co.uk, .com.au, etc.) and single TLDs
+		hostname = hostname.replace(/\.(co|com|ac|gov|org|net)\.[a-z]{2,}$/i, "");
+		hostname = hostname.replace(/\.[a-z]{2,}$/i, "");
+
+		// Get first path segment if it exists
+		const pathSegments = parsed.pathname.split("/").filter((s) => s.length > 0);
+		const firstPath = pathSegments[0] || "";
+
+		// Combine hostname and path
+		let siteName = firstPath ? `${hostname}-${firstPath}` : hostname;
+
+		// Replace invalid characters with hyphens
+		siteName = siteName.replace(/[^a-zA-Z0-9-]/g, "-");
+
+		// Compress consecutive hyphens
+		siteName = siteName.replace(/-+/g, "-");
+
+		// Remove leading/trailing hyphens
+		siteName = siteName.replace(/^-|-$/g, "");
+
+		return siteName || "site";
+	} catch {
+		// If URL parsing fails, return a safe default
+		return "site";
+	}
+}

--- a/link-crawler/tests/unit/config.test.ts
+++ b/link-crawler/tests/unit/config.test.ts
@@ -7,7 +7,7 @@ describe("parseConfig", () => {
 
 		expect(config.startUrl).toBe("https://example.com");
 		expect(config.maxDepth).toBe(1);
-		expect(config.outputDir).toBe("./.context");
+		expect(config.outputDir).toBe("./.context/example");
 		expect(config.sameDomain).toBe(true);
 		expect(config.delay).toBe(500);
 		expect(config.timeout).toBe(30000);
@@ -68,5 +68,26 @@ describe("parseConfig", () => {
 
 		const configDefault = parseConfig({}, "https://example.com");
 		expect(configDefault.keepSession).toBe(false);
+	});
+
+	it("should generate site-specific output directory from URL", () => {
+		const config1 = parseConfig({}, "https://nextjs.org/docs");
+		expect(config1.outputDir).toBe("./.context/nextjs-docs");
+
+		const config2 = parseConfig({}, "https://docs.python.org/3/");
+		expect(config2.outputDir).toBe("./.context/python-3");
+
+		const config3 = parseConfig({}, "https://www.example.com");
+		expect(config3.outputDir).toBe("./.context/example");
+	});
+
+	it("should allow custom output directory to override default", () => {
+		const config = parseConfig({ output: "./custom-dir" }, "https://nextjs.org/docs");
+		expect(config.outputDir).toBe("./custom-dir");
+	});
+
+	it("should allow legacy ./.context directory to be specified explicitly", () => {
+		const config = parseConfig({ output: "./.context" }, "https://nextjs.org/docs");
+		expect(config.outputDir).toBe("./.context");
 	});
 });

--- a/link-crawler/tests/unit/site-name.test.ts
+++ b/link-crawler/tests/unit/site-name.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { generateSiteName } from "../../src/utils/site-name.js";
+
+describe("generateSiteName", () => {
+	it("should generate site name from hostname and path", () => {
+		expect(generateSiteName("https://nextjs.org/docs")).toBe("nextjs-docs");
+		expect(generateSiteName("https://react.dev/learn")).toBe("react-learn");
+		expect(generateSiteName("https://docs.example.com/api")).toBe("example-api");
+	});
+
+	it("should remove www prefix", () => {
+		expect(generateSiteName("https://www.example.com")).toBe("example");
+		expect(generateSiteName("https://www.example.com/docs")).toBe("example-docs");
+	});
+
+	it("should handle URLs without path", () => {
+		expect(generateSiteName("https://example.com")).toBe("example");
+		expect(generateSiteName("https://github.com")).toBe("github");
+	});
+
+	it("should use only first path segment", () => {
+		expect(generateSiteName("https://example.com/en/docs/guide")).toBe("example-en");
+		expect(generateSiteName("https://api.example.com/v1/docs")).toBe("example-v1");
+	});
+
+	it("should replace invalid characters with hyphens", () => {
+		expect(generateSiteName("https://example.com/api_v2")).toBe("example-api-v2");
+		expect(generateSiteName("https://example.com/my.docs")).toBe("example-my-docs");
+	});
+
+	it("should compress consecutive hyphens", () => {
+		expect(generateSiteName("https://example.com/my--docs")).toBe("example-my-docs");
+		expect(generateSiteName("https://my---example.com/docs")).toBe("my-example-docs");
+	});
+
+	it("should remove leading and trailing hyphens", () => {
+		expect(generateSiteName("https://example.com/-docs-")).toBe("example-docs");
+	});
+
+	it("should handle invalid URLs gracefully", () => {
+		expect(generateSiteName("not-a-url")).toBe("site");
+		expect(generateSiteName("")).toBe("site");
+	});
+
+	it("should handle URLs with trailing slashes", () => {
+		expect(generateSiteName("https://example.com/docs/")).toBe("example-docs");
+		expect(generateSiteName("https://example.com/")).toBe("example");
+	});
+
+	it("should handle subdomain-based docs sites", () => {
+		expect(generateSiteName("https://docs.python.org/3/")).toBe("python-3");
+		expect(generateSiteName("https://api.stripe.com/v1")).toBe("stripe-v1");
+	});
+
+	it("should handle different TLDs", () => {
+		expect(generateSiteName("https://example.co.uk/docs")).toBe("example-docs");
+		expect(generateSiteName("https://example.io/api")).toBe("example-api");
+		expect(generateSiteName("https://example.dev/guide")).toBe("example-guide");
+	});
+
+	it("should return 'site' for edge cases", () => {
+		expect(generateSiteName("https://")).toBe("site");
+		expect(generateSiteName("http://localhost")).toBe("localhost");
+	});
+});


### PR DESCRIPTION
## Summary
Closes #228

## Changes
- URLからサイト名を自動生成する `generateSiteName()` 関数を追加
- デフォルト出力先を `./.context/<サイト名>/` に変更
- `-o` オプション指定時は従来通りその値を使用
- サブドメイン（docs, api など）を除去して主要ドメイン名を使用
- パスの最初のセグメントをサイト名に含める（例: nextjs-docs, python-3）

## Examples
```bash
# 自動生成されるサイト名
https://nextjs.org/docs → .context/nextjs-docs/
https://docs.python.org/3/ → .context/python-3/
https://www.example.com → .context/example/

# カスタムディレクトリも引き続き使用可能
crawl https://nextjs.org/docs -o ./my-custom-dir
```

## Testing
- 包括的なユニットテスト追加（12テストケース）
- 既存テスト更新（3テストケース）
- 全テスト（369件）がパス
- TypeScript型チェック、Biome linterともにパス