### PR TITLE
docs: design.md の Merger.merge() 実装がソースと不一致

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -296,7 +296,8 @@ interface DetectedSpec {
 
 ### 5.3 full.md 形式
 
-ページを `# タイトル` で区切り、Source URL付きで1ファイルに結合:
+ページを `# タイトル` で区切り、Source URL付きで1ファイルに結合。
+セクション間は `\n\n---\n\n` で結合される:
 
 ```markdown
 # Getting Started
@@ -321,6 +322,8 @@ interface DetectedSpec {
 
 設定方法...
 ```
+
+**Note**: セパレータ `---` の前後には空行（`\n\n`）が入る。
 
 ### 5.4 チャンク分割ロジック
 
@@ -601,21 +604,32 @@ function computeHash(content: string): string {
 ### 8.2 差分検知
 
 ```typescript
+/**
+ * ハッシュ管理クラス
+ * 差分検知を行う
+ * 
+ * Note: ファイルI/Oは IndexManager が担当し、
+ * Hasher は純粋なロジッククラスとして実装
+ */
 class Hasher {
-  private existingHashes: Map<string, string>;
+  private hashes: Map<string, string>;
 
-  constructor(indexPath: string) {
-    this.existingHashes = this.loadHashes(indexPath);
+  constructor(existingHashes: Map<string, string> = new Map()) {
+    this.hashes = new Map(existingHashes);
   }
 
-  isChanged(url: string, content: string): boolean {
-    const newHash = computeHash(content);
-    const existingHash = this.existingHashes.get(url);
+  /**
+   * URLのコンテンツが変更されたかを判定
+   * @param url 対象URL
+   * @param newHash 新しいハッシュ値
+   * @returns 変更があればtrue、なければfalse
+   */
+  isChanged(url: string, newHash: string): boolean {
+    const existingHash = this.hashes.get(url);
+    if (existingHash === undefined) {
+      return true; // 新規ページは変更扱い
+    }
     return existingHash !== newHash;
-  }
-
-  private loadHashes(path: string): Map<string, string> {
-    // index.json から url → hash のマップを構築
   }
 }
 ```
@@ -627,11 +641,54 @@ class Hasher {
 ### 9.1 Merger（全ページ結合）
 
 ```typescript
+/**
+ * ページ結合クラス
+ * 全ページを結合してfull.mdを生成
+ */
 class Merger {
+  constructor(private outputDir: string) {}
+
+  /**
+   * ページを結合してMarkdownを生成
+   * Note: merge()はヘッダー情報のみを生成し、
+   * 実際のコンテンツ処理はwriteFull()で行う
+   */
   merge(pages: CrawledPage[]): string {
     return pages
-      .map(page => `# ${page.title}\n\n${this.stripTitle(page.markdown)}`)
-      .join("\n\n");
+      .map(page => {
+        const title = page.title || page.url;
+        const header = `# ${title}`;
+        const urlLine = `> Source: ${page.url}`;
+        return `${header}\n\n${urlLine}\n`;
+      })
+      .join("\n---\n\n");
+  }
+
+  /**
+   * full.mdを出力
+   * @param pages クロール済みページ一覧
+   * @param pageContents ページ内容のMap (file -> markdown)
+   * @returns 出力ファイルパス
+   */
+  writeFull(pages: CrawledPage[], pageContents: Map<string, string>): string {
+    const sections: string[] = [];
+
+    for (const page of pages) {
+      const title = page.title || page.url;
+      const header = `# ${title}`;
+      const urlLine = `> Source: ${page.url}`;
+
+      const rawContent = pageContents.get(page.file) || "";
+      const content = this.stripTitle(rawContent);
+
+      sections.push(`${header}\n\n${urlLine}\n\n${content}`);
+    }
+
+    const fullContent = sections.join("\n\n---\n\n");
+    const outputPath = join(this.outputDir, "full.md");
+    writeFileSync(outputPath, fullContent);
+
+    return outputPath;
   }
 
   /**
@@ -671,26 +728,90 @@ class Merger {
 ### 9.2 Chunker（見出しベース分割）
 
 ```typescript
+/**
+ * Markdownチャンク分割クラス
+ * full.mdをH1見出しベースでチャンク分割
+ */
 class Chunker {
+  constructor(private outputDir: string) {}
+
+  /**
+   * MarkdownをH1見出しで分割
+   * @param fullMarkdown 結合されたMarkdown文字列
+   * @returns 分割されたチャンクの配列
+   */
   chunk(fullMarkdown: string): string[] {
     const chunks: string[] = [];
     const lines = fullMarkdown.split("\n");
     let currentChunk: string[] = [];
+    let inFrontmatter = false;
+    let isFirstH1 = true;
 
     for (const line of lines) {
-      if (line.startsWith("# ") && currentChunk.length > 0) {
-        // h1で新チャンク開始
-        chunks.push(currentChunk.join("\n"));
-        currentChunk = [];
+      // frontmatterの検出
+      if (line.trim() === "---") {
+        inFrontmatter = !inFrontmatter;
+        currentChunk.push(line);
+        continue;
       }
+
+      // frontmatter内は無条件で追加
+      if (inFrontmatter) {
+        currentChunk.push(line);
+        continue;
+      }
+
+      // H1見出しの検出（行頭が"# "）
+      if (line.startsWith("# ")) {
+        if (!isFirstH1 && currentChunk.length > 0) {
+          // 前のチャンクを保存
+          chunks.push(currentChunk.join("\n").trim());
+          currentChunk = [];
+        }
+        isFirstH1 = false;
+      }
+
       currentChunk.push(line);
     }
 
+    // 最後のチャンクを追加
     if (currentChunk.length > 0) {
-      chunks.push(currentChunk.join("\n"));
+      chunks.push(currentChunk.join("\n").trim());
     }
 
-    return chunks;
+    return chunks.filter((chunk) => chunk.length > 0);
+  }
+
+  /**
+   * チャンクをファイルに出力
+   * @param chunks チャンクの配列
+   * @returns 出力されたファイルパスの配列
+   */
+  writeChunks(chunks: string[]): string[] {
+    const chunksDir = join(this.outputDir, "chunks");
+    mkdirSync(chunksDir, { recursive: true });
+
+    const outputPaths: string[] = [];
+    for (let i = 0; i < chunks.length; i++) {
+      const chunkNum = String(i + 1).padStart(3, "0");
+      const chunkFile = `chunk-${chunkNum}.md`;
+      const chunkPath = join(chunksDir, chunkFile);
+      writeFileSync(chunkPath, chunks[i]);
+      outputPaths.push(chunkPath);
+    }
+
+    return outputPaths;
+  }
+
+  /**
+   * full.mdファイルを読み込んでチャンク分割
+   * @returns 出力されたファイルパスの配列
+   */
+  chunkFullMd(): string[] {
+    const fullMdPath = join(this.outputDir, "full.md");
+    const content = readFileSync(fullMdPath, "utf-8");
+    const chunks = this.chunk(content);
+    return this.writeChunks(chunks);
   }
 }
 ```


### PR DESCRIPTION
## Summary
Closes #440

## Changes
設計書（`docs/design.md`）のコード例を実際の実装に合わせて更新しました。

### 修正内容

#### 1. Merger クラス (§9.1)
- `constructor(outputDir: string)` を追加
- `merge()` メソッドの実装を正確に記述（ヘッダーとURL行のみ生成）
- `writeFull(pages, pageContents)` メソッドを追加（実際のコンテンツ処理）
- `CrawledPage` に存在しない `markdown` プロパティへの参照を削除

#### 2. Chunker クラス (§9.2)
- `constructor(outputDir: string)` を追加
- frontmatter対応を含む正確な `chunk()` 実装を記述
- `writeChunks()` と `chunkFullMd()` メソッドを追加

#### 3. Hasher クラス (§8.2)
- `constructor(existingHashes: Map<string, string>)` に変更
- `isChanged(url, newHash)` のシグネチャを修正（`content` → `newHash`）
- 存在しない `loadHashes()` メソッドを削除
- IndexManager がファイルI/Oを担当することを明記

#### 4. full.md 形式 (§5.3)
- セパレータ `---` の前後に空行（`\n\n`）があることを明確化
- 実装での `join("\n\n---\n\n")` の動作を正確に反映

## Testing
- ドキュメント変更のため、コードテストは不要
- 実装コードとの整合性を手動で確認済み

## Impact
- 新規開発者が設計書を参照した際の混乱を防止
- AIエージェントが設計書を参照した際の誤実装を防止