### PR TITLE
docs: セットアップ手順のディレクトリ名を汎用的に変更

### DIFF
--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -9,8 +9,9 @@ description: 技術ドキュメントサイトをクロールし、AIコンテ�
 
 ## セットアップ
 
+このスキルディレクトリに移動して依存関係をインストールします：
+
 ```bash
-cd link-crawler
 bun install
 ```
 


### PR DESCRIPTION
## Summary
Closes #315

## Changes
- SKILL.md のセットアップセクションから固定のディレクトリ名  を削除
- 代わりに「このスキルディレクトリに移動して依存関係をインストールします」という説明文を追加
- 実際のディレクトリ名に依存しない汎用的な表現に変更

## Testing
- Markdownの構文を確認
- 変更内容がIssueの要件を満たしていることを確認