### PR TITLE
docs: セクション9.2のChunker実装コードを実装と同期

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -802,18 +802,45 @@ class Chunker {
    * @returns 分割されたチャンクの配列
    */
   chunk(fullMarkdown: string): string[] {
+    // 空入力ガード
+    if (!fullMarkdown.trim()) {
+      return [];
+    }
+
+    // H1見出し（# ）で分割
+    // ただし、frontmatter内の#は除外
     const chunks: string[] = [];
     const lines = fullMarkdown.split("\n");
     let currentChunk: string[] = [];
     let inFrontmatter = false;
+    let frontmatterEnded = false; // frontmatter終了フラグ
     let isFirstH1 = true;
+    let seenNonEmptyLine = false; // 非空行検出フラグ
 
     for (const line of lines) {
-      // frontmatterの検出
-      if (line.trim() === "---") {
-        inFrontmatter = !inFrontmatter;
-        currentChunk.push(line);
-        continue;
+      // frontmatter検出（ファイル先頭のみ）
+      if (line.trim() === "---" && !frontmatterEnded) {
+        // 先頭の空行をスキップした後の最初の---
+        if (!seenNonEmptyLine) {
+          inFrontmatter = true;
+          currentChunk.push(line);
+          seenNonEmptyLine = true;
+          continue;
+        }
+
+        // frontmatter内で2番目の---を検出
+        if (inFrontmatter) {
+          inFrontmatter = false;
+          frontmatterEnded = true;
+          currentChunk.push(line);
+          continue;
+        }
+      }
+
+      // 非空行を検出（frontmatterがない場合）
+      if (line.trim() !== "" && !seenNonEmptyLine) {
+        seenNonEmptyLine = true;
+        frontmatterEnded = true; // frontmatterなし確定
       }
 
       // frontmatter内は無条件で追加
@@ -849,14 +876,22 @@ class Chunker {
    * @returns 出力されたファイルパスの配列
    */
   writeChunks(chunks: string[]): string[] {
+    // 空チェック
+    if (chunks.length === 0) {
+      return [];
+    }
+
+    // chunksディレクトリ作成
     const chunksDir = join(this.outputDir, "chunks");
     mkdirSync(chunksDir, { recursive: true });
 
     const outputPaths: string[] = [];
+
     for (let i = 0; i < chunks.length; i++) {
       const chunkNum = String(i + 1).padStart(3, "0");
       const chunkFile = `chunk-${chunkNum}.md`;
       const chunkPath = join(chunksDir, chunkFile);
+
       writeFileSync(chunkPath, chunks[i]);
       outputPaths.push(chunkPath);
     }


### PR DESCRIPTION
## 概要

`docs/design.md` のセクション9.2に記載されているChunkerの実装コードを、実際の `link-crawler/src/output/chunker.ts` の実装に合わせて更新しました。

## 変更内容

### 1. `chunk()` メソッド
- **空入力ガード**: `if (!fullMarkdown.trim()) { return []; }` を追加
- **frontmatter処理の改善**: 
  - `frontmatterEnded` フラグを追加（frontmatter終了を追跡）
  - `seenNonEmptyLine` フラグを追加（非空行を検出）
  - ファイル先頭のfrontmatterのみを正しく検出するロジックを追加
- **コメント追加**: frontmatter処理の設計意図を明記

### 2. `writeChunks()` メソッド
- **空チェック**: `if (chunks.length === 0) { return []; }` を追加
- **コメント追加**: 処理の各ステップを明確化

## 影響範囲

- `docs/design.md` のセクション9.2のみ
- 実装コードには変更なし（ドキュメント更新のみ）

## 検証

- 実装ファイル (`link-crawler/src/output/chunker.ts`) と設計書の一致を確認
- frontmatter処理のロジックが正確に記述されていることを確認

Closes #531