### PR TITLE
refactor: タイムアウトエラーメッセージの単位表示を改善

### DIFF
--- a/link-crawler/src/crawler/fetcher.ts
+++ b/link-crawler/src/crawler/fetcher.ts
@@ -158,7 +158,7 @@ export class PlaywrightFetcher implements Fetcher {
 			const timeoutPromise = new Promise<never>((_, reject) => {
 				setTimeout(() => {
 					reject(
-						new TimeoutError(`Request timeout after ${this.config.timeout}ms`, this.config.timeout),
+						new TimeoutError(`Request timeout after ${this.config.timeout / 1000}s (${this.config.timeout}ms)`, this.config.timeout),
 					);
 				}, this.config.timeout);
 			});


### PR DESCRIPTION
## Summary
Closes #303

## Changes
- タイムアウトエラーメッセージを改善し、秒とミリ秒の両方を表示するように変更
- Before: Request timeout after 30000ms
- After: Request timeout after 30s (30000ms)

## Testing
- 既存のfetcher.test.tsの37テストが全てパス
- TypeScript型チェックがパス