### PR TITLE
docs: SKILL.mdのコマンド例パスを改善

### DIFF
--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -33,8 +33,10 @@ bun install
 
 ## 基本的な使い方
 
+スキルディレクトリ内で実行：
+
 ```bash
-bun run link-crawler/src/crawl.ts <url> [options]
+bun run src/crawl.ts <url> [options]
 ```
 
 ### オプション一覧


### PR DESCRIPTION
## Summary
Closes #356

## Changes
- SKILL.mdの「基本的な使い方」セクションのコマンド例を修正
- `bun run link-crawler/src/crawl.ts` → `bun run src/crawl.ts`
- スキルディレクトリ内での実行を前提とした表記に統一
- 「スキルディレクトリ内で実行：」という説明文を追加

## Details
このPRは、piスキルとして登録・使用する際の正しいパス表記にドキュメントを修正します。

### 変更前
```bash
bun run link-crawler/src/crawl.ts <url> [options]
```

### 変更後  
```bash
# スキルディレクトリ内で実行：
bun run src/crawl.ts <url> [options]
```

この変更により、「基本的な使い方」と「piエージェントでの使用例」の両方のセクションで一貫したパス表記が使用されるようになります。

## Testing
- ドキュメントの整合性を確認
- 両セクションで同じパス表記を使用