### PR TITLE
refactor: 重複するCSSセレクタの削除

### DIFF
--- a/link-crawler/src/parser/extractor.ts
+++ b/link-crawler/src/parser/extractor.ts
@@ -31,7 +31,6 @@ function protectCodeBlocks(doc: Document): Map<string, string> {
 	const prioritySelectors = [
 		"[data-rehype-pretty-code-fragment]",
 		"[data-rehype-pretty-code-figure]",
-		"figure[data-rehype-pretty-code-figure]",
 		".code-block",
 		".hljs",
 		".prism-code",


### PR DESCRIPTION
## Summary
Closes #313

## Changes
- Remove redundant CSS selector `figure[data-rehype-pretty-code-figure]` from `prioritySelectors` array
- The attribute selector `[data-rehype-pretty-code-figure]` already matches all elements with this attribute, including figure elements

## Testing
- All 375 existing tests pass
- No functional changes to the codebase