### PR TITLE
docs: add --keep-session option to cli-spec.md

### DIFF
--- a/docs/link-crawler/cli-spec.md
+++ b/docs/link-crawler/cli-spec.md
@@ -47,6 +47,7 @@ crawl <url> [options]
 | `--no-pages` | | | ページ単位ファイル出力を無効化 |
 | `--no-merge` | | | 結合ファイル(full.md)出力を無効化 |
 | `--chunks` | | `false` | チャンク分割出力を有効化 |
+| `--keep-session` | | `false` | デバッグ用に.playwright-cliディレクトリを保持 |
 
 ### 3.5 ヘルプ
 


### PR DESCRIPTION
## Summary
Closes #242

## Changes
- Added `--keep-session` option to `docs/link-crawler/cli-spec.md` in section 3.4 (出力制御)
- Option description: "デバッグ用に.playwright-cliディレクトリを保持"
- Default value: `false`

## Details
The `--keep-session` option was already implemented in `link-crawler/src/crawl.ts` and documented in `README.md` and `link-crawler/SKILL.md`, but was missing from the formal CLI specification document `cli-spec.md`.

## Testing
- ✅ Verified table format matches existing style
- ✅ Verified description consistency with other documents
- ✅ Verified placement in correct section (3.4 出力制御)
- ✅ Verified default value and option format