### PR TITLE
docs: development.mdのbun.lockbをbun.lockに修正

### DIFF
--- a/docs/link-crawler/development.md
+++ b/docs/link-crawler/development.md
@@ -412,7 +412,7 @@ rm -rf node_modules/.cache
 ### 8.3 型エラーが解消しない
 
 ```bash
-rm -rf node_modules bun.lockb
+rm -rf node_modules bun.lock
 bun install
 ```
 
@@ -430,7 +430,7 @@ npx playwright install chromium
 rm -rf node_modules/.vitest
 
 # 依存関係再インストール
-rm -rf node_modules bun.lockb
+rm -rf node_modules bun.lock
 bun install
 ```
 


### PR DESCRIPTION
## Summary
Closes #249

## Changes
- `docs/link-crawler/development.md` の2箇所で `bun.lockb` を `bun.lock` に修正
  - 行415: トラブルシューティングセクション「8.3 型エラーが解消しない」
  - 行433: トラブルシューティングセクション「8.5 テストが失敗する」

## Testing
- 修正前: `grep -n "bun.lockb" docs/link-crawler/development.md` で2件検出
- 修正後: `grep -n "bun.lockb" docs/link-crawler/development.md` で0件
- 確認: `grep -n "bun.lock" docs/link-crawler/development.md` で2件（行415, 433）検出
- 実際のプロジェクトファイル: `./link-crawler/bun.lock` が存在することを確認済み