### PR TITLE
docs: design.mdのライブラリバージョンを更新

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -35,8 +35,8 @@
 | Test Framework | Vitest | 4.x | 高速、ESM対応、Bun互換 |
 | CLI Parser | Commander | 13.x | 軽量、標準的 |
 | Browser | playwright-cli | latest | SPA完全対応、セッション管理 |
-| DOM Parser | JSDOM | 26.x | Node.js標準的なDOM実装 |
-| Content Extractor | @mozilla/readability | 0.5.x | Firefox由来、高品質 |
+| DOM Parser | JSDOM | 28.x | Node.js標準的なDOM実装 |
+| Content Extractor | @mozilla/readability | 0.6.x | Firefox由来、高品質 |
 | Markdown Converter | Turndown | 7.x | GFM対応、カスタマイズ可能 |
 
 ---


### PR DESCRIPTION
## Summary
Closes #429

## Changes
- JSDOM: 26.x → 28.x
- @mozilla/readability: 0.5.x → 0.6.x

`docs/design.md` の技術スタックテーブルに記載されている依存ライブラリのバージョンを、`link-crawler/package.json` の実際のバージョンと一致させました。

## Testing
- ✅ 全テスト421件がパス
- ✅ バージョン記載がpackage.jsonと一致することを確認