### PR TITLE
docs: design.mdのセクション番号の誤りを修正

### DIFF
--- a/link-crawler/docs/design.md
+++ b/link-crawler/docs/design.md
@@ -669,20 +669,20 @@ class Chunker {
 
 ## 12. スキル統合
 
-### 11.1 SKILL.md配置
+### 12.1 SKILL.md配置
 
 ```
 link-crawler/
 └── SKILL.md    # piエージェント向けスキル定義
 ```
 
-### 11.2 グローバル登録
+### 12.2 グローバル登録
 
 ```bash
 ln -s /path/to/link-crawler ~/.pi/agent/skills/link-crawler
 ```
 
-### 11.3 利用イメージ
+### 12.3 利用イメージ
 
 ```
 pi> Next.jsのドキュメントをクロールして設計の参考にしたい


### PR DESCRIPTION
## Summary
Closes #354

## Changes
- link-crawler/docs/design.mdのセクション「12. スキル統合」のサブセクション番号を修正
  - 11.1 → 12.1 (SKILL.md配置)
  - 11.2 → 12.2 (グローバル登録)
  - 11.3 → 12.3 (利用イメージ)

## Testing
- セクション番号が1から13まで連番になっていることを確認
- サブセクション番号が正しく12.x系列になっていることを確認