### PR TITLE
refactor: バージョン番号の一元管理化

### DIFF
--- a/docs/link-crawler/development.md
+++ b/docs/link-crawler/development.md
@@ -453,7 +453,7 @@ bun run build
 ./dist/crawl.js https://example.com
 
 # 5. バージョン更新
-# package.json の version を更新
+# package.json の version を更新（crawl.ts は自動的に反映されます）
 
 # 6. コミット・タグ
 git add -A

--- a/link-crawler/src/crawl.ts
+++ b/link-crawler/src/crawl.ts
@@ -1,9 +1,18 @@
 #!/usr/bin/env bun
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { program } from "commander";
 import { parseConfig } from "./config.js";
 import { EXIT_CODES } from "./constants.js";
 import { Crawler } from "./crawler/index.js";
 import { ConfigError, CrawlError, DependencyError, FetchError, TimeoutError } from "./errors.js";
+
+// package.jsonからバージョンを読み込む
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageJsonPath = join(__dirname, "../package.json");
+const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
 
 program
 	.name("crawl")
@@ -24,7 +33,7 @@ program
 	.option("--no-merge", "Skip merged output file")
 	.option("--chunks", "Enable chunked output files", false)
 	.option("--keep-session", "Keep .playwright-cli directory after crawl (for debugging)", false)
-	.version("2.0.0")
+	.version(packageJson.version)
 	.parse();
 
 const options = program.opts();


### PR DESCRIPTION
## Summary
Closes #230

## Changes
- **crawl.ts**: package.jsonからバージョンを動的に読み込むように変更
- **development.md**: リリース手順を更新（1箇所のみの更新と明記）

## Technical Details
- Node.js標準ライブラリ（fs, path, url）を使用してpackage.jsonを読み込み
- `import.meta.url`でESM環境での相対パス解決
- ビルド後（dist/crawl.js）からも正しく動作することを確認

## Testing
- ✅ 全369テスト通過
- ✅ 開発版で動作確認: `bun run dev --version` → 2.0.0
- ✅ ビルド版で動作確認: `./dist/crawl.js --version` → 2.0.0
- ✅ Biomeチェック通過
- ✅ TypeScriptチェック通過

## Benefits
- バージョン管理が単一箇所（package.json）に集約
- リリース時の不整合リスクを排除
- メンテナンス性の向上