### PR TITLE
docs: fix CLI spec full.md format to include Source URL and separator

### DIFF
--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -233,13 +233,23 @@ crawl https://docs.example.com --delay 2000
 ```markdown
 # Getting Started
 
+> Source: https://docs.example.com/getting-started
+
 導入部分の内容...
+
+---
 
 # Installation
 
+> Source: https://docs.example.com/installation
+
 インストール手順...
 
+---
+
 # Configuration
+
+> Source: https://docs.example.com/configuration
 
 設定方法...
 ```


### PR DESCRIPTION
## Summary
Closes #477

## Changes
- Added `> Source: <URL>` line after each section heading in full.md format example
- Added `---` separator between sections in full.md format example
- Aligns CLI specification with actual implementation in `merger.ts`
- Ensures consistency between `cli-spec.md` and `design.md`

## Testing
- Manual verification: format matches the actual implementation in `link-crawler/src/output/merger.ts`
- Cross-reference check: format now matches `docs/design.md` section 5.3
- Documentation-only change, no code tests required

## Impact
- Users will now see accurate documentation that matches the actual output
- Eliminates confusion between specification and implementation
- All documentation sources (cli-spec.md, design.md, merger.ts) are now consistent