### PR TITLE
docs: 設計書の型定義を実装に合わせて更新

### DIFF
--- a/docs/link-crawler/design.md
+++ b/docs/link-crawler/design.md
@@ -411,7 +411,7 @@ class PlaywrightFetcher {
     // コンテンツ取得
     const html = await $`playwright-cli eval "document.documentElement.outerHTML" --session ${this.sessionId}`;
 
-    return { html: html.text(), finalUrl: url };
+    return { html: html.text(), finalUrl: url, contentType: "text/html" };
   }
 
   async close(): Promise<void> {
@@ -510,9 +510,36 @@ class Merger {
       .join("\n\n");
   }
 
-  private stripTitle(markdown: string): string {
-    // 先頭の # タイトル行を除去（重複防止）
-    return markdown.replace(/^#\s+.+\n+/, "");
+  /**
+   * Markdownから先頭のH1タイトルを除去
+   * frontmatterがある場合は考慮する
+   * 
+   * Note: publicメソッドとして実装（テストで使用されている）
+   * 
+   * @param markdown Markdown文字列
+   * @returns タイトル除去後のMarkdown
+   */
+  stripTitle(markdown: string): string {
+    // frontmatterをスキップ
+    let content = markdown;
+    if (content.startsWith("---")) {
+      const endIndex = content.indexOf("---", 3);
+      if (endIndex !== -1) {
+        content = content.slice(endIndex + 3).trimStart();
+      }
+    }
+
+    // 先頭のH1を除去
+    const lines = content.split("\n");
+    if (lines.length > 0 && lines[0].startsWith("# ")) {
+      lines.shift();
+      // タイトル後の空行も除去
+      while (lines.length > 0 && lines[0].trim() === "") {
+        lines.shift();
+      }
+    }
+
+    return lines.join("\n");
   }
 }
 ```

--- a/link-crawler/docs/design.md
+++ b/link-crawler/docs/design.md
@@ -608,9 +608,36 @@ class Merger {
       .join("\n\n");
   }
 
-  private stripTitle(markdown: string): string {
-    // 先頭の # タイトル行を除去（重複防止）
-    return markdown.replace(/^#\s+.+\n+/, "");
+  /**
+   * Markdownから先頭のH1タイトルを除去
+   * frontmatterがある場合は考慮する
+   * 
+   * Note: publicメソッドとして実装（テストで使用されている）
+   * 
+   * @param markdown Markdown文字列
+   * @returns タイトル除去後のMarkdown
+   */
+  stripTitle(markdown: string): string {
+    // frontmatterをスキップ
+    let content = markdown;
+    if (content.startsWith("---")) {
+      const endIndex = content.indexOf("---", 3);
+      if (endIndex !== -1) {
+        content = content.slice(endIndex + 3).trimStart();
+      }
+    }
+
+    // 先頭のH1を除去
+    const lines = content.split("\n");
+    if (lines.length > 0 && lines[0].startsWith("# ")) {
+      lines.shift();
+      // タイトル後の空行も除去
+      while (lines.length > 0 && lines[0].trim() === "") {
+        lines.shift();
+      }
+    }
+
+    return lines.join("\n");
   }
 }
 ```


### PR DESCRIPTION
## Summary
Closes #375

## Changes
- **FetchResult型の更新**: `contentType: string`プロパティを追加
- **Merger.stripTitleのアクセス修飾子**: `private`から`public`（修飾子なし）に変更
- **stripTitleの実装詳細の更新**: frontmatter対応や複数空行除去など、実際の実装に合わせた詳細なロジックに更新

## Files Changed
- `docs/link-crawler/design.md`
- `link-crawler/docs/design.md`

## Testing
- ドキュメント更新のため自動テストは不要
- 既存のMergerテストがパスすることを確認済み
- 設計書の型定義と実際の実装が一致していることを確認

## Verification
```bash
# FetchResult型の確認
grep -A 3 "contentType" docs/link-crawler/design.md
grep -A 3 "contentType" link-crawler/src/types.ts

# Merger.stripTitleの確認
grep "stripTitle(markdown: string)" docs/link-crawler/design.md
grep "stripTitle(markdown: string)" link-crawler/src/output/merger.ts
```