### PR TITLE
fix: types: SpawnResultのexitCode型をnumber | nullに修正

### DIFF
--- a/link-crawler/src/utils/runtime.ts
+++ b/link-crawler/src/utils/runtime.ts
@@ -3,7 +3,7 @@ export interface SpawnResult {
 	success: boolean;
 	stdout: string;
 	stderr: string;
-	exitCode: number;
+	exitCode: number | null;
 }
 
 /** ランタイムアダプターインターフェース */
@@ -70,7 +70,7 @@ export class NodeRuntimeAdapter implements RuntimeAdapter {
 					success: exitCode === 0,
 					stdout,
 					stderr,
-					exitCode: exitCode ?? -1,
+					exitCode,
 				});
 			});
 


### PR DESCRIPTION
## Summary
Closes #291

## Changes
- Changed `SpawnResult.exitCode` type from `number` to `number | null`
- Updated `NodeRuntimeAdapter` to preserve null values instead of converting to -1
- This accurately reflects Node.js `child_process.spawn` behavior where exitCode can be null when process terminates abnormally

## Testing
- ✅ `npm run typecheck` passes
- ✅ `npm run test` passes (373 tests)

## Why
- Improves type safety by accurately representing possible values
- Aligns with Node.js specification for process exit codes