### PR TITLE
chore: .gitignore に開発アーティファクトを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,17 +4,18 @@
 !.pi/skills/delete-environment/
 !.pi/skills/delete-environment/**
 
-# pi-issue-runner
-.worktrees/
+# Development artifacts
 .improve-logs/
+.worktrees/
+test-output-*/
+.playwright-cli/
+
+# pi-issue-runner
 .pi-runner.yaml.local
 .pi-prompt.md
 *.swp
 docs/plans/*.md
 !docs/plans/README.md
-
-# Playwright cli
-.playwright-cli/
 .context/
 
 # Dependencies


### PR DESCRIPTION
## Summary
Closes #368

## Changes
- 新しい "Development artifacts" セクションを作成
- , ,  を統合
- 不足していた  パターンを追加
- 開発中に生成される一時ファイルの誤コミットを防止

## Testing
✅ 全てのパターンが  でテスト済み
✅ , , ,  が正しく無視される

## Details
- 既存の3つのパターンを "Development artifacts" セクションに統合
- 新たに  パターンを追加
- セクション構成を整理し、可読性を向上