### PR TITLE
fix: add -u option to install.sh for undefined variable detection

### DIFF
--- a/link-crawler/install.sh
+++ b/link-crawler/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -euo pipefail
 
 echo "🔧 link-crawler インストールスクリプト"
 echo ""


### PR DESCRIPTION
## Summary
Closes #264

## Changes
- Changed `set -eo pipefail` to `set -euo pipefail` in `link-crawler/install.sh`
- Added `-u` option to enable undefined variable detection
- Ensures consistency of `set` options across project shell scripts

## Testing
- ✅ Syntax check passed (`bash -n install.sh`)
- ✅ Full script execution test passed
- ✅ All installation steps complete successfully
- ✅ No undefined variable references detected

## Impact
- No breaking changes
- Improves script robustness by catching undefined variable references
- Aligns with project standards (same as `delete_env.sh`)