### PR TITLE
fix: delete-environment スキルが存在しない外部スクリプトを参照している

### DIFF
--- a/.pi/skills/delete-environment/SKILL.md
+++ b/.pi/skills/delete-environment/SKILL.md
@@ -67,9 +67,15 @@ bash .pi/skills/delete-environment/scripts/delete_env.sh temp-env /tmp/dev-env
 
 `environments.json` から指定された環境IDのエントリを削除します。
 
+スクリプトは自動的に以下の方法で JSON を更新します：
+
+1. **jq が利用可能な場合**: `jq` を使用して安全に JSON を更新
+2. **Python3 が利用可能な場合**: Python の `json` モジュールを使用
+3. **どちらも利用できない場合**: 警告を表示して他の処理を継続
+
 ```bash
-# 内部で env-json.sh を使用
-bash .opencode/skill/environments-json-management/scripts/env-json.sh remove <env-id>
+# 自動検出された environments.json を更新
+# デフォルトパス: <repo-root>/environments.json
 ```
 
 ### 2. Docker リソースのクリーンアップ
@@ -140,14 +146,18 @@ rm -rf <path-to-delete>
 
 ## トラブルシューティング
 
-### env-json.sh が見つからない
+### environments.json の更新に失敗する
 
 ```bash
-# 警告が表示されますが、他の処理は継続されます
-[WARN] env-json.sh not found. Skipping JSON update.
+# jq または Python3 がない場合、警告が表示されます
+[WARN] jq not found. Attempting basic JSON update...
+[WARN] Could not update environments.json. Manual update may be required.
 ```
 
-**対処**: environments.json の手動更新が必要な場合があります
+**対処**: 
+- `jq` をインストールすることをお勧めします: `brew install jq` (macOS) または `apt-get install jq` (Linux)
+- または Python3 を使用可能にしてください
+- 手動で environments.json を編集することもできます
 
 ### Dockerコンテナが削除できない
 

--- a/.pi/skills/delete-environment/scripts/delete_env.sh
+++ b/.pi/skills/delete-environment/scripts/delete_env.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-ENV_JSON_SCRIPT="${REPO_ROOT}/.opencode/skill/environments-json-management/scripts/env-json.sh"
+ENV_JSON_FILE="${REPO_ROOT}/environments.json"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -12,6 +12,70 @@ NC='\033[0m'
 log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Update environments.json by removing the specified environment ID
+update_environments_json() {
+    local env_id="$1"
+    local json_file="$ENV_JSON_FILE"
+    
+    if [ ! -f "$json_file" ]; then
+        log_warn "environments.json not found at $json_file. Skipping JSON update."
+        return 0
+    fi
+    
+    # Check if jq is available
+    if command -v jq &> /dev/null; then
+        # Use jq to remove the environment entry
+        local temp_file="${json_file}.tmp"
+        if jq --arg id "$env_id" 'del(.[$id])' "$json_file" > "$temp_file" 2>/dev/null; then
+            mv "$temp_file" "$json_file"
+            log_info "Removed environment '$env_id' from environments.json"
+        else
+            log_warn "Failed to update environments.json with jq."
+            rm -f "$temp_file"
+        fi
+    else
+        # Fallback: simple grep-based removal (basic implementation)
+        log_warn "jq not found. Attempting basic JSON update..."
+        
+        # Create a backup
+        cp "$json_file" "${json_file}.bak"
+        
+        # Remove lines containing the environment ID (naive approach for simple JSON)
+        if grep -q "\"$env_id\"" "$json_file"; then
+            # Try to remove the entry - this is a basic implementation
+            # For complex JSON, jq is strongly recommended
+            local temp_file="${json_file}.tmp"
+            
+            # Remove the key-value pair for this env_id
+            # This is a simplified approach that works for flat JSON structures
+            if python3 -c "
+import json
+import sys
+try:
+    with open('$json_file', 'r') as f:
+        data = json.load(f)
+    if '$env_id' in data:
+        del data['$env_id']
+        with open('$json_file', 'w') as f:
+            json.dump(data, f, indent=2)
+        sys.exit(0)
+    sys.exit(0)
+except Exception as e:
+    sys.exit(1)
+" 2>/dev/null; then
+                log_info "Removed environment '$env_id' from environments.json"
+            else
+                log_warn "Could not update environments.json. Manual update may be required."
+                mv "${json_file}.bak" "$json_file"
+            fi
+        else
+            log_info "Environment '$env_id' not found in environments.json"
+        fi
+        
+        rm -f "${json_file}.bak"
+    fi
+}
 
 if [ $# -lt 1 ]; then
     echo "Usage: $0 <env-id> [path-to-delete]"
@@ -29,12 +93,8 @@ fi
 
 log_info "Starting deletion for environment: $ENV_ID"
 
-if [ -f "$ENV_JSON_SCRIPT" ]; then
-    log_info "Updating environments.json..."
-    bash "$ENV_JSON_SCRIPT" remove "$ENV_ID"
-else
-    log_warn "env-json.sh not found at $ENV_JSON_SCRIPT. Skipping JSON update."
-fi
+log_info "Updating environments.json..."
+update_environments_json "$ENV_ID"
 
 log_info "Cleaning up Docker resources..."
 


### PR DESCRIPTION
## Summary
Closes #263

## Changes
- 存在しない .opencode/skill/environments-json-management/scripts/env-json.sh の参照を削除
- JSON更新機能をスクリプト内に直接実装
  - jq が利用可能な場合は jq を使用
  - jq がない場合は Python3 の json モジュールを使用
  - どちらもない場合は警告を表示して処理を継続
- SKILL.md のドキュメントを更新して新しい実装を反映

## Testing
- スクリプトの構文チェックを実行
- テスト用の environments.json を作成して削除機能を検証
- 正常に環境IDが削除されることを確認