### PR TITLE
chore: package.jsonのテストコマンドをbun xに統一

### DIFF
--- a/link-crawler/package.json
+++ b/link-crawler/package.json
@@ -11,9 +11,9 @@
 		"check": "biome check .",
 		"fix": "biome check --write .",
 		"typecheck": "tsc --noEmit",
-		"test": "npx vitest run",
-		"test:watch": "npx vitest",
-		"test:coverage": "npx vitest run --coverage"
+		"test": "bun x vitest run",
+		"test:watch": "bun x vitest",
+		"test:coverage": "bun x vitest run --coverage"
 	},
 	"dependencies": {
 		"@mozilla/readability": "^0.5.0",


### PR DESCRIPTION
## Summary
Closes #289

## Changes
- `link-crawler/package.json` のテストスクリプトを `npx` から `bun x` に変更
  - `test`: `bun x vitest run`
  - `test:watch`: `bun x vitest`
  - `test:coverage`: `bun x vitest run --coverage`

## Testing
- [x] 全373テストが正常に実行されることを確認
- [x] Biome check通過
- [x] TypeScript型チェック通過

## 理由
- プロジェクトはBunを前提としている
- `bun x`はBunのパッケージ実行コマンドで、npxと同等の機能を持つ
- ツールチェーンをBunに統一することで一貫性が向上する