### PR TITLE
docs: 開発ガイド(development.md)のドキュメント一覧リンクが欠落

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,7 @@ ln -s /path/to/link-crawler ~/.pi/agent/skills/link-crawler
 | ドキュメント | 内容 |
 |-------------|------|
 | [設計書](./design.md) | アーキテクチャ・データ構造・モジュール設計 |
+| [開発ガイド](./development.md) | 開発ワークフロー・コーディング規約・テスト方針 |
 
 ## 🚀 目的別ガイド
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -236,17 +236,31 @@ try {
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  test: {
-    globals: true,
-    environment: "node",
-    include: ["tests/**/*.test.ts"],
-    coverage: {
-      provider: "v8",
-      reporter: ["text", "html"],
-      include: ["src/**/*.ts"],
-      exclude: ["src/crawl.ts"], // CLI エントリーポイント除外
-    },
-  },
+	test: {
+		globals: true,
+		include: ["tests/**/*.test.ts"],
+		globalTeardown: "./tests/global-teardown.ts",
+		// Enable file-level parallelism for faster test execution
+		// forks pool provides complete isolation between test files
+		fileParallelism: true,
+		// forksプールを使用して各テストファイルを完全に分離
+		// (threadsではなくforksを使用することで、module mocksが他のファイルに影響しない)
+		pool: "forks",
+		// Vitest 4: poolOptions moved to top-level
+		singleFork: false,
+		// テスト間でモックをクリアして分離を確保
+		clearMocks: true,
+		mockReset: true,
+		restoreMocks: true,
+		// 各テストファイルを完全に分離
+		isolate: true,
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "html", "json-summary"],
+			include: ["src/**/*.ts"],
+			exclude: ["src/crawl.ts"],
+		},
+	},
 });
 ```
 


### PR DESCRIPTION
## Summary
Closes #481

## Changes
- **docs/README.md**: 開発者向けドキュメント一覧テーブルに「開発ガイド」(development.md)へのリンクを追加
- **docs/development.md**: セクション5.2のVitest設定サンプルを実際の `vitest.config.ts` と同期
  - `globalTeardown`, `fileParallelism`, `pool: "forks"`, `singleFork` を追加
  - `clearMocks`, `mockReset`, `restoreMocks`, `isolate` を追加
  - `coverage.reporter` に `json-summary` を追加

## Testing
✅ Manual verification completed:
- `grep "development.md" docs/README.md` - Link exists
- `grep "pool:" docs/development.md` - pool: forks present
- `grep "fileParallelism" docs/development.md` - fileParallelism present
- `grep "clearMocks" docs/development.md` - clearMocks present

## Issue Details
This PR fixes documentation inconsistencies:
1. development.md was not referenced in docs/README.md developer documentation list
2. Vitest configuration sample in development.md was outdated and missing important settings

Both issues are now resolved.