### PR TITLE
refactor: --diffオプションの説明文を修正

### DIFF
--- a/link-crawler/src/crawl.ts
+++ b/link-crawler/src/crawl.ts
@@ -28,7 +28,7 @@ program
 	.option("--timeout <sec>", "Request timeout in seconds", "30")
 	.option("--wait <ms>", "Wait time for page rendering in ms", "2000")
 	.option("--headed", "Show browser window", false)
-	.option("--diff", "Show diff from previous crawl", false)
+	.option("--diff", "Incremental crawl (update only changed pages)", false)
 	.option("--no-pages", "Skip individual page output")
 	.option("--no-merge", "Skip merged output file")
 	.option("--chunks", "Enable chunked output files", false)


### PR DESCRIPTION
## Summary
Closes #373

## Changes
- `--diff`オプションのヘルプ説明文を修正
  - **Before**: "Show diff from previous crawl"
  - **After**: "Incremental crawl (update only changed pages)"
- ドキュメント（SKILL.md, cli-spec.md）の記載と整合性を取る

## Testing
- ✅ `bun run lint` passed
- ✅ `bun run typecheck` passed
- ✅ `bun run test` passed (421 tests)
- ✅ Manual verification: `bun run dev --help` displays correct help text

## Impact
- ヘルプテキストのみの変更
- 機能に影響なし
- ドキュメントとの整合性を改善