### PR TITLE
fix: pages/*.mdのfrontmatterにhashフィールドを追加

### DIFF
--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -168,7 +168,7 @@ export class Crawler {
 			} else {
 				// メモリに保存 (Merger/Chunker用)
 				const pageFile = this.writer.buildPageFilename(metadata, title);
-				const frontmatter = this.writer.buildFrontmatter(url, metadata, title, depth);
+				const frontmatter = this.writer.buildFrontmatter(url, metadata, title, depth, hash);
 				this.pageContents.set(pageFile, frontmatter + markdown);
 				// writerにもページ情報を追加（ファイルは書き込まない）
 				this.writer.registerPage(url, pageFile, depth, links, metadata, title, hash);

--- a/link-crawler/src/output/writer.ts
+++ b/link-crawler/src/output/writer.ts
@@ -111,7 +111,7 @@ export class OutputWriter {
 		const pagePath = join(this.config.outputDir, pageFile);
 		const computedHash = hash ?? computeHash(markdown);
 
-		const frontmatter = this.buildFrontmatter(url, metadata, title, depth);
+		const frontmatter = this.buildFrontmatter(url, metadata, title, depth, computedHash);
 		writeFileSync(pagePath, frontmatter + markdown);
 
 		this.registerPage(url, pageFile, depth, links, metadata, title, computedHash);
@@ -125,6 +125,7 @@ export class OutputWriter {
 		metadata: PageMetadata,
 		title: string | null,
 		depth: number,
+		hash?: string,
 	): string {
 		const pageCrawledAt = new Date().toISOString();
 		const lines: (string | null)[] = [
@@ -133,6 +134,7 @@ export class OutputWriter {
 			`title: "${(metadata.title || title || "").replace(/"/g, '\\"')}"`,
 			metadata.description ? `description: "${metadata.description.replace(/"/g, '\\"')}"` : null,
 			metadata.keywords ? `keywords: "${metadata.keywords}"` : null,
+			hash ? `hash: "${hash}"` : null,
 			`crawledAt: ${pageCrawledAt}`,
 			`depth: ${depth}`,
 			"---",

--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -142,6 +142,33 @@ describe("OutputWriter", () => {
 		expect(content).toMatch(/---\n\n## Introduction/);
 	});
 
+	it("should include hash in frontmatter", () => {
+		const writer = new OutputWriter(defaultConfig);
+		const markdown = "# Test Content\n\nThis is test content.";
+
+		const pageFile = writer.savePage(
+			"https://example.com/page1",
+			markdown,
+			1,
+			[],
+			defaultMetadata,
+			"Test Page",
+		);
+
+		const pagePath = join(testOutputDir, pageFile);
+		const content = readFileSync(pagePath, "utf-8");
+
+		// Verify that hash is included in frontmatter
+		expect(content).toMatch(/^---\n/);
+		expect(content).toMatch(/\nhash: "[a-f0-9]{64}"\n/);
+		expect(content).toMatch(/\n---\n\n/);
+
+		// Verify hash is a SHA-256 hex string (64 characters)
+		const hashMatch = content.match(/hash: "([a-f0-9]{64})"/);
+		expect(hashMatch).toBeTruthy();
+		expect(hashMatch![1]).toHaveLength(64);
+	});
+
 	describe("filename with title", () => {
 		it("should include slugified title in filename", () => {
 			const writer = new OutputWriter(defaultConfig);


### PR DESCRIPTION
## Summary
Closes #478

## Changes
- `buildFrontmatter()` メソッドに `hash?: string` パラメータを追加
- frontmatter出力に `hash: "..."` フィールドを追加
- `savePage()` から呼び出す際にhashを渡すように修正
- Crawlerの `--no-pages` モードでもhashを渡すように修正
- frontmatterにhashが含まれることを検証するテストを追加

## Testing
- 全444テストがパス
- 手動検証で生成されたfrontmatterにhashフィールドが含まれることを確認
- CLI仕様書（docs/cli-spec.md セクション5.5）に記載されている通りの出力を実現

## Implementation Details
hashフィールドは `keywords` と `crawledAt` の間に配置され、CLI仕様書で定義されている順序に従います：
```yaml
---
url: https://example.com/test
title: "Test Page"
description: "Test description"
hash: "1380c0356a3c6d005cff0211171f637221d2ccb821b6ce2a8a2ff55471e587ec"
crawledAt: 2026-02-06T15:26:28.759Z
depth: 1
---
```