### PR TITLE
refactor: add debug logging to empty catch blocks

### DIFF
--- a/link-crawler/src/crawler/fetcher.ts
+++ b/link-crawler/src/crawler/fetcher.ts
@@ -219,8 +219,11 @@ export class PlaywrightFetcher implements Fetcher {
 			// Note: 以前は ["close", "--session", sessionId] だったが、
 			// playwright-cli 0.0.63+ では session-stop コマンドを使用
 			await this.runCli(["session-stop"]);
-		} catch {
-			// セッションが既に閉じている場合は無視
+		} catch (error) {
+			// セッションが既に閉じている場合は無視（デバッグログのみ）
+			if (process.env.DEBUG === "1") {
+				console.log(`[DEBUG] session-stop failed (expected if already closed): ${error}`);
+			}
 		}
 
 		// .playwright-cli ディレクトリをクリーンアップ
@@ -230,8 +233,11 @@ export class PlaywrightFetcher implements Fetcher {
 				if (existsSync(cliDir)) {
 					rmSync(cliDir, { recursive: true, force: true });
 				}
-			} catch {
-				// クリーンアップ失敗は無視
+			} catch (error) {
+				// クリーンアップ失敗は無視（デバッグログのみ）
+				if (process.env.DEBUG === "1") {
+					console.log(`[DEBUG] .playwright-cli cleanup failed: ${error}`);
+				}
 			}
 		}
 	}

--- a/link-crawler/src/crawler/post-processor.ts
+++ b/link-crawler/src/crawler/post-processor.ts
@@ -82,8 +82,12 @@ export class PostProcessor {
 				const pagePath = join(this.config.outputDir, page.file);
 				const content = readFileSync(pagePath, "utf-8");
 				contents.set(page.file, content);
-			} catch {
-				// ファイルが読み込めない場合は空文字
+			} catch (error) {
+				// ファイルが読み込めない場合は空文字（デバッグログのみ）
+				this.logger.logDebug("Failed to read page file", {
+					file: page.file,
+					error: String(error),
+				});
 				contents.set(page.file, "");
 			}
 		}


### PR DESCRIPTION
## Summary
Closes #471

## Changes
- Added debug logging to 2 empty catch blocks in `link-crawler/src/crawler/fetcher.ts` (in `close()` method)
- Added debug logging to 1 empty catch block in `link-crawler/src/crawler/post-processor.ts` (in `loadPageContentsFromDisk()`)
- All changes comply with coding standards (`docs/development.md` §4.4)

## Implementation Details
- **fetcher.ts**: Uses `process.env.DEBUG` for conditional logging since logger instance is not available in `close()` method
- **post-processor.ts**: Uses `this.logger.logDebug()` since logger instance is available
- Debug logs only appear when `DEBUG=1` environment variable is set

## Testing
- ✅ All 436 unit and integration tests pass
- ✅ Linting passes with no issues
- ✅ Manual verification with `DEBUG=1` shows logs
- ✅ Normal mode shows no debug output