### PR TITLE
docs: README.mdに英語セクションとContributingセクションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,68 @@
 # dict-skills
 
+> A pi skill for crawling technical documentation sites and saving content as AI-friendly Markdown
+
+[日本語版 (Japanese)](#日本語)
+
+## English
+
+### Overview
+
+This pi skill recursively crawls web pages starting from a specified URL and saves the collected content as structured Markdown optimized for AI context.
+
+**Key Features:**
+- Recursive link exploration with depth control
+- Same-domain crawling support
+- Structured output (pages/chunks/full.md)
+- Differential crawling for efficient updates
+- Merged Markdown output for AI context
+
+### Quick Start
+
+**Prerequisites:**
+- [Bun](https://bun.sh/) 1.0+
+- [playwright-cli](https://www.npmjs.com/package/@playwright/cli): `npm install -g @playwright/cli`
+
+**Installation:**
+```bash
+# Clone the repository
+git clone https://github.com/takemo101/dict-skills.git
+cd dict-skills
+
+# Install dependencies
+cd link-crawler
+bun install
+```
+
+**Basic Usage:**
+```bash
+# Crawl a URL with depth 2 (outputs to .context/<site-name>/)
+bun run link-crawler/src/crawl.ts https://nextjs.org/docs -d 2
+# → outputs to .context/nextjs-docs/
+```
+
+### Documentation
+
+| Document | Target Audience | Content |
+|----------|----------------|---------|
+| [SKILL.md](link-crawler/SKILL.md) | **pi users** | Concise usage as a pi skill |
+| [CLI Specification](docs/link-crawler/cli-spec.md) | **CLI users** | Complete option list, examples, output format specifications |
+| [Design Document](docs/link-crawler/design.md) | **Developers** | Architecture, data structures, technical specifications |
+
+### Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+For bug reports and feature requests, please check our [Issues](https://github.com/takemo101/dict-skills/issues).
+
+### License
+
+MIT
+
+---
+
+## 日本語
+
 技術ドキュメントサイトをクロールし、AIコンテキスト用のMarkdownとして保存する pi スキル
 
 ## 概要
@@ -59,6 +122,12 @@ bun run link-crawler/src/crawl.ts https://nextjs.org/docs -d 2
 | 終了コード・環境変数 | [CLI仕様書](docs/link-crawler/cli-spec.md#6-終了コード) |
 | piスキルとしての使い方 | [SKILL.md](link-crawler/SKILL.md) |
 | アーキテクチャ・設計 | [設計書](docs/link-crawler/design.md) |
+
+## コントリビューション
+
+プルリクエストを歓迎します！お気軽にご提案ください。
+
+バグ報告や機能リクエストは [Issues](https://github.com/takemo101/dict-skills/issues) をご確認ください。
 
 ## ライセンス
 


### PR DESCRIPTION
## Summary
Closes #371

## Changes
- Added English section at the top of README.md for internationalization
- Added Contributing section in both English and Japanese
- Improved document structure with clear language separation
- Maintained existing comprehensive Japanese documentation

## Verification
```bash
✅ README.md exists
✅ English project overview added
✅ Installation instructions present
✅ Basic usage examples included
✅ License information included
✅ Contributing guidelines added
```

## Issue Requirements Met
All P1 requirements from Issue #371 have been satisfied:
- [x] README.md exists
- [x] Project name and overview in English
- [x] Installation instructions
- [x] Basic usage examples
- [x] License information
- [x] Contributing guidelines (optional, but added)

The existing README.md was already comprehensive in Japanese. This PR adds English content to improve accessibility for international contributors.