### PR TITLE
refactor: テストコードの Biome lint 警告を修正 (non-null assertion)

### DIFF
--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -166,7 +166,7 @@ describe("OutputWriter", () => {
 		// Verify hash is a SHA-256 hex string (64 characters)
 		const hashMatch = content.match(/hash: "([a-f0-9]{64})"/);
 		expect(hashMatch).toBeTruthy();
-		expect(hashMatch![1]).toHaveLength(64);
+		expect(hashMatch?.[1]).toHaveLength(64);
 	});
 
 	describe("filename with title", () => {


### PR DESCRIPTION
## Summary
Closes #511

## Changes
- `link-crawler/tests/unit/writer.test.ts` の non-null assertion (`!`) を optional chaining (`?.`) に変更
- Biome lint警告 (`lint/style/noNonNullAssertion`) を解消

## Testing
- ✅ 全テスト合格 (447 tests in 19 test files)
- ✅ Biome lint check 合格 (0 warnings)
- ✅ 既存機能への影響なし

## Details
**変更箇所**: Line 169
```typescript
// Before:
expect(hashMatch![1]).toHaveLength(64);

// After:
expect(hashMatch?.[1]).toHaveLength(64);
```

**検証方法**:
```bash
cd link-crawler && bunx biome check src/ tests/
bun run test
```