### PR TITLE
test: crawler.test.ts の未使用変数を修正し、テストを改善する

### DIFF
--- a/link-crawler/tests/unit/crawler.test.ts
+++ b/link-crawler/tests/unit/crawler.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -378,10 +378,12 @@ info:
 			await crawler.run();
 
 			const pagesDir = join(testDir, "pages");
-			// Directory should exist but be empty or not contain page files
-			const _hasPageFiles =
-				existsSync(pagesDir) &&
-				(await readFile(join(testDir, "index.json"), "utf-8")).includes("page-001.md");
+			// pages: false の場合、ページディレクトリが存在しても page-*.md ファイルは作成されない
+			if (existsSync(pagesDir)) {
+				const files = await readdir(pagesDir);
+				const pageFiles = files.filter((f) => f.startsWith("page-") && f.endsWith(".md"));
+				expect(pageFiles).toHaveLength(0);
+			}
 
 			// Index should still be updated
 			const indexPath = join(testDir, "index.json");


### PR DESCRIPTION
## Summary
Closes #350

## Changes
- Remove unused `_hasPageFiles` variable in crawler.test.ts
- Add proper assertion to verify that page-*.md files are not created when `pages: false`
- Add `readdir` import for directory contents inspection
- Improve test coverage for the `pages` option behavior

## Testing
- ✅ All 409 tests pass (17 test files)
- ✅ Type checking passes
- ✅ Code quality checks pass
- ✅ Specific test case "should not save individual pages when pages is false" now properly validates the expected behavior

## Implementation Details
The unused variable was calculating whether page files existed but never actually asserting on it. The new implementation:
1. Checks if the pages directory exists
2. Lists all files in the directory
3. Filters for page-*.md files
4. Asserts that no such files exist when `pages: false`

This ensures the `pages: false` option is properly tested and behaves as expected.