### PR TITLE
fix: link-crawler/SKILL.md と README.md のドキュメントリンク切れ

### DIFF
--- a/link-crawler/README.md
+++ b/link-crawler/README.md
@@ -77,7 +77,7 @@ bun run src/crawl.ts https://nextjs.org/docs \
 | `--exclude <pattern>` | 除外するURLパターン（正規表現） | - |
 | `--delay <ms>` | リクエスト間隔 | `500` |
 
-**完全なオプション一覧は [CLI仕様書](./docs/cli-spec.md) を参照してください。**
+**完全なオプション一覧は [CLI仕様書](../docs/cli-spec.md) を参照してください。**
 
 ## 出力ファイル
 
@@ -95,8 +95,8 @@ bun run src/crawl.ts https://nextjs.org/docs \
 | ドキュメント | 対象読者 | 内容 |
 |-------------|---------|------|
 | [SKILL.md](./SKILL.md) | **piユーザー** | piスキルとしての使い方・オプション一覧 |
-| [CLI仕様書](./docs/cli-spec.md) | **CLIユーザー** | 完全なオプション一覧・詳細な使用例・出力形式 |
-| [設計書](./docs/design.md) | **開発者** | アーキテクチャ・データ構造・技術仕様 |
+| [CLI仕様書](../docs/cli-spec.md) | **CLIユーザー** | 完全なオプション一覧・詳細な使用例・出力形式 |
+| [設計書](../docs/design.md) | **開発者** | アーキテクチャ・データ構造・技術仕様 |
 
 ## 開発
 

--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -52,7 +52,7 @@ bun run src/crawl.ts <url> [options]
 - `--include <pattern>`: 含めるURLパターン（正規表現）
 - `--exclude <pattern>`: 除外するURLパターン（正規表現）
 
-**完全なオプション一覧は [CLI仕様書](./docs/cli-spec.md) を参照してください。**
+**完全なオプション一覧は [CLI仕様書](../docs/cli-spec.md) を参照してください。**
 
 ## piエージェントでの使用例
 
@@ -74,11 +74,11 @@ bun run src/crawl.ts https://nextjs.org/docs -d 2
 | `pages/*.md` | ページ単位 |
 | `index.json` | メタデータ・ハッシュ |
 
-**詳細な仕様は [CLI仕様書](./docs/cli-spec.md) を参照してください。**
+**詳細な仕様は [CLI仕様書](../docs/cli-spec.md) を参照してください。**
 
 ## 参考リンク
 
 | ドキュメント | 内容 |
 |-------------|------|
-| [CLI仕様書](./docs/cli-spec.md) | 完全なオプション一覧・使用例・出力形式の詳細 |
-| [設計書](./docs/design.md) | アーキテクチャ・データ構造・技術仕様 |
+| [CLI仕様書](../docs/cli-spec.md) | 完全なオプション一覧・使用例・出力形式の詳細 |
+| [設計書](../docs/design.md) | アーキテクチャ・データ構造・技術仕様 |


### PR DESCRIPTION
## Summary
Closes #417

## Changes
- link-crawler/SKILL.md の4箇所のリンクを `./docs/` から `../docs/` に修正
- link-crawler/README.md の3箇所のリンクを `./docs/` から `../docs/` に修正
- 全てのリンクが有効であることを検証済み

## Testing
- リンク検証スクリプトで全リンクの存在確認を実施
  - ✅ OK: ../docs/cli-spec.md
  - ✅ OK: ../docs/design.md
- GitHub上でのリンク動作確認はPRマージ後に実施予定

## Review
- ドキュメント修正のみ、コードへの影響なし
- 変更範囲は link-crawler/ ディレクトリ配下のみ
- 既存のドキュメントスタイルに従った修正