### PR TITLE
refactor: Biome lint/format エラーの修正

### DIFF
--- a/link-crawler/src/crawler/fetcher.ts
+++ b/link-crawler/src/crawler/fetcher.ts
@@ -32,8 +32,6 @@ export interface PlaywrightPathConfig {
  *    - close: session-stop コマンドに変更
  */
 export class PlaywrightFetcher implements Fetcher {
-	// sessionIdは現在未使用だが、将来の並列実行対応のため保持
-	private sessionId: string;
 	private initialized = false;
 	private nodePath: string = "node";
 	private playwrightPath: string = "playwright-cli";
@@ -45,8 +43,6 @@ export class PlaywrightFetcher implements Fetcher {
 		runtime?: RuntimeAdapter,
 		pathConfig?: PlaywrightPathConfig,
 	) {
-		// 短いsessionId（Unixソケットパス長制限対策、現在は未使用）
-		this.sessionId = `c${Date.now().toString(36)}`;
 		this.runtime = runtime ?? createRuntimeAdapter();
 		this.pathConfig = pathConfig ?? {
 			nodePaths: PATHS.NODE_PATHS,
@@ -123,10 +119,7 @@ export class PlaywrightFetcher implements Fetcher {
 		await this.runtime.sleep(this.config.spaWait);
 
 		// コンテンツ取得
-		const result = await this.runCli([
-			"eval",
-			"document.documentElement.outerHTML",
-		]);
+		const result = await this.runCli(["eval", "document.documentElement.outerHTML"]);
 		if (!result.success) {
 			throw new FetchError(`Failed to get content: ${result.stderr}`, url);
 		}


### PR DESCRIPTION
## Summary
Closes #404

Biome lint/format エラーを修正し、コード品質を向上させました。

## Changes
- **未使用のprivate class member削除**: `PlaywrightFetcher.sessionId` プロパティとその初期化コードを削除
  - playwright-cli 0.0.63+の仕様変更により、デフォルトセッションを使用するため不要になったプロパティ
  - YAGNI原則に従い、現在使用されていないコードを削除
- **フォーマット修正**: 配列リテラルを1行に修正してBiomeの期待に合わせた

## Testing
- ✅ `bunx biome check src/crawler/fetcher.ts` - エラー0件
- ✅ `bun run typecheck` - 型エラーなし
- ✅ 機能変更なし（コード品質改善のみ）

## Impact
- 影響範囲: `link-crawler/src/crawler/fetcher.ts` のみ
- 破壊的変更: なし
- 機能変更: なし（コード品質改善のみ）