### PR TITLE
fix: リンク抽出で tel:, data:, blob:, ftp: スキームを除外

### DIFF
--- a/link-crawler/src/parser/links.ts
+++ b/link-crawler/src/parser/links.ts
@@ -49,7 +49,11 @@ export function extractLinks(dom: JSDOM, visited: Set<string>, config: CrawlConf
 			!href ||
 			href.startsWith("#") ||
 			href.startsWith("javascript:") ||
-			href.startsWith("mailto:")
+			href.startsWith("mailto:") ||
+			href.startsWith("tel:") ||
+			href.startsWith("data:") ||
+			href.startsWith("blob:") ||
+			href.startsWith("ftp:")
 		) {
 			continue;
 		}

--- a/link-crawler/tests/unit/links.test.ts
+++ b/link-crawler/tests/unit/links.test.ts
@@ -305,6 +305,74 @@ describe("extractLinks", () => {
 		expect(links[0]).toBe("https://example.com/page");
 	});
 
+	it("should exclude tel: links", () => {
+		const html = `
+			<html>
+				<body>
+					<a href="tel:+1234567890">Call</a>
+					<a href="/page">Page</a>
+				</body>
+			</html>
+		`;
+		const visited = new Set<string>();
+		const dom = new JSDOM(html, { url: "https://example.com" });
+		const links = extractLinks(dom, visited, baseConfig);
+
+		expect(links).toHaveLength(1);
+		expect(links[0]).toBe("https://example.com/page");
+	});
+
+	it("should exclude data: URIs", () => {
+		const html = `
+			<html>
+				<body>
+					<a href="data:text/html,<h1>Test</h1>">Data URI</a>
+					<a href="/page">Page</a>
+				</body>
+			</html>
+		`;
+		const visited = new Set<string>();
+		const dom = new JSDOM(html, { url: "https://example.com" });
+		const links = extractLinks(dom, visited, baseConfig);
+
+		expect(links).toHaveLength(1);
+		expect(links[0]).toBe("https://example.com/page");
+	});
+
+	it("should exclude blob: URLs", () => {
+		const html = `
+			<html>
+				<body>
+					<a href="blob:https://example.com/some-guid">Blob</a>
+					<a href="/page">Page</a>
+				</body>
+			</html>
+		`;
+		const visited = new Set<string>();
+		const dom = new JSDOM(html, { url: "https://example.com" });
+		const links = extractLinks(dom, visited, baseConfig);
+
+		expect(links).toHaveLength(1);
+		expect(links[0]).toBe("https://example.com/page");
+	});
+
+	it("should exclude ftp: links", () => {
+		const html = `
+			<html>
+				<body>
+					<a href="ftp://ftp.example.com/file.txt">FTP</a>
+					<a href="/page">Page</a>
+				</body>
+			</html>
+		`;
+		const visited = new Set<string>();
+		const dom = new JSDOM(html, { url: "https://example.com" });
+		const links = extractLinks(dom, visited, baseConfig);
+
+		expect(links).toHaveLength(1);
+		expect(links[0]).toBe("https://example.com/page");
+	});
+
 	it("should exclude visited links", () => {
 		const html = `
 			<html>


### PR DESCRIPTION
## Summary
Closes #510

## Changes
- `extractLinks()` で `tel:`, `data:`, `blob:`, `ftp:` スキームをフィルタリング
- 各スキームに対するユニットテストを追加（4件）
- 既存の `javascript:`, `mailto:` と同じパターンで実装

## Testing
- 全451テストがパス
- TypeScriptコンパイル成功
- 新規テストケース4件を追加