### PR TITLE
fix: global-teardown が integration テスト出力ディレクトリを削除しない（197件残留）

### DIFF
--- a/link-crawler/tests/global-teardown.ts
+++ b/link-crawler/tests/global-teardown.ts
@@ -32,4 +32,19 @@ export default async function globalTeardown() {
 	} catch (error) {
 		console.warn("Warning: Failed to clean up .test-index-manager-* directories", error);
 	}
+
+	// Clean up .test-output-* directories in tests/integration
+	try {
+		const integrationDir = join(linkCrawlerDir, "tests", "integration");
+		const entries = readdirSync(integrationDir);
+		for (const entry of entries) {
+			if (entry.startsWith(".test-output-")) {
+				const fullPath = join(integrationDir, entry);
+				rmSync(fullPath, { recursive: true, force: true });
+				console.log(`✓ Cleaned up: tests/integration/${entry}`);
+			}
+		}
+	} catch (error) {
+		console.warn("Warning: Failed to clean up integration test output directories", error);
+	}
 }


### PR DESCRIPTION
## Summary
Closes #488

## Changes
- `global-teardown.ts` に `tests/integration/.test-output-*` ディレクトリのクリーンアップ処理を追加
- 既存の残留ディレクトリ（29件）を手動削除

## Implementation Details
- 既存のクリーンアップパターンと同じ構造で実装
- エラーハンドリング: try-catch で警告のみ表示
- `.test-output-*` パターンで integration ディレクトリをスキャンして削除

## Testing
- 全447テストがパス ✅
- テスト実行後に残留ディレクトリがないことを確認 ✅
- メインリポジトリの残留ディレクトリも削除済み ✅

## Related
- 問題の詳細: tests/integration/ に .test-output-integration-* パターンのディレクトリが蓄積していた
- 原因: global-teardown.ts が integration ディレクトリをスキャンしていなかった