### PR TITLE
docs: SKILL.mdの使用例コマンドパスを修正する

### DIFF
--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -37,7 +37,7 @@ bun run link-crawler/src/crawl.ts <url> [options]
 
 ```bash
 # Next.jsドキュメントをクロール
-bun run link-crawler/src/crawl.ts https://nextjs.org/docs -d 2
+bun run src/crawl.ts https://nextjs.org/docs -d 2
 
 # → .context/nextjs-docs/full.md が生成され、piエージェントのコンテキストとして利用可能
 ```


### PR DESCRIPTION
## Summary
Closes #298

## Changes
- Fixed command path in SKILL.md usage example section
- Changed  to  in the pi agent usage example
- This aligns with the setup instructions that direct users to  first

## Testing
- Verified the file exists at the corrected path: 
- Command example now correctly references  when running from within the link-crawler directory