### PR TITLE
fix: Biome lint警告 - links.ts の import を import type に変更

### DIFF
--- a/link-crawler/src/parser/links.ts
+++ b/link-crawler/src/parser/links.ts
@@ -1,4 +1,4 @@
-import { JSDOM } from "jsdom";
+import type { JSDOM } from "jsdom";
 import type { CrawlConfig } from "../types.js";
 
 /** URL を正規化 */


### PR DESCRIPTION
## Summary
Closes #479

## Changes
- `link-crawler/src/parser/links.ts` の `import { JSDOM } from "jsdom"` を `import type { JSDOM } from "jsdom"` に変更
- JSDOM は型注釈としてのみ使用されているため、Biome の `lint/style/useImportType` ルールに従い `import type` を使用

## Testing
- ✅ `bun run check` - 警告0件
- ✅ `bun run typecheck` - パス
- ✅ `bun run test` - 全443テストパス