### PR TITLE
docs: types.ts のフィールドに単位を明示するJSDocコメントを追加

### DIFF
--- a/link-crawler/src/types.ts
+++ b/link-crawler/src/types.ts
@@ -6,8 +6,11 @@ export interface CrawlConfig {
 	sameDomain: boolean;
 	includePattern: RegExp | null;
 	excludePattern: RegExp | null;
+	/** リクエスト間隔（ミリ秒） */
 	delay: number;
+	/** リクエストタイムアウト（ミリ秒） */
 	timeout: number;
+	/** SPAページ待機時間（ミリ秒） */
 	spaWait: number;
 	headed: boolean;
 	diff: boolean;


### PR DESCRIPTION
## Summary
Closes #287

## Changes
- <code>timeout</code> フィールドに「リクエストタイムアウト（ミリ秒）」のJSDocコメントを追加
- <code>delay</code> フィールドに「リクエスト間隔（ミリ秒）」のJSDocコメントを追加  
- <code>spaWait</code> フィールドに「SPAページ待機時間（ミリ秒）」のJSDocコメントを追加

## Testing
- npm run typecheck がパスすることを確認済み
- JSDocコメントが正しく追加されていることを確認済み

## 対象ファイル
- link-crawler/src/types.ts