### PR TITLE
fix: PostProcessor - ページコンテンツ読み込みテストの失敗

### DIFF
--- a/link-crawler/tests/unit/post-processor.test.ts
+++ b/link-crawler/tests/unit/post-processor.test.ts
@@ -269,7 +269,9 @@ describe("PostProcessor", () => {
 			const pages = [createPage("https://example.com/page1", "Page 1", "pages/nonexistent.md")];
 
 			// Should not throw even though file doesn't exist
-			await expect(processor.process(pages)).resolves.not.toThrow();
+			await processor.process(pages);
+			// If we get here without throwing, the test passes
+			expect(mockLogger.logPostProcessingStart).toHaveBeenCalled();
 		});
 
 		it("should handle when full.md read fails but chunker can still run with pages content", async () => {


### PR DESCRIPTION
## Summary
Closes #395

## Changes
- Fixed the failing test `should handle missing files gracefully` in `post-processor.test.ts`
- Replaced `.resolves.not.toThrow()` with direct await pattern due to Bun vitest compatibility issue
- The PostProcessor implementation itself is working correctly

## Root Cause
The test was failing due to a bug in Bun's vitest compatibility with `.resolves.not.toThrow()`. The PostProcessor implementation correctly handles missing files through try-catch in `loadPageContentsFromDisk()`.

## Testing
- ✅ All 20 tests in `post-processor.test.ts` pass
- ✅ The test now properly verifies that processing pages with nonexistent files doesn't throw
- ✅ Added assertion to confirm the processing actually executed

## Technical Details
**Before**: `await expect(processor.process(pages)).resolves.not.toThrow();`  
**After**: `await processor.process(pages);` + assertion that processing started

This approach:
1. Directly awaits the promise, letting any exceptions bubble up
2. Verifies execution by checking that `logPostProcessingStart` was called
3. Works correctly with Bun's test runner