### PR TITLE
fix: テスト並列実行時の分離問題（17件のテスト失敗）

### DIFF
--- a/link-crawler/vitest.config.ts
+++ b/link-crawler/vitest.config.ts
@@ -4,6 +4,15 @@ export default defineConfig({
 	test: {
 		globals: true,
 		include: ["tests/**/*.test.ts"],
+		// ファイル間の並列実行を無効化してテスト分離問題を解消
+		fileParallelism: false,
+		// 同時実行数を1に制限してテスト分離を確保
+		pool: "threads",
+		poolOptions: {
+			threads: {
+				singleThread: true,
+			},
+		},
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "html", "json-summary"],


### PR DESCRIPTION
## Summary
Closes #408

## Changes
- `vitest.config.ts` に `fileParallelism: false` と `singleThread: true` を追加
- テストファイル間の並列実行を無効化してファイルシステム競合を解消
- IndexManager および Integration テストの 17 件の失敗を修正

## Root Cause
- Vitest のデフォルト並列実行により、複数のテストファイルが同時に同じディレクトリを操作
- `beforeEach` でのディレクトリクリーンアップが他のテストに影響

## Solution
```typescript
{
  test: {
    fileParallelism: false,  // テストファイル間の並列実行を無効化
    pool: "threads",
    poolOptions: {
      threads: {
        singleThread: true,  // 完全な分離を保証
      },
    },
  }
}
```

## Testing
✅ All 421 tests pass with `bun run test`
✅ Type check passes with `bun run typecheck`

## Important Note
**Test command must be `bun run test`** (not `bun test`)
- `bun test`: Uses Bun's native test runner (ignores Vitest config) ✗
- `bun run test`: Uses Vitest with proper config ✓

## Acceptance Criteria
- [x] All 421 tests pass
- [x] Individual and full test runs produce same results
- [x] Type check passes