### PR TITLE
fix: docs/README.md のサイト名出力例が実際の生成結果と不一致

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ cd link-crawler
 bun run dev https://docs.example.com -d 2
 
 # 出力確認（サイト名ディレクトリ配下に生成されます）
-cat .context/docs-example-com/full.md
+cat .context/example/full.md
 ```
 
 ### 方法2: 手動インストール
@@ -37,7 +37,7 @@ bun install
 bun run dev https://docs.example.com -d 2
 
 # 出力確認（サイト名ディレクトリ配下に生成されます）
-cat .context/docs-example-com/full.md
+cat .context/example/full.md
 ```
 
 ## piスキル統合


### PR DESCRIPTION
## Summary
Closes #445

## Changes
- `docs/README.md` の2箇所で出力パスを修正
  - Before: `.context/docs-example-com/full.md`
  - After: `.context/example/full.md`

## Reason
`generateSiteName('https://docs.example.com')` は `'example'` を返すため、ドキュメントの出力例が実際の動作と一致していませんでした。

## Verification
```bash
$ bun -e "import { generateSiteName } from './src/utils/site-name.ts'; console.log(generateSiteName('https://docs.example.com'))"
example
```

## Testing
- ドキュメント修正のため自動テストは不要
- 既存の `generateSiteName()` の動作と一致することを確認済み