### PR TITLE
fix: Chunkerのfrontmatter検出ロジックが不正確（---がセパレータと衝突する）

### DIFF
--- a/link-crawler/src/output/chunker.ts
+++ b/link-crawler/src/output/chunker.ts
@@ -24,14 +24,34 @@ export class Chunker {
 		const lines = fullMarkdown.split("\n");
 		let currentChunk: string[] = [];
 		let inFrontmatter = false;
+		let frontmatterEnded = false; // frontmatter終了フラグ
 		let isFirstH1 = true;
+		let seenNonEmptyLine = false; // 非空行検出フラグ
 
 		for (const line of lines) {
-			// frontmatterの検出
-			if (line.trim() === "---") {
-				inFrontmatter = !inFrontmatter;
-				currentChunk.push(line);
-				continue;
+			// frontmatter検出（ファイル先頭のみ）
+			if (line.trim() === "---" && !frontmatterEnded) {
+				// 先頭の空行をスキップした後の最初の---
+				if (!seenNonEmptyLine) {
+					inFrontmatter = true;
+					currentChunk.push(line);
+					seenNonEmptyLine = true;
+					continue;
+				}
+
+				// frontmatter内で2番目の---を検出
+				if (inFrontmatter) {
+					inFrontmatter = false;
+					frontmatterEnded = true;
+					currentChunk.push(line);
+					continue;
+				}
+			}
+
+			// 非空行を検出（frontmatterがない場合）
+			if (line.trim() !== "" && !seenNonEmptyLine) {
+				seenNonEmptyLine = true;
+				frontmatterEnded = true; // frontmatterなし確定
 			}
 
 			// frontmatter内は無条件で追加

--- a/link-crawler/tests/unit/chunker.test.ts
+++ b/link-crawler/tests/unit/chunker.test.ts
@@ -129,6 +129,92 @@ More content.
 			expect(result[0]).not.toMatch(/^\s/);
 			expect(result[0]).not.toMatch(/\s$/);
 		});
+
+		it("should handle full.md format with --- separators (3+ pages)", () => {
+			const chunker = new Chunker(testOutputDir);
+			const markdown = `# Page 1
+
+> Source: https://example.com/page1
+
+Content of page 1.
+
+---
+
+# Page 2
+
+> Source: https://example.com/page2
+
+Content of page 2.
+
+---
+
+# Page 3
+
+> Source: https://example.com/page3
+
+Content of page 3.`;
+
+			const result = chunker.chunk(markdown);
+
+			expect(result).toHaveLength(3);
+			expect(result[0]).toContain("# Page 1");
+			expect(result[1]).toContain("# Page 2");
+			expect(result[2]).toContain("# Page 3");
+			expect(result[0]).toContain("Content of page 1");
+			expect(result[1]).toContain("Content of page 2");
+			expect(result[2]).toContain("Content of page 3");
+		});
+
+		it("should handle 4 pages with --- separators", () => {
+			const chunker = new Chunker(testOutputDir);
+			const markdown = `# Page 1
+Content 1.
+
+---
+
+# Page 2
+Content 2.
+
+---
+
+# Page 3
+Content 3.
+
+---
+
+# Page 4
+Content 4.`;
+
+			const result = chunker.chunk(markdown);
+
+			expect(result).toHaveLength(4);
+			expect(result[0]).toContain("# Page 1");
+			expect(result[1]).toContain("# Page 2");
+			expect(result[2]).toContain("# Page 3");
+			expect(result[3]).toContain("# Page 4");
+		});
+
+		it("should handle frontmatter at start and --- separators later", () => {
+			const chunker = new Chunker(testOutputDir);
+			const markdown = `---
+title: Test Document
+---
+
+# Page 1
+Content 1.
+
+---
+
+# Page 2
+Content 2.`;
+
+			const result = chunker.chunk(markdown);
+
+			expect(result).toHaveLength(2);
+			expect(result[0]).toContain("title: Test Document");
+			expect(result[0]).toContain("# Page 1");
+			expect(result[1]).toContain("# Page 2");
+		});
 	});
 
 	describe("writeChunks", () => {


### PR DESCRIPTION
## Summary
Closes #499

## Problem
`Chunker.chunk()`のfrontmatter検出ロジックが、`full.md`のセクションセパレータ`---`と衝突し、偶数番目のページが正しくチャンク分割されない問題を修正しました。

## Changes
- frontmatter検出をファイル先頭のみに限定
- セクションセパレータ(`---`)との衝突を回避
- `frontmatterEnded`と`seenNonEmptyLine`フラグを追加して制御

## Testing
- 3ページ以上のfull.md形式のテストケースを追加
- 4ページ（偶数）のテストケースを追加
- frontmatter + セパレータ混在のテストケースを追加
- 既存テスト全てパス（446テスト成功）

## Files Changed
- `link-crawler/src/output/chunker.ts` - frontmatter検出ロジックの修正
- `link-crawler/tests/unit/chunker.test.ts` - テストケースの追加