### PR TITLE
refactor: Merger.merge() メソッドがデッドコード

### DIFF
--- a/link-crawler/src/output/merger.ts
+++ b/link-crawler/src/output/merger.ts
@@ -10,29 +10,6 @@ export class Merger {
 	constructor(private outputDir: string) {}
 
 	/**
-	 * ページを結合してMarkdownを生成
-	 * @param pages クロール済みページ一覧
-	 * @returns 結合されたMarkdown文字列
-	 */
-	merge(pages: CrawledPage[]): string {
-		if (pages.length === 0) {
-			return "";
-		}
-
-		const sections = pages.map((page) => {
-			const title = page.title || page.url;
-			const header = `# ${title}`;
-			const urlLine = `> Source: ${page.url}`;
-			// コンテンツは実際のファイルから読み込むのではなく、
-			// ここではヘッダー情報のみを生成
-			// 実際のコンテンツはwriteFullで読み込む
-			return { header, urlLine, page };
-		});
-
-		return sections.map((s) => `${s.header}\n\n${s.urlLine}\n`).join("\n---\n\n");
-	}
-
-	/**
 	 * Markdownから先頭のH1タイトルを除去
 	 * frontmatterがある場合は考慮する
 	 * @param markdown Markdown文字列

--- a/link-crawler/tests/unit/merger.test.ts
+++ b/link-crawler/tests/unit/merger.test.ts
@@ -78,41 +78,6 @@ Content after title.`;
 		});
 	});
 
-	describe("merge", () => {
-		it("should return empty string for empty pages", () => {
-			const merger = new Merger(testOutputDir);
-
-			const result = merger.merge([]);
-
-			expect(result).toBe("");
-		});
-
-		it("should merge multiple pages with headers", () => {
-			const merger = new Merger(testOutputDir);
-			const pages = [
-				createPage("https://example.com/page1", "Page 1", "pages/page-001.md"),
-				createPage("https://example.com/page2", "Page 2", "pages/page-002.md"),
-			];
-
-			const result = merger.merge(pages);
-
-			expect(result).toContain("# Page 1");
-			expect(result).toContain("> Source: https://example.com/page1");
-			expect(result).toContain("# Page 2");
-			expect(result).toContain("> Source: https://example.com/page2");
-			expect(result).toContain("---");
-		});
-
-		it("should use URL as title if title is null", () => {
-			const merger = new Merger(testOutputDir);
-			const pages = [createPage("https://example.com/untitled", null, "pages/page-001.md")];
-
-			const result = merger.merge(pages);
-
-			expect(result).toContain("# https://example.com/untitled");
-		});
-	});
-
 	describe("writeFull", () => {
 		it("should write full.md file", () => {
 			const merger = new Merger(testOutputDir);


### PR DESCRIPTION
## Summary
Closes #446

## Changes
- Removed unused `Merger.merge()` method from `link-crawler/src/output/merger.ts`
- Removed related test cases from `link-crawler/tests/unit/merger.test.ts`
- Total: 58 lines removed (dead code cleanup)

## Background
The `merge()` method was only defined but never called in production code. Only `writeFull()` is used by `PostProcessor`. The `merge()` method only generated headers without actual content, while `writeFull()` includes full page content.

## Testing
- ✅ All 418 tests pass
- ✅ TypeScript compilation successful
- ✅ Biome lint check passed (1 pre-existing warning unrelated to changes)
- ✅ Verified `merge()` has zero production usage via grep
- ✅ `writeFull()` functionality remains intact

## Impact
- Zero functional impact (removing dead code only)
- Improved code maintainability
- Reduced cognitive load for future developers