### PR TITLE
docs: Restore links to existing documentation files

### DIFF
--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -66,6 +66,8 @@ bun run link-crawler/src/crawl.ts <url> [options]
 | `--help` | `-h` | ヘルプ表示 |
 | `--version` | `-V` | バージョン表示 |
 
+**詳細な仕様は [CLI仕様書](../docs/link-crawler/cli-spec.md) を参照してください。**
+
 ## piエージェントでの使用例
 
 ```bash
@@ -85,3 +87,12 @@ bun run src/crawl.ts https://nextjs.org/docs -d 2
 | `chunks/*.md` | 見出しベース分割（`--chunks`有効時） |
 | `pages/*.md` | ページ単位 |
 | `index.json` | メタデータ・ハッシュ |
+
+**詳細な仕様は [CLI仕様書](../docs/link-crawler/cli-spec.md) を参照してください。**
+
+## 参考リンク
+
+| ドキュメント | 内容 |
+|-------------|------|
+| [CLI仕様書](../docs/link-crawler/cli-spec.md) | 完全なオプション一覧・使用例・出力形式の詳細 |
+| [設計書](../docs/link-crawler/design.md) | アーキテクチャ・データ構造・技術仕様 |


### PR DESCRIPTION
## Summary
Closes #311

## Changes
- Restore CLI specification link in Help section
- Restore CLI specification link in Output Files section  
- Add Reference Links section with CLI spec and Design docs

## Background
Documentation files (cli-spec.md, design.md) now exist that were previously missing.
Restoring links that were removed in #302.

## Testing
- [x] Verified linked files exist
- [x] Verified relative paths are correct