### PR TITLE
feat: add hash field to page frontmatter

### DIFF
--- a/link-crawler/src/output/writer.ts
+++ b/link-crawler/src/output/writer.ts
@@ -111,7 +111,7 @@ export class OutputWriter {
 		const pagePath = join(this.config.outputDir, pageFile);
 		const computedHash = hash ?? computeHash(markdown);
 
-		const frontmatter = this.buildFrontmatter(url, metadata, title, depth);
+		const frontmatter = this.buildFrontmatter(url, metadata, title, computedHash, depth);
 		writeFileSync(pagePath, frontmatter + markdown);
 
 		this.registerPage(url, pageFile, depth, links, metadata, title, computedHash);
@@ -124,6 +124,7 @@ export class OutputWriter {
 		url: string,
 		metadata: PageMetadata,
 		title: string | null,
+		hash: string,
 		depth: number,
 	): string {
 		const pageCrawledAt = new Date().toISOString();
@@ -133,6 +134,7 @@ export class OutputWriter {
 			`title: "${(metadata.title || title || "").replace(/"/g, '\\"')}"`,
 			metadata.description ? `description: "${metadata.description.replace(/"/g, '\\"')}"` : null,
 			metadata.keywords ? `keywords: "${metadata.keywords}"` : null,
+			`hash: ${hash}`,
 			`crawledAt: ${pageCrawledAt}`,
 			`depth: ${depth}`,
 			"---",

--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -142,6 +142,28 @@ describe("OutputWriter", () => {
 		expect(content).toMatch(/---\n\n## Introduction/);
 	});
 
+	it("should include hash field in frontmatter", () => {
+		const writer = new OutputWriter(defaultConfig);
+		const markdown = "# Test Content\n\nThis is test content.";
+
+		writer.savePage(
+			"https://example.com/page1",
+			markdown,
+			1,
+			["https://example.com/page2"],
+			defaultMetadata,
+			"Test Page",
+		);
+
+		const pagePath = join(testOutputDir, "pages/page-001-test-page.md");
+		const content = readFileSync(pagePath, "utf-8");
+
+		// Verify that hash field is present in frontmatter
+		expect(content).toMatch(/^---\n/);
+		expect(content).toMatch(/\nhash: [a-f0-9]{64}\n/);
+		expect(content).toMatch(/\n---\n\n/);
+	});
+
 	describe("filename with title", () => {
 		it("should include slugified title in filename", () => {
 			const writer = new OutputWriter(defaultConfig);


### PR DESCRIPTION
## Summary
Closes #489

Resolves the inconsistency between CLI documentation (docs/cli-spec.md §5.5) and implementation where the frontmatter example showed a `hash` field but the actual `buildFrontmatter()` method didn't include it.

## Changes
- **Added hash parameter** to `buildFrontmatter()` method signature
- **Included hash field** in frontmatter output (between optional metadata and timestamp fields)
- **Updated `savePage()`** to pass the computed hash to `buildFrontmatter()`
- **Added test** to verify hash field is present in frontmatter with correct format (64-char hex)

## Implementation Details
The hash field is now included in the frontmatter for all crawled pages:

```markdown
---
url: https://docs.example.com/getting-started
title: "Getting Started"
description: "Quick start guide"
keywords: "guide, tutorial"
hash: a1b2c3d4e5f6789012345678901234567890123456789012345678901234
crawledAt: 2026-02-01T14:00:01.000Z
depth: 1
---
```

This aligns with the CLI specification and enables AI agents to correctly reference and validate page content using the hash.

## Testing
- ✅ All existing tests pass (444 tests)
- ✅ New test verifies hash field in frontmatter
- ✅ Hash format validated (64-character hexadecimal)

## Impact
- **No breaking changes**: Only adds a new field to frontmatter
- **Backward compatible**: Old files without hash continue to work
- **Documentation aligned**: Implementation now matches cli-spec.md §5.5