### PR TITLE
fix: テストコードの Biome lint 警告を修正（non-null assertion）

### DIFF
--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -166,7 +166,7 @@ describe("OutputWriter", () => {
 		// Verify hash is a SHA-256 hex string (64 characters)
 		const hashMatch = content.match(/hash: "([a-f0-9]{64})"/);
 		expect(hashMatch).toBeTruthy();
-		expect(hashMatch![1]).toHaveLength(64);
+		expect(hashMatch?.[1]).toHaveLength(64);
 	});
 
 	describe("filename with title", () => {


### PR DESCRIPTION
## Summary
Closes #518

## Changes
- `link-crawler/tests/unit/writer.test.ts` の L169 で non-null assertion (`!`) を optional chaining (`?.`) に変更
- Biome lint 警告を解消

## Testing
- `cd link-crawler && npx @biomejs/biome check src tests` → Found 0 warnings.
- `cd link-crawler && bun test tests/unit/writer.test.ts` → 20/20 tests passed

## Notes
- L168 で `expect(hashMatch).toBeTruthy()` により null チェック済みのため、optional chaining に変更してもロジックに影響なし