### PR TITLE
docs: index.jsonのconfig.depthをmaxDepthに修正

### DIFF
--- a/docs/link-crawler/cli-spec.md
+++ b/docs/link-crawler/cli-spec.md
@@ -151,7 +151,7 @@ crawl https://docs.example.com --delay 2000
   "crawledAt": "2026-02-01T14:00:00.000Z",
   "baseUrl": "https://docs.example.com",
   "config": {
-    "depth": 2,
+    "maxDepth": 2,
     "sameDomain": true
   },
   "totalPages": 15,

--- a/docs/link-crawler/design.md
+++ b/docs/link-crawler/design.md
@@ -337,7 +337,7 @@ interface DetectedSpec {
   "crawledAt": "2026-02-01T14:00:00.000Z",
   "baseUrl": "https://docs.example.com",
   "config": {
-    "depth": 2,
+    "maxDepth": 2,
     "sameDomain": true
   },
   "totalPages": 15,


### PR DESCRIPTION
## Summary
Closes #266

## Changes
- `docs/link-crawler/cli-spec.md`: `config.depth` → `config.maxDepth`
- `docs/link-crawler/design.md`: `config.depth` → `config.maxDepth`

## Details
ドキュメントの index.json スキーマ例において、`config` オブジェクト内のフィールド名が実装と不一致だったため修正しました。

**実装 (index-manager.ts)**:
```typescript
config: {
  maxDepth: this.config.maxDepth,
  sameDomain: this.config.sameDomain,
}
```

**修正内容**:
- `config.depth` を `config.maxDepth` に変更
- `pages[].depth` は変更なし（個別ページの深度を表すため正しい）

## Verification
- ✅ 実装との整合性確認済み
- ✅ 他のドキュメントファイルに同様の問題がないことを確認済み
- ✅ JSON構文が正しいことを確認済み