### PR TITLE
chore: biome.jsonのlint対象にtestsディレクトリを追加する

### DIFF
--- a/link-crawler/biome.json
+++ b/link-crawler/biome.json
@@ -7,7 +7,7 @@
 		"useIgnoreFile": true
 	},
 	"files": {
-		"includes": ["src/**/*.ts"],
+		"includes": ["src/**/*.ts", "tests/**/*.ts"],
 		"ignoreUnknown": true
 	},
 	"linter": {


### PR DESCRIPTION
## Summary
Closes #297

## Changes
- Added `tests/**/*.ts` to the `files.includes` array in `biome.json`
- Changed from `["src/**/*.ts"]` to `["src/**/*.ts", "tests/**/*.ts"]`

## Testing
- `npx biome check .` passes with no errors
- All 373 existing tests pass
- Test code is now included in lint/format targets

## Benefits
- Test code formatting is now checked
- Unused imports/variables in tests are detected
- Code style consistency is maintained across the entire codebase