### PR TITLE
docs: 設計書(design.md)のfull.md出力形式の記述を更新

### DIFF
--- a/link-crawler/docs/design.md
+++ b/link-crawler/docs/design.md
@@ -295,18 +295,28 @@ interface DetectedSpec {
 
 ### 5.3 full.md 形式
 
-ページを `# タイトル` で区切り、1ファイルに結合:
+ページを `# タイトル` で区切り、Source URL付きで1ファイルに結合:
 
 ```markdown
 # Getting Started
 
+> Source: https://docs.example.com/getting-started
+
 導入部分の内容...
+
+---
 
 # Installation
 
+> Source: https://docs.example.com/installation
+
 インストール手順...
 
+---
+
 # Configuration
+
+> Source: https://docs.example.com/configuration
 
 設定方法...
 ```


### PR DESCRIPTION
## Summary
Closes #339

## Changes
- Section 5.3の説明に「Source URL付きで」を追加
- 各セクションに`> Source: <URL>`行を追加
- セクション間に`---`区切り線を追加
- 実装コード(merger.ts)と完全に一致するよう修正

## Details
現在のドキュメントは実装と一致していなかったため、`src/output/merger.ts`の実装に合わせて更新しました。

### Before
```markdown
# Getting Started

導入部分の内容...
```

### After
```markdown
# Getting Started

> Source: https://docs.example.com/getting-started

導入部分の内容...

---
```

## Testing
- [x] ドキュメントが実装コード(`merger.ts:writeFull`)と一致することを確認
- [x] Markdown構文が正しいことを確認
- [x] 他のセクションとの整合性を確認

## Verification
実装コード: `link-crawler/src/output/merger.ts`
テストコード: `link-crawler/tests/unit/merger.test.ts`