### PR TITLE
fix: add -u option to install.sh for undefined variable detection

### DIFF
--- a/link-crawler/install.sh
+++ b/link-crawler/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -euo pipefail
 
 echo "🔧 link-crawler インストールスクリプト"
 echo ""


### PR DESCRIPTION
## Summary
Closes #264

## Changes
- Changed `set -eo pipefail` to `set -euo pipefail` in `link-crawler/install.sh`
- This enables undefined variable detection, making the script more robust
- Ensures consistency with `delete_env.sh` which already uses `set -euo pipefail`

## Testing
- Verified `install.sh` now has `set -euo pipefail`
- Tested undefined variable detection with `bash -c 'set -euo pipefail; echo $UNDEFINED_VAR'` - correctly detects unbound variable
- Both `install.sh` and `delete_env.sh` now use consistent `set` options