### PR TITLE
test: 無効な正規表現パターンに対するテストケース追加

### DIFF
--- a/link-crawler/src/config.ts
+++ b/link-crawler/src/config.ts
@@ -1,4 +1,5 @@
 import { DEFAULTS } from "./constants.js";
+import { ConfigError } from "./errors.js";
 import type { CrawlConfig } from "./types.js";
 import { generateSiteName } from "./utils/site-name.js";
 
@@ -7,13 +8,41 @@ export function parseConfig(options: Record<string, unknown>, startUrl: string):
 	const defaultOutputDir = `./.context/${generateSiteName(startUrl)}`;
 	const outputDir = String(options.output || defaultOutputDir);
 
+	// Validate and parse include pattern
+	let includePattern: RegExp | null = null;
+	if (options.include) {
+		try {
+			includePattern = new RegExp(String(options.include));
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new ConfigError(
+				`Invalid regular expression pattern for --include: ${message}`,
+				"include",
+			);
+		}
+	}
+
+	// Validate and parse exclude pattern
+	let excludePattern: RegExp | null = null;
+	if (options.exclude) {
+		try {
+			excludePattern = new RegExp(String(options.exclude));
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new ConfigError(
+				`Invalid regular expression pattern for --exclude: ${message}`,
+				"exclude",
+			);
+		}
+	}
+
 	return {
 		startUrl,
 		maxDepth: Math.min(Number(options.depth) || DEFAULTS.MAX_DEPTH, DEFAULTS.MAX_DEPTH_LIMIT),
 		outputDir,
 		sameDomain: options.sameDomain !== false,
-		includePattern: options.include ? new RegExp(String(options.include)) : null,
-		excludePattern: options.exclude ? new RegExp(String(options.exclude)) : null,
+		includePattern,
+		excludePattern,
 		delay: Number(options.delay) || DEFAULTS.DELAY_MS,
 		timeout: (Number(options.timeout) || DEFAULTS.TIMEOUT_SEC) * 1000,
 		spaWait: Number(options.wait) || DEFAULTS.SPA_WAIT_MS,

--- a/link-crawler/tests/unit/config.test.ts
+++ b/link-crawler/tests/unit/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { parseConfig } from "../../src/config.js";
+import { ConfigError } from "../../src/errors.js";
 
 describe("parseConfig", () => {
 	it("should parse config with default values", () => {
@@ -89,5 +90,35 @@ describe("parseConfig", () => {
 	it("should allow legacy ./.context directory to be specified explicitly", () => {
 		const config = parseConfig({ output: "./.context" }, "https://nextjs.org/docs");
 		expect(config.outputDir).toBe("./.context");
+	});
+});
+
+describe("parseConfig error handling", () => {
+	it("should throw ConfigError for invalid include pattern", () => {
+		expect(() => parseConfig({ include: "[invalid" }, "https://example.com")).toThrow(ConfigError);
+	});
+
+	it("should throw ConfigError for invalid exclude pattern", () => {
+		expect(() => parseConfig({ exclude: "(unclosed" }, "https://example.com")).toThrow(ConfigError);
+	});
+
+	it("should include pattern name in error message for include", () => {
+		try {
+			parseConfig({ include: "[" }, "https://example.com");
+			throw new Error("Expected ConfigError to be thrown");
+		} catch (e) {
+			expect(e).toBeInstanceOf(ConfigError);
+			expect((e as ConfigError).configKey).toBe("include");
+		}
+	});
+
+	it("should include pattern name in error message for exclude", () => {
+		try {
+			parseConfig({ exclude: "(" }, "https://example.com");
+			throw new Error("Expected ConfigError to be thrown");
+		} catch (e) {
+			expect(e).toBeInstanceOf(ConfigError);
+			expect((e as ConfigError).configKey).toBe("exclude");
+		}
 	});
 });


### PR DESCRIPTION
## Summary
Closes #340

無効な正規表現パターン（`--include` / `--exclude` オプション）に対するエラーハンドリングとテストケースを追加しました。

## Changes

### エラーハンドリングの実装 (`link-crawler/src/config.ts`)
- `ConfigError` をインポート
- `includePattern` および `excludePattern` の生成を try-catch でラップ
- 無効なパターンの場合、適切なエラーメッセージと `configKey` を含む `ConfigError` をスロー

### テストケースの追加 (`link-crawler/tests/unit/config.test.ts`)
- `ConfigError` をインポート
- 新しいテストスイート「parseConfig error handling」を追加
- 以下の4つのテストケースを実装：
  - 無効な `--include` パターンで `ConfigError` がスローされることを確認
  - 無効な `--exclude` パターンで `ConfigError` がスローされることを確認
  - `include` エラーに `configKey` が正しく設定されることを確認
  - `exclude` エラーに `configKey` が正しく設定されることを確認

## Testing

```bash
bun run test tests/unit/config.test.ts
# ✅ 12 tests passed

bun run test
# ✅ All 406 tests passed
```

## Code Quality

```bash
bun x biome check src/config.ts tests/unit/config.test.ts
# ✅ All checks passed
```

## Related Issues

- Issue #337: 正規表現バリデーションのエラーハンドリング改善（本PRで対応済み）

## Notes

Issue #340 は Issue #337 の修正後に実施することが求められていましたが、#337 が未マージであったため、本PRで両方の要件を実装しています。