### PR TITLE
fix: Update test expectations for playwright-cli session-stop command

### DIFF
--- a/link-crawler/tests/unit/fetcher.test.ts
+++ b/link-crawler/tests/unit/fetcher.test.ts
@@ -479,9 +479,7 @@ describe("PlaywrightFetcher", () => {
 
 			expect(mockRuntime.spawn).toHaveBeenCalledWith(expect.any(String), [
 				"playwright-cli",
-				"close",
-				"--session",
-				expect.any(String),
+				"session-stop",
 			]);
 		});
 

--- a/link-crawler/tests/unit/index-manager.test.ts
+++ b/link-crawler/tests/unit/index-manager.test.ts
@@ -1,5 +1,5 @@
-import { existsSync } from "node:fs";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync, writeFileSync } from "node:fs";
+import { mkdir, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CrawlLogger } from "../../src/crawler/logger.js";
@@ -52,7 +52,7 @@ describe("IndexManager", () => {
 				],
 				specs: [],
 			};
-			await writeFile(join(testDir, "index.json"), JSON.stringify(indexData));
+			writeFileSync(join(testDir, "index.json"), JSON.stringify(indexData));
 
 			const manager = new IndexManager(testDir, "https://example.com", {
 				maxDepth: 2,
@@ -79,7 +79,7 @@ describe("IndexManager", () => {
 			const mockLogger = {
 				logIndexLoadError: vi.fn(),
 			} as unknown as CrawlLogger;
-			await writeFile(join(testDir, "index.json"), "{ invalid json }");
+			writeFileSync(join(testDir, "index.json"), "{ invalid json }");
 
 			const manager = new IndexManager(
 				testDir,
@@ -105,7 +105,7 @@ describe("IndexManager", () => {
 				pages: [],
 				specs: [],
 			};
-			await writeFile(join(testDir, "index.json"), JSON.stringify(indexData));
+			writeFileSync(join(testDir, "index.json"), JSON.stringify(indexData));
 
 			const manager = new IndexManager(testDir, "https://example.com", {
 				maxDepth: 2,
@@ -127,7 +127,7 @@ describe("IndexManager", () => {
 				pages: "not an array",
 				specs: [],
 			};
-			await writeFile(join(testDir, "index.json"), JSON.stringify(indexData));
+			writeFileSync(join(testDir, "index.json"), JSON.stringify(indexData));
 
 			const manager = new IndexManager(
 				testDir,
@@ -156,7 +156,7 @@ describe("IndexManager", () => {
 				totalPages: 0,
 				specs: [],
 			};
-			await writeFile(join(testDir, "index.json"), JSON.stringify(indexData));
+			writeFileSync(join(testDir, "index.json"), JSON.stringify(indexData));
 
 			const manager = new IndexManager(
 				testDir,
@@ -178,7 +178,7 @@ describe("IndexManager", () => {
 			const mockLogger = {
 				logIndexFormatError: vi.fn(),
 			} as unknown as CrawlLogger;
-			await writeFile(join(testDir, "index.json"), "null");
+			writeFileSync(join(testDir, "index.json"), "null");
 
 			const manager = new IndexManager(
 				testDir,
@@ -200,7 +200,7 @@ describe("IndexManager", () => {
 			const mockLogger = {
 				logIndexFormatError: vi.fn(),
 			} as unknown as CrawlLogger;
-			await writeFile(join(testDir, "index.json"), "123");
+			writeFileSync(join(testDir, "index.json"), "123");
 
 			const manager = new IndexManager(
 				testDir,
@@ -264,7 +264,7 @@ describe("IndexManager", () => {
 				],
 				specs: [],
 			};
-			await writeFile(join(testDir, "index.json"), JSON.stringify(indexData));
+			writeFileSync(join(testDir, "index.json"), JSON.stringify(indexData));
 
 			const manager = new IndexManager(testDir, "https://example.com", {
 				maxDepth: 2,
@@ -302,7 +302,7 @@ describe("IndexManager", () => {
 				],
 				specs: [],
 			};
-			await writeFile(join(testDir, "index.json"), JSON.stringify(indexData));
+			writeFileSync(join(testDir, "index.json"), JSON.stringify(indexData));
 
 			const manager = new IndexManager(testDir, "https://example.com", {
 				maxDepth: 2,
@@ -358,7 +358,7 @@ describe("IndexManager", () => {
 				],
 				specs: [],
 			};
-			await writeFile(join(testDir, "index.json"), JSON.stringify(indexData));
+			writeFileSync(join(testDir, "index.json"), JSON.stringify(indexData));
 
 			const manager = new IndexManager(testDir, "https://example.com", {
 				maxDepth: 2,
@@ -416,7 +416,7 @@ describe("IndexManager", () => {
 				],
 				specs: [],
 			};
-			await writeFile(join(testDir, "index.json"), JSON.stringify(indexData));
+			writeFileSync(join(testDir, "index.json"), JSON.stringify(indexData));
 
 			const manager = new IndexManager(testDir, "https://example.com", {
 				maxDepth: 2,
@@ -456,7 +456,7 @@ describe("IndexManager", () => {
 				],
 				specs: [],
 			};
-			await writeFile(join(testDir, "index.json"), JSON.stringify(indexData));
+			writeFileSync(join(testDir, "index.json"), JSON.stringify(indexData));
 
 			const manager = new IndexManager(testDir, "https://example.com", {
 				maxDepth: 2,


### PR DESCRIPTION
## Summary
Closes #403

## Changes
- **fetcher.test.ts**: Updated test assertion to expect `session-stop` command instead of deprecated `close --session` format
- **index-manager.test.ts**: Fixed async/sync mismatch by replacing `await writeFile()` with `writeFileSync()` (12 occurrences)
- **Dependencies**: Ran `bun install` to ensure `turndown-plugin-gfm` is available

## Test Results

### Individual Test Files ✅
- `fetcher.test.ts`: 52 passing, 0 failing
- `index-manager.test.ts`: 27 passing, 0 failing  
- `crawler.test.ts` (integration): 13 passing, 0 failing

### Full Test Suite ⚠️
- **Before**: 403 passing, 18 failing
- **After**: 404 passing, 17 failing

## Known Issue
The remaining 17 test failures occur only when running the full test suite together, not when tests are run individually. This appears to be a vitest test isolation/configuration issue that requires further investigation beyond this PR's scope.

## Root Cause Analysis
1. **PlaywrightFetcher test**: Implementation changed to use `session-stop` but test wasn't updated
2. **IndexManager tests**: Tests used async `writeFile()` but IndexManager reads files synchronously with `readFileSync()`, causing a race condition

## Verification
```bash
cd link-crawler
bun test tests/unit/fetcher.test.ts       # 52 pass
bun test tests/unit/index-manager.test.ts # 27 pass
bun test tests/integration/crawler.test.ts # 13 pass
```