### PR TITLE
docs: Issue #243 already resolved in #177 (keepSession field)

### DIFF
--- a/.github/ISSUE_243_RESOLUTION.md
+++ b/.github/ISSUE_243_RESOLUTION.md
@@ -1,0 +1,72 @@
+# Issue #243 Resolution Documentation
+
+## Summary
+Issue #243 reported that `keepSession` field was missing from `CrawlConfig` interface in `docs/link-crawler/design.md`. However, investigation revealed this issue was **already resolved** before the issue was created.
+
+## Resolution Details
+
+### Fix Commit
+- **Commit**: `3bc84ddf1c2c69aa1fa065309cbf5e757c86679c`
+- **Date**: Feb 3, 2026 at 07:23 JST
+- **Author**: takemo101
+- **Related Issue**: #177
+- **Message**: 
+  ```
+  docs: update CrawlConfig type definition in design.md
+  
+  - Rename `wait` to `spaWait` to match implementation
+  - Add missing `keepSession` field
+  
+  Refs #177
+  ```
+
+### Timeline
+1. **07:23 JST**: Fix committed (commit 3bc84dd)
+2. **22:45 JST**: Issue #243 created (15 hours later)
+
+### Root Cause
+The issue was likely created by an automated project review tool running on an outdated snapshot of the codebase, before the fix from issue #177 was synchronized.
+
+## Current State
+
+Both files now have the `keepSession: boolean;` field:
+
+### link-crawler/src/types.ts ✅
+```typescript
+export interface CrawlConfig {
+  // ... other fields
+  keepSession: boolean;
+}
+```
+
+### docs/link-crawler/design.md ✅
+```typescript
+interface CrawlConfig {
+  // ... other fields
+  keepSession: boolean;
+}
+```
+
+## Verification Commands
+
+```bash
+# Verify presence in both files
+grep "keepSession" link-crawler/src/types.ts
+grep "keepSession" docs/link-crawler/design.md
+
+# Full interface comparison
+grep -A20 "interface CrawlConfig" link-crawler/src/types.ts
+grep -A20 "interface CrawlConfig" docs/link-crawler/design.md
+```
+
+## Recommendation
+
+To prevent similar false-positive issues in the future:
+1. Ensure automated review tools run against the latest committed code
+2. Add validation step to check if reported issues still exist in main branch
+3. Consider implementing issue deduplication based on recent commits
+
+---
+
+**Status**: No code changes required. This PR serves to formally close the already-resolved issue.
+**Closing**: This PR will close #243 via the `Closes #243` keyword in the PR description.


### PR DESCRIPTION
## Summary
Closes #243

## Investigation Results

Issue #243 reported that `keepSession` field was missing from `CrawlConfig` interface in `docs/link-crawler/design.md`. However, **this issue was already resolved** before it was created.

## Resolution Timeline

1. **Feb 3, 2026 07:23 JST**: Issue fixed in commit `3bc84dd` (issue #177)
2. **Feb 3, 2026 22:45 JST**: Issue #243 created (15 hours later)

The issue was likely created by an automated project review tool running on an outdated snapshot of the codebase.

## Verification

Both files now have the `keepSession: boolean;` field:

### ✅ link-crawler/src/types.ts
```typescript
export interface CrawlConfig {
  // ... other fields
  keepSession: boolean;
}
```

### ✅ docs/link-crawler/design.md
```typescript
interface CrawlConfig {
  // ... other fields
  keepSession: boolean;
}
```

### Verification Commands
```bash
grep "keepSession" link-crawler/src/types.ts
# Output: keepSession: boolean;

grep "keepSession" docs/link-crawler/design.md  
# Output: keepSession: boolean;
```

## Changes in This PR

This PR adds documentation explaining the resolution history:
- Added `.github/ISSUE_243_RESOLUTION.md` documenting the investigation
- No code changes required (already fixed in #177)

## Related Issues

- #177 - Original issue where the fix was applied
- Commit 3bc84dd - The commit that added the missing `keepSession` field

## Recommendation

To prevent similar false-positive issues:
1. Ensure automated review tools run against latest committed code
2. Add validation to check if issues still exist in main branch
3. Implement issue deduplication based on recent commits

---

**Note**: This is a documentation-only PR to formally close an already-resolved issue.