### PR TITLE
fix: writer.test.ts の non-null assertion を optional chain に置換

### DIFF
--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -166,7 +166,7 @@ describe("OutputWriter", () => {
 		// Verify hash is a SHA-256 hex string (64 characters)
 		const hashMatch = content.match(/hash: "([a-f0-9]{64})"/);
 		expect(hashMatch).toBeTruthy();
-		expect(hashMatch![1]).toHaveLength(64);
+		expect(hashMatch?.[1]).toHaveLength(64);
 	});
 
 	describe("filename with title", () => {


### PR DESCRIPTION
## Summary
Closes #532

## Changes
- `link-crawler/tests/unit/writer.test.ts` の行169で `hashMatch![1]` を `hashMatch?.[1]` に変更
- Biome lint 警告 (`style/noNonNullAssertion`) を解決

## Testing
- ✅ `bun run check`: 警告0件を確認
- ✅ `bun run test writer`: 20個のテストがパス
- ✅ `bun run test`: 全447個のテストがパス

## Details
non-null assertion (`!`) は型チェックのみで実行時の安全性を保証しないため、optional chain (`?.`) への置き換えはベストプラクティスです。
すぐ前の行で `expect(hashMatch).toBeTruthy()` により null チェックが行われているため、動作に影響はありません。