### PR TITLE
docs: design.md のバージョン情報とモジュール構成の不整合

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -35,8 +35,8 @@
 | Test Framework | Vitest | 4.x | 高速、ESM対応、Bun互換 |
 | CLI Parser | Commander | 13.x | 軽量、標準的 |
 | Browser | playwright-cli | latest | SPA完全対応、セッション管理 |
-| DOM Parser | JSDOM | 26.x | Node.js標準的なDOM実装 |
-| Content Extractor | @mozilla/readability | 0.5.x | Firefox由来、高品質 |
+| DOM Parser | JSDOM | 28.x | Node.js標準的なDOM実装 |
+| Content Extractor | @mozilla/readability | 0.6.x | Firefox由来、高品質 |
 | Markdown Converter | Turndown | 7.x | GFM対応、カスタマイズ可能 |
 
 ---
@@ -108,7 +108,8 @@ link-crawler/
 │   │   └── turndown-plugin-gfm.d.ts  # Turndown型定義
 │   │
 │   └── utils/
-│       └── runtime.ts          # ランタイムアダプター
+│       ├── runtime.ts          # ランタイムアダプター
+│       └── site-name.ts        # サイト名生成
 │
 ├── package.json
 ├── tsconfig.json

--- a/docs/development.md
+++ b/docs/development.md
@@ -70,18 +70,17 @@ link-crawler/
 │   │   ├── converter.test.ts
 │   │   ├── crawler.test.ts
 │   │   ├── errors.test.ts
+│   │   ├── extractor.test.ts
 │   │   ├── fetcher.test.ts
 │   │   ├── hasher.test.ts
 │   │   ├── index-manager.test.ts
+│   │   ├── links.test.ts
 │   │   ├── logger.test.ts
 │   │   ├── merger.test.ts
 │   │   ├── post-processor.test.ts
 │   │   ├── runtime.test.ts
 │   │   ├── site-name.test.ts
-│   │   ├── writer.test.ts
-│   │   └── parser/
-│   │       ├── extractor.test.ts
-│   │       └── links.test.ts
+│   │   └── writer.test.ts
 │   └── integration/             # 統合テスト
 │       └── crawler.test.ts
 │


### PR DESCRIPTION
## Summary
Closes #420

## Changes
- **バージョン情報の修正 (design.md)**:
  - JSDOM: 26.x → 28.x (package.json と一致)
  - @mozilla/readability: 0.5.x → 0.6.x (package.json と一致)
- **モジュール構成の追加 (design.md)**:
  - utils/ に site-name.ts を追加
- **テストディレクトリ構成の修正 (development.md)**:
  - tests/unit/ をフラット構造に修正 (parser/ サブディレクトリを削除)

## Verification
```bash
# バージョン確認
grep -E 'jsdom|readability' link-crawler/package.json
# jsdom: ^28.0.0
# @mozilla/readability: ^0.6.0

# ファイル構成確認
ls link-crawler/src/utils/
# runtime.ts site-name.ts

ls link-crawler/tests/unit/
# extractor.test.ts links.test.ts (フラット構造)
```