### PR TITLE
docs: design.md のセクション番号を修正する

### DIFF
--- a/docs/link-crawler/design.md
+++ b/docs/link-crawler/design.md
@@ -571,20 +571,20 @@ class Chunker {
 
 ## 12. スキル統合
 
-### 11.1 SKILL.md配置
+### 12.1 SKILL.md配置
 
 ```
 link-crawler/
 └── SKILL.md    # piエージェント向けスキル定義
 ```
 
-### 11.2 グローバル登録
+### 12.2 グローバル登録
 
 ```bash
 ln -s /path/to/link-crawler ~/.pi/agent/skills/link-crawler
 ```
 
-### 11.3 利用イメージ
+### 12.3 利用イメージ
 
 ```
 pi> Next.jsのドキュメントをクロールして設計の参考にしたい


### PR DESCRIPTION
## Summary
Closes #348

## Changes
セクション12「スキル統合」のサブセクション番号を修正しました：
- 11.1 SKILL.md配置 → 12.1 SKILL.md配置
- 11.2 グローバル登録 → 12.2 グローバル登録
- 11.3 利用イメージ → 12.3 利用イメージ

## Testing
- セクション番号が親セクション（12）と整合していることを確認
- 誤った番号（11.1, 11.2, 11.3）が残っていないことを確認
- Markdown構文が正しいことを確認