### PR TITLE
docs: README.md の出力パス例を実際の動作に合わせて修正

### DIFF
--- a/docs/link-crawler/README.md
+++ b/docs/link-crawler/README.md
@@ -31,8 +31,8 @@ cd link-crawler
 # クロール実行
 bun run dev https://docs.example.com -d 2
 
-# 出力確認
-cat .context/full.md
+# 出力確認（サイト名ディレクトリ配下に生成されます）
+cat .context/docs-example-com/full.md
 ```
 
 ### 方法2: 手動インストール
@@ -44,8 +44,8 @@ bun install
 # クロール実行
 bun run dev https://docs.example.com -d 2
 
-# 出力確認
-cat .context/full.md
+# 出力確認（サイト名ディレクトリ配下に生成されます）
+cat .context/docs-example-com/full.md
 ```
 
 ## piスキル統合


### PR DESCRIPTION
## Summary
Closes #265

## Changes
- クイックスタート2箇所の出力パス例を修正
- Before: `cat .context/full.md`
- After: `cat .context/docs-example-com/full.md`
- サイト名ディレクトリ配下に生成されることをコメントで明示

## Details
README.md に記載された出力パス例が実際の動作と異なっていた問題を修正しました。

**根拠 (src/config.ts)**:
```typescript
const defaultOutputDir = `./.context/${generateSiteName(startUrl)}`;
```

実際の出力先は `.context/<サイト名>/full.md` であり、README の例では `.context/full.md` と記載されていたためユーザーが混乱する可能性がありました。

## Verification
- [x] cli-spec.md との整合性を確認（既に `./.context/<サイト名>/` と正しく記載済み）
- [x] 他のドキュメントとの整合性を確認
- [x] 具体例として `docs.example.com` → `docs-example-com` を使用