### PR TITLE
docs: README.mdの作成とドキュメント構成の改善

### DIFF
--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -67,7 +67,7 @@ bun run link-crawler/src/crawl.ts <url> [options]
 | `--help` | `-h` | ヘルプ表示 |
 | `--version` | `-V` | バージョン表示 |
 
-**詳細な仕様は [CLI仕様書](../docs/link-crawler/cli-spec.md) を参照してください。**
+**詳細な仕様は [CLI仕様書](./docs/cli-spec.md) を参照してください。**
 
 ## piエージェントでの使用例
 
@@ -89,11 +89,11 @@ bun run src/crawl.ts https://nextjs.org/docs -d 2
 | `pages/*.md` | ページ単位 |
 | `index.json` | メタデータ・ハッシュ |
 
-**詳細な仕様は [CLI仕様書](../docs/link-crawler/cli-spec.md) を参照してください。**
+**詳細な仕様は [CLI仕様書](./docs/cli-spec.md) を参照してください。**
 
 ## 参考リンク
 
 | ドキュメント | 内容 |
 |-------------|------|
-| [CLI仕様書](../docs/link-crawler/cli-spec.md) | 完全なオプション一覧・使用例・出力形式の詳細 |
-| [設計書](../docs/link-crawler/design.md) | アーキテクチャ・データ構造・技術仕様 |
+| [CLI仕様書](./docs/cli-spec.md) | 完全なオプション一覧・使用例・出力形式の詳細 |
+| [設計書](./docs/design.md) | アーキテクチャ・データ構造・技術仕様 |

--- a/link-crawler/docs/cli-spec.md
+++ b/link-crawler/docs/cli-spec.md
@@ -1,0 +1,322 @@
+# Link Crawler CLI仕様
+
+## 1. 基本構文
+
+```bash
+crawl <url> [options]
+```
+
+## 2. 引数
+
+| 引数 | 必須 | 説明 |
+|------|------|------|
+| `<url>` | ✓ | クロール開始URL |
+
+## 3. オプション一覧
+
+### 3.1 クロール制御
+
+| オプション | 短縮 | デフォルト | 説明 |
+|-----------|------|-----------|------|
+| `--depth <num>` | `-d` | `1` | 最大クロール深度（上限10） |
+| `--delay <ms>` | | `500` | リクエスト間隔（ミリ秒） |
+| `--timeout <sec>` | | `30` | リクエストタイムアウト（秒） |
+| `--wait <ms>` | | `2000` | ページレンダリング待機時間（ミリ秒） |
+| `--headed` | | `false` | ブラウザを表示（デバッグ用） |
+
+### 3.2 スコープ制御
+
+| オプション | デフォルト | 説明 |
+|-----------|-----------|------|
+| `--same-domain` | `true` | 同一ドメインのみクロール |
+| `--no-same-domain` | | クロスドメインリンクも追跡 |
+| `--include <pattern>` | | 含めるURLパターン（正規表現） |
+| `--exclude <pattern>` | | 除外するURLパターン（正規表現） |
+
+### 3.3 差分クロール
+
+| オプション | デフォルト | 説明 |
+|-----------|-----------|------|
+| `--diff` | `false` | 差分クロール（変更ページのみ更新） |
+
+### 3.4 出力制御
+
+| オプション | 短縮 | デフォルト | 説明 |
+|-----------|------|-----------|------|
+| `--output <dir>` | `-o` | `./.context/<サイト名>/` | 出力ディレクトリ |
+| `--no-pages` | | | ページ単位ファイル出力を無効化 |
+| `--no-merge` | | | 結合ファイル(full.md)出力を無効化 |
+| `--chunks` | | `false` | チャンク分割出力を有効化 |
+| `--keep-session` | | `false` | デバッグ用に.playwright-cliディレクトリを保持 |
+
+### 3.5 ヘルプ
+
+| オプション | 短縮 | 説明 |
+|-----------|------|------|
+| `--help` | `-h` | ヘルプ表示 |
+| `--version` | `-V` | バージョン表示 |
+
+---
+
+## 4. 使用例
+
+### 4.1 基本的なクロール
+
+```bash
+# 深度2でクロール
+crawl https://docs.example.com -d 2
+
+# 出力先を指定
+crawl https://docs.example.com -o ./my-docs
+```
+
+### 4.2 差分クロール
+
+```bash
+# 初回クロール
+crawl https://docs.example.com -o ./docs -d 3
+
+# 2回目以降（変更ページのみ更新）
+crawl https://docs.example.com -o ./docs -d 3 --diff
+```
+
+### 4.3 スコープ制御
+
+```bash
+# 特定パス配下のみ
+crawl https://docs.example.com --include "/api/"
+
+# 特定パスを除外
+crawl https://docs.example.com --exclude "/v1/|/deprecated/"
+
+# 組み合わせ
+crawl https://docs.example.com --include "/guide/" --exclude "/internal/"
+```
+
+### 4.4 出力形式制御
+
+```bash
+# AIコンテキスト用: 結合ファイルのみ
+crawl https://docs.example.com --no-pages
+
+# ページ単位のみ
+crawl https://docs.example.com --no-merge
+
+# チャンクのみ
+crawl https://docs.example.com --no-pages --no-merge --chunks
+```
+
+### 4.5 デバッグ・調整
+
+```bash
+# ブラウザを表示して動作確認
+crawl https://docs.example.com --headed
+
+# 遅いサイト向けに待機時間延長
+crawl https://slow-site.example.com --wait 5000
+
+# サーバー負荷軽減のためリクエスト間隔延長
+crawl https://docs.example.com --delay 2000
+```
+
+---
+
+## 5. 出力構造
+
+### 5.1 ディレクトリ構成
+
+```
+.context/
+└── <サイト名>/       # URLから自動生成（例: nextjs-docs, python-3, example）
+    ├── index.json       # メタデータ・ハッシュ情報
+    ├── full.md          # 全ページ結合（AIコンテキスト用）
+    ├── chunks/          # 見出しベースチャンク分割
+    │   ├── chunk-001.md
+    │   ├── chunk-002.md
+    │   └── ...
+    ├── pages/           # ページ単位
+    │   ├── page-001.md
+    │   ├── page-002.md
+    │   └── ...
+    └── specs/           # 検出されたAPI仕様
+        ├── openapi.yaml
+        └── ...
+```
+
+**サイト名の命名規則:**
+
+出力ディレクトリ名（`<サイト名>`）は、クロール対象URLから自動生成されます：
+
+1. サブドメイン（`docs`, `api`, `www`, `blog`, `dev`等）は除去されます
+2. TLD（`.com`, `.org`, `.dev`等）は除去されます
+3. パスの最初のセグメントが追加されます
+
+**変換例:**
+
+| URL | 生成されるサイト名 |
+|-----|------------------|
+| `https://nextjs.org/docs` | `nextjs-docs` |
+| `https://docs.python.org/3/` | `python-3` |
+| `https://docs.example.com` | `example` |
+| `https://www.example.com` | `example` |
+| `https://api.example.com/v1` | `example-v1` |
+| `https://docs.example.com/api` | `example-api` |
+
+### 5.2 index.json
+
+クロール結果のメタデータ。差分クロール用のハッシュ情報を含む。
+
+```json
+{
+  "crawledAt": "2026-02-01T14:00:00.000Z",
+  "baseUrl": "https://docs.example.com",
+  "config": {
+    "maxDepth": 2,
+    "sameDomain": true
+  },
+  "totalPages": 15,
+  "pages": [
+    {
+      "url": "https://docs.example.com/getting-started",
+      "title": "Getting Started",
+      "file": "pages/page-001.md",
+      "depth": 1,
+      "links": [
+        "https://docs.example.com/installation",
+        "https://docs.example.com/configuration"
+      ],
+      "metadata": {
+        "title": "Getting Started",
+        "description": "Quick start guide for beginners",
+        "keywords": "guide, tutorial, quickstart",
+        "author": null,
+        "ogTitle": "Getting Started - Example Docs",
+        "ogType": "article"
+      },
+      "hash": "a1b2c3d4e5f6...",
+      "crawledAt": "2026-02-01T14:00:01.000Z"
+    }
+  ],
+  "specs": [
+    {
+      "url": "https://docs.example.com/openapi.yaml",
+      "type": "openapi",
+      "file": "specs/openapi.yaml"
+    }
+  ]
+}
+```
+
+#### ページフィールド
+
+| フィールド | 型 | 説明 |
+|-----------|------|------|
+| `url` | string | ページURL |
+| `title` | string \| null | ページタイトル |
+| `file` | string | 出力ファイルパス（pages/以下） |
+| `depth` | number | クロール深度（開始URL=0） |
+| `links` | string[] | ページから抽出されたリンク一覧 |
+| `metadata` | object | ページメタデータ |
+| `metadata.title` | string \| null | メタタグから抽出したタイトル |
+| `metadata.description` | string \| null | メタディスクリプション |
+| `metadata.keywords` | string \| null | メタキーワード |
+| `metadata.author` | string \| null | 著者情報 |
+| `metadata.ogTitle` | string \| null | Open Graphタイトル |
+| `metadata.ogType` | string \| null | Open Graphタイプ |
+| `hash` | string | コンテンツのSHA-256ハッシュ |
+| `crawledAt` | string | クロール日時（ISO 8601） |
+
+### 5.3 full.md
+
+全ページを `# タイトル` で結合したファイル。LLMへの入力に最適。
+
+```markdown
+# Getting Started
+
+導入部分の内容...
+
+# Installation
+
+インストール手順...
+
+# Configuration
+
+設定方法...
+```
+
+### 5.4 chunks/*.md
+
+見出し（h1）を境界としてチャンク分割。
+
+```markdown
+<!-- chunk-001.md -->
+# Getting Started
+
+導入部分...
+
+## Prerequisites
+
+前提条件...
+
+## Quick Start
+
+クイックスタート...
+```
+
+```markdown
+<!-- chunk-002.md -->
+# Installation
+
+インストール手順...
+
+## npm
+
+npm install...
+```
+
+### 5.5 pages/*.md
+
+ページ単位でfrontmatter付きMarkdown。
+
+```markdown
+---
+url: https://docs.example.com/getting-started
+title: "Getting Started"
+hash: "a1b2c3d4e5f6..."
+crawledAt: 2026-02-01T14:00:01.000Z
+depth: 1
+---
+
+# Getting Started
+
+本文...
+```
+
+---
+
+## 6. 終了コード
+
+| コード | 意味 | 対応 |
+|--------|------|------|
+| `0` | 正常終了 | - |
+| `1` | 一般エラー | エラーメッセージを確認 |
+| `2` | 引数エラー | `--help` でオプション確認 |
+| `3` | playwright-cli未インストール | `npm install -g @playwright/cli` |
+| `4` | クロールエラー | 個別ページの取得失敗、タイムアウト等 |
+
+---
+
+## 7. 環境変数
+
+| 変数 | 説明 |
+|------|------|
+| `DEBUG=1` | デバッグログを出力 |
+
+---
+
+## 8. 注意事項
+
+- クロール対象サイトの利用規約を確認すること
+- 過度なリクエストを避けるため `--delay` を適切に設定
+- 大規模サイトは `--include` でスコープを限定
+- playwright-cliが必要: `npm install -g @playwright/cli`

--- a/link-crawler/docs/design.md
+++ b/link-crawler/docs/design.md
@@ -1,0 +1,608 @@
+# Link Crawler 設計書
+
+## 1. 概要
+
+### 1.1 目的
+
+技術ドキュメントサイトをクロールし、**AIコンテキスト用のMarkdown**として保存するCLIツール。
+
+### 1.2 ユースケース
+
+| ユースケース | 説明 |
+|-------------|------|
+| 知識ベース構築 | 最新ドキュメントをローカルに保存し、LLMに読み込ませる |
+| 設計参考資料 | フレームワークのベストプラクティスを取得し、設計相談に利用 |
+| 定期更新 | 差分クロールで最新状態を維持 |
+
+### 1.3 設計原則
+
+| 原則 | 説明 |
+|------|------|
+| AIファースト | 出力形式はLLMへの入力を最優先に設計 |
+| シンプル | playwright-cli統一、不要な分岐を排除 |
+| 効率性 | 差分クロールで無駄なリクエストを削減 |
+| 再現性 | ハッシュで変更追跡、同一入力で同一出力 |
+
+---
+
+## 2. 技術スタック
+
+| カテゴリ | 技術 | バージョン | 選定理由 |
+|----------|------|-----------|----------|
+| Runtime | Bun | 1.3.x | 高速起動、TypeScriptネイティブ |
+| Language | TypeScript | 5.8.x | 型安全性 |
+| Linter/Formatter | Biome | 2.x | 高速、設定シンプル |
+| Test Framework | Vitest | 4.x | 高速、ESM対応、Bun互換 |
+| CLI Parser | Commander | 13.x | 軽量、標準的 |
+| Browser | playwright-cli | latest | SPA完全対応、セッション管理 |
+| DOM Parser | JSDOM | 26.x | Node.js標準的なDOM実装 |
+| Content Extractor | @mozilla/readability | 0.5.x | Firefox由来、高品質 |
+| Markdown Converter | Turndown | 7.x | GFM対応、カスタマイズ可能 |
+
+---
+
+## 3. アーキテクチャ
+
+### 3.1 全体構成
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│                              CLI Layer                             │
+│  ┌──────────────────────────────────────────────────────────────┐  │
+│  │  crawl.ts: エントリーポイント、引数解析、ワークフロー制御    │  │
+│  └──────────────────────────────────────────────────────────────┘  │
+├────────────────────────────────────────────────────────────────────┤
+│                            Core Layer                              │
+│  ┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐   │
+│  │  Crawler   │  │   Parser   │  │   Differ   │  │   Output   │   │
+│  │  Engine    │  │            │  │            │  │   Writer   │   │
+│  └─────┬──────┘  └─────┬──────┘  └─────┬──────┘  └─────┬──────┘   │
+│        │               │               │               │          │
+│        ▼               ▼               ▼               ▼          │
+│  ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────────┐    │
+│  │ Fetcher  │   │Extractor │   │  Hasher  │   │ Merger/     │    │
+│  │          │   │Converter │   │          │   │ Chunker     │    │
+│  └──────────┘   └──────────┘   └──────────┘   └──────────────┘    │
+├────────────────────────────────────────────────────────────────────┤
+│                          External Layer                            │
+│  ┌────────────────┐  ┌────────────────┐  ┌────────────────┐       │
+│  │ playwright-cli │  │     JSDOM      │  │  File System   │       │
+│  └────────────────┘  └────────────────┘  └────────────────┘       │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.2 モジュール構成
+
+```
+link-crawler/
+├── SKILL.md                    # piスキル定義
+├── src/
+│   ├── crawl.ts                # エントリーポイント
+│   ├── config.ts               # 設定パース
+│   ├── types.ts                # 型定義
+│   ├── constants.ts            # 定数定義
+│   ├── errors.ts               # エラークラス
+│   │
+│   ├── crawler/
+│   │   ├── index.ts            # CrawlerEngine
+│   │   ├── fetcher.ts          # PlaywrightFetcher
+│   │   ├── logger.ts           # ログ出力
+│   │   └── post-processor.ts   # 後処理
+│   │
+│   ├── parser/
+│   │   ├── extractor.ts        # HTML → 本文抽出
+│   │   ├── converter.ts        # HTML → Markdown
+│   │   └── links.ts            # リンク抽出・正規化
+│   │
+│   ├── diff/
+│   │   ├── index.ts            # バレルエクスポート
+│   │   └── hasher.ts           # SHA256ハッシュ・差分検知
+│   │
+│   ├── output/
+│   │   ├── writer.ts           # ページ書き込み
+│   │   ├── merger.ts           # full.md 生成
+│   │   ├── chunker.ts          # chunks/*.md 生成
+│   │   └── index-manager.ts    # index.json管理
+│   │
+│   ├── types/
+│   │   └── turndown-plugin-gfm.d.ts  # Turndown型定義
+│   │
+│   └── utils/
+│       └── runtime.ts          # ランタイムアダプター
+│
+├── package.json
+├── tsconfig.json
+├── biome.json
+└── .gitignore
+```
+
+### 3.3 モジュール責務
+
+| モジュール | 責務 | 入力 | 出力 |
+|-----------|------|------|------|
+| `Constants` | 定数定義（デフォルト値、ファイル名、パターン、終了コード） | - | 定数オブジェクト |
+| `Errors` | エラークラス定義（CrawlError, FetchError, ConfigError等） | Error情報 | Typed Error |
+| `CrawlerEngine` | クロール制御、再帰管理 | URL, Config | CrawledPages |
+| `PlaywrightFetcher` | ページ取得 | URL | HTML |
+| `CrawlLogger` | クロールログ出力（開始、進捗、完了、エラー等） | Config, Events | コンソール出力 |
+| `PostProcessor` | 後処理実行（Merger/Chunker呼び出し、ページ内容読み込み） | CrawledPages | full.md, chunks/ |
+| `Extractor` | 本文抽出 | HTML | ContentHTML |
+| `Converter` | Markdown変換 | ContentHTML | Markdown |
+| `LinksParser` | リンク抽出 | HTML | URLs |
+| `Hasher` | ハッシュ計算・比較 | Content | Hash, Changed |
+| `IndexManager` | index.jsonの読み込み・保存・管理 | CrawledPage | index.json |
+| `OutputWriter` | ページファイル保存、フロントマター付与 | Page | .md File |
+| `Merger` | 全ページ結合 | Pages | full.md |
+| `Chunker` | チャンク分割 | full.md | chunks/*.md |
+| `RuntimeAdapter` | ランタイム抽象化（Bun/Node.js互換） | Command | SpawnResult |
+
+---
+
+## 4. データフロー
+
+### 4.1 メインフロー
+
+```
+[Start]
+   │
+   ▼
+┌─────────────────────┐
+│ 1. 設定パース       │ CLI引数 → CrawlConfig
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│ 2. 既存index.json   │ --diff時のみ
+│    読み込み         │ 
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────────────────────────┐
+│ 3. クロールループ                        │
+│  ┌─────────────────────────────────────┐│
+│  │ 3.1 playwright-cli でHTML取得       ││
+│  │ 3.2 ハッシュ計算                    ││
+│  │ 3.3 差分チェック (--diff時)         ││
+│  │     └─ 変更なし → スキップ          ││
+│  │ 3.4 本文抽出 (Readability)          ││
+│  │ 3.5 Markdown変換 (Turndown)         ││
+│  │ 3.6 ページ保存                      ││
+│  │ 3.7 リンク抽出 → キューに追加       ││
+│  └─────────────────────────────────────┘│
+│  depth < maxDepth まで再帰              │
+└──────────┬──────────────────────────────┘
+           │
+           ▼
+┌─────────────────────┐
+│ 4. 後処理           │
+│  4.1 full.md 生成   │
+│  4.2 chunks/ 生成   │
+│  4.3 index.json更新 │
+└──────────┬──────────┘
+           │
+           ▼
+        [End]
+```
+
+### 4.2 差分クロールフロー
+
+```
+[ページ取得完了]
+       │
+       ▼
+┌──────────────────┐
+│ コンテンツから   │
+│ SHA256ハッシュ   │
+│ 計算             │
+└────────┬─────────┘
+         │
+         ▼
+    ┌────────────┐     Yes    ┌─────────────┐
+    │ index.json │───────────▶│ ハッシュ比較 │
+    │ に既存あり？│            └──────┬──────┘
+    └────────────┘                   │
+         │ No                        │
+         ▼                     ┌─────┴─────┐
+    ┌──────────┐               │           │
+    │ 新規追加 │           一致│       不一致
+    └──────────┘               ▼           ▼
+                          ┌────────┐  ┌────────┐
+                          │ スキップ│  │  更新  │
+                          └────────┘  └────────┘
+```
+
+---
+
+## 5. データ構造
+
+### 5.1 型定義
+
+```typescript
+/** クロール設定 */
+interface CrawlConfig {
+  startUrl: string;
+  maxDepth: number;
+  outputDir: string;
+  sameDomain: boolean;
+  includePattern: RegExp | null;
+  excludePattern: RegExp | null;
+  delay: number;
+  timeout: number;
+  spaWait: number;
+  headed: boolean;
+  diff: boolean;
+  pages: boolean;
+  merge: boolean;
+  chunks: boolean;
+  keepSession: boolean;
+}
+
+/** ページメタデータ */
+interface PageMetadata {
+  title: string | null;
+  description: string | null;
+  keywords: string | null;
+  author: string | null;
+  ogTitle: string | null;
+  ogType: string | null;
+}
+
+/** クロール済みページ情報 */
+interface CrawledPage {
+  url: string;
+  title: string | null;
+  file: string;
+  depth: number;
+  links: string[];
+  metadata: PageMetadata;
+  hash: string;
+  crawledAt: string;
+}
+
+/** クロール結果 */
+interface CrawlResult {
+  crawledAt: string;
+  baseUrl: string;
+  config: Partial<CrawlConfig>;
+  totalPages: number;
+  pages: CrawledPage[];
+  specs: DetectedSpec[];
+}
+
+/** 検出されたAPI仕様 */
+interface DetectedSpec {
+  url: string;
+  type: string;
+  file: string;
+}
+```
+
+### 5.2 出力構造
+
+```
+.context/
+├── index.json       # メタデータ・ハッシュ
+├── full.md          # 結合ファイル（AIコンテキスト用）
+├── chunks/          # 見出しベース分割
+│   ├── chunk-001.md
+│   └── ...
+├── pages/           # ページ単位
+│   ├── page-001.md
+│   └── ...
+└── specs/           # API仕様
+    └── ...
+```
+
+### 5.3 full.md 形式
+
+ページを `# タイトル` で区切り、1ファイルに結合:
+
+```markdown
+# Getting Started
+
+導入部分の内容...
+
+# Installation
+
+インストール手順...
+
+# Configuration
+
+設定方法...
+```
+
+### 5.4 チャンク分割ロジック
+
+見出し（`#`, `##`, `###`）を境界として分割:
+
+```
+入力 (full.md):
+  # A
+  ## A-1
+  ## A-2
+  # B
+  ## B-1
+
+出力:
+  chunk-001.md: # A, ## A-1, ## A-2
+  chunk-002.md: # B, ## B-1
+```
+
+分割境界: `#`（h1）を新チャンクの開始とする。
+
+### 5.5 index.json スキーマ
+
+```json
+{
+  "crawledAt": "2026-02-01T14:00:00.000Z",
+  "baseUrl": "https://docs.example.com",
+  "config": {
+    "maxDepth": 2,
+    "sameDomain": true
+  },
+  "totalPages": 15,
+  "pages": [
+    {
+      "url": "https://docs.example.com/getting-started",
+      "title": "Getting Started",
+      "file": "pages/page-001.md",
+      "depth": 1,
+      "links": [
+        "https://docs.example.com/installation",
+        "https://docs.example.com/configuration"
+      ],
+      "metadata": {
+        "title": "Getting Started",
+        "description": "Quick start guide for beginners",
+        "keywords": "guide, tutorial, quickstart",
+        "author": null,
+        "ogTitle": "Getting Started - Example Docs",
+        "ogType": "article"
+      },
+      "hash": "a1b2c3d4e5f6...",
+      "crawledAt": "2026-02-01T14:00:01.000Z"
+    }
+  ],
+  "specs": [
+    {
+      "url": "https://docs.example.com/openapi.yaml",
+      "type": "openapi",
+      "file": "specs/openapi.yaml"
+    }
+  ]
+}
+```
+
+---
+
+## 6. PlaywrightFetcher
+
+### 6.1 設計方針
+
+- playwright-cliを使用（全サイト統一、SPA/静的の区別なし）
+- セッション管理でブラウザインスタンス再利用
+- ネットワーク安定まで待機
+
+### 6.2 実装イメージ
+
+```typescript
+class PlaywrightFetcher {
+  private sessionId: string;
+  private initialized = false;
+
+  constructor(private config: CrawlConfig) {
+    this.sessionId = `crawl-${Date.now()}`;
+  }
+
+  async fetch(url: string): Promise<FetchResult | null> {
+    if (!this.initialized) {
+      await this.ensurePlaywrightCli();
+      this.initialized = true;
+    }
+
+    const headedFlag = this.config.headed ? "--headed" : "";
+
+    // ページを開く
+    await $`playwright-cli open ${url} --session ${this.sessionId} ${headedFlag}`;
+
+    // レンダリング待機
+    await Bun.sleep(this.config.spaWait);
+
+    // コンテンツ取得
+    const html = await $`playwright-cli eval "document.documentElement.outerHTML" --session ${this.sessionId}`;
+
+    return { html: html.text(), finalUrl: url };
+  }
+
+  async close(): Promise<void> {
+    await $`playwright-cli close --session ${this.sessionId}`.quiet();
+  }
+
+  private async ensurePlaywrightCli(): Promise<void> {
+    try {
+      await $`which playwright-cli`.quiet();
+    } catch {
+      console.error("playwright-cli not found. Install: npm i -g @playwright/cli");
+      process.exit(3);
+    }
+  }
+}
+```
+
+---
+
+## 7. セッション管理
+
+### 7.1 概要
+
+`--keep-session`オプションを使用して、Playwrightのセッションデータ（`.playwright-cli`ディレクトリ）の保持/削除を制御できます。
+
+### 7.2 動作
+
+**通常時（`--keep-session`未指定または`false`）：**
+- クロール完了時に`.playwright-cli`ディレクトリを自動削除
+- 一時ファイルが残らず、クリーンな状態を維持
+- デフォルト動作
+
+**デバッグ時（`--keep-session`指定）：**
+- `.playwright-cli`ディレクトリを保持
+- Playwrightのセッション情報、一時ファイル、ブラウザ状態の確認が可能
+- トラブルシューティングやデバッグに有用
+
+### 7.3 使用例
+
+```bash
+# 通常実行（セッション自動削除）
+crawl https://docs.example.com
+
+# デバッグ実行（セッション保持）
+crawl https://docs.example.com --keep-session
+# → クロール後も .playwright-cli/ が残る
+```
+
+---
+
+## 8. 差分クロール
+
+### 8.1 ハッシュ計算
+
+```typescript
+import { createHash } from "crypto";
+
+function computeHash(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+```
+
+### 8.2 差分検知
+
+```typescript
+class Hasher {
+  private existingHashes: Map<string, string>;
+
+  constructor(indexPath: string) {
+    this.existingHashes = this.loadHashes(indexPath);
+  }
+
+  isChanged(url: string, content: string): boolean {
+    const newHash = computeHash(content);
+    const existingHash = this.existingHashes.get(url);
+    return existingHash !== newHash;
+  }
+
+  private loadHashes(path: string): Map<string, string> {
+    // index.json から url → hash のマップを構築
+  }
+}
+```
+
+---
+
+## 9. 出力処理
+
+### 9.1 Merger（全ページ結合）
+
+```typescript
+class Merger {
+  merge(pages: CrawledPage[]): string {
+    return pages
+      .map(page => `# ${page.title}\n\n${this.stripTitle(page.markdown)}`)
+      .join("\n\n");
+  }
+
+  private stripTitle(markdown: string): string {
+    // 先頭の # タイトル行を除去（重複防止）
+    return markdown.replace(/^#\s+.+\n+/, "");
+  }
+}
+```
+
+### 9.2 Chunker（見出しベース分割）
+
+```typescript
+class Chunker {
+  chunk(fullMarkdown: string): string[] {
+    const chunks: string[] = [];
+    const lines = fullMarkdown.split("\n");
+    let currentChunk: string[] = [];
+
+    for (const line of lines) {
+      if (line.startsWith("# ") && currentChunk.length > 0) {
+        // h1で新チャンク開始
+        chunks.push(currentChunk.join("\n"));
+        currentChunk = [];
+      }
+      currentChunk.push(line);
+    }
+
+    if (currentChunk.length > 0) {
+      chunks.push(currentChunk.join("\n"));
+    }
+
+    return chunks;
+  }
+}
+```
+
+---
+
+## 10. エラーハンドリング
+
+| エラー種別 | 検知方法 | 対応 |
+|-----------|---------|------|
+| playwright-cli未インストール | `which` 失敗 | exit 3、インストール手順表示 |
+| ネットワークエラー | fetch例外 | ログ出力、スキップ、続行 |
+| タイムアウト | playwright-cli タイムアウト | ログ出力、スキップ、続行 |
+| パースエラー | Readability失敗 | フォールバック抽出、警告ログ |
+| 書き込みエラー | FS例外 | エラー表示、exit 1 |
+
+---
+
+## 11. パフォーマンス
+
+| 観点 | 対策 |
+|------|------|
+| リクエスト負荷 | `--delay` でインターバル制御（デフォルト500ms） |
+| 不要なリクエスト | 差分クロールでハッシュ一致時スキップ |
+| ブラウザリソース | セッション再利用、処理完了後close |
+| メモリ | ページ処理後即座にDOM解放 |
+
+---
+
+## 12. スキル統合
+
+### 11.1 SKILL.md配置
+
+```
+link-crawler/
+└── SKILL.md    # piエージェント向けスキル定義
+```
+
+### 11.2 グローバル登録
+
+```bash
+ln -s /path/to/link-crawler ~/.pi/agent/skills/link-crawler
+```
+
+### 11.3 利用イメージ
+
+```
+pi> Next.jsのドキュメントをクロールして設計の参考にしたい
+
+→ link-crawlerスキルを読み込み
+→ bun run crawl.ts https://nextjs.org/docs -d 2
+→ full.md をコンテキストとして読み込み
+→ 設計相談に回答
+```
+
+---
+
+## 13. 今後の拡張ポイント
+
+| 機能 | 説明 | 優先度 |
+|------|------|--------|
+| sitemap.xml対応 | サイトマップからURL取得 | 中 |
+| 認証対応 | Cookie/Bearer/Basic | 中 |
+| robots.txt対応 | クロール可否判定 | 低 |
+| 並列クロール | 複数ページ同時取得 | 低 |
+| 設定ファイル | crawl.config.json | 低 |


### PR DESCRIPTION
## Summary
Closes #321

## Changes
- **外部ドキュメントをスキル内に配置**: `docs/link-crawler/{cli-spec,design}.md` を `link-crawler/docs/` にコピー
- **SKILL.mdの外部参照を解消**: 4箇所の外部参照 (`../docs/link-crawler/`) を内部参照 (`./docs/`) に変更
- **README.md**: 既に適切な内容が存在するため対応不要

これにより、link-crawlerスキルが単独で配布された際もドキュメントが利用可能になります。

## Testing
- ✅ 全テストがパス (375/375 tests)
- ✅ 外部参照が残っていないことを確認
- ✅ コピーしたドキュメントファイルの存在確認完了

## Review Checklist
- ✅ コード品質: 変更は最小限かつ焦点を絞ったもの
- ✅ テスト: 全てのテストがパス
- ✅ ドキュメント: 適切に更新済み
- ✅ セキュリティ: 問題なし