### PR TITLE
fix: escape double quotes in YAML frontmatter keywords field

### DIFF
--- a/link-crawler/src/output/writer.ts
+++ b/link-crawler/src/output/writer.ts
@@ -133,7 +133,7 @@ export class OutputWriter {
 			`url: ${url}`,
 			`title: "${(metadata.title || title || "").replace(/"/g, '\\"')}"`,
 			metadata.description ? `description: "${metadata.description.replace(/"/g, '\\"')}"` : null,
-			metadata.keywords ? `keywords: "${metadata.keywords}"` : null,
+			metadata.keywords ? `keywords: "${metadata.keywords.replace(/"/g, '\\"')}"` : null,
 			hash ? `hash: "${hash}"` : null,
 			`crawledAt: ${pageCrawledAt}`,
 			`depth: ${depth}`,

--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -357,4 +357,96 @@ describe("OutputWriter", () => {
 			expect(pageFile).toBe("pages/page-001-english123.md");
 		});
 	});
+
+	describe("YAML frontmatter escaping", () => {
+		it("should escape double quotes in keywords field", () => {
+			const writer = new OutputWriter(defaultConfig);
+			const metadataWithQuotes: PageMetadata = {
+				...defaultMetadata,
+				keywords: 'test, "quoted keyword", another',
+			};
+
+			const pageFile = writer.savePage(
+				"https://example.com/page1",
+				"# Content",
+				1,
+				[],
+				metadataWithQuotes,
+				"Test",
+			);
+
+			const pagePath = join(testOutputDir, pageFile);
+			const content = readFileSync(pagePath, "utf-8");
+
+			// Verify escaped quotes in keywords
+			expect(content).toMatch(/keywords: "test, \\"quoted keyword\\", another"/);
+		});
+
+		it("should escape double quotes in title field", () => {
+			const writer = new OutputWriter(defaultConfig);
+			const metadataWithQuotes: PageMetadata = {
+				...defaultMetadata,
+				title: 'Test "quoted" title',
+			};
+
+			const pageFile = writer.savePage(
+				"https://example.com/page1",
+				"# Content",
+				1,
+				[],
+				metadataWithQuotes,
+				null,
+			);
+
+			const pagePath = join(testOutputDir, pageFile);
+			const content = readFileSync(pagePath, "utf-8");
+
+			expect(content).toMatch(/title: "Test \\"quoted\\" title"/);
+		});
+
+		it("should escape double quotes in description field", () => {
+			const writer = new OutputWriter(defaultConfig);
+			const metadataWithQuotes: PageMetadata = {
+				...defaultMetadata,
+				description: 'Description with "quotes"',
+			};
+
+			const pageFile = writer.savePage(
+				"https://example.com/page1",
+				"# Content",
+				1,
+				[],
+				metadataWithQuotes,
+				"Test",
+			);
+
+			const pagePath = join(testOutputDir, pageFile);
+			const content = readFileSync(pagePath, "utf-8");
+
+			expect(content).toMatch(/description: "Description with \\"quotes\\""/);
+		});
+
+		it("should handle keywords without quotes", () => {
+			const writer = new OutputWriter(defaultConfig);
+			const metadataWithoutQuotes: PageMetadata = {
+				...defaultMetadata,
+				keywords: "test, keyword, another",
+			};
+
+			const pageFile = writer.savePage(
+				"https://example.com/page1",
+				"# Content",
+				1,
+				[],
+				metadataWithoutQuotes,
+				"Test",
+			);
+
+			const pagePath = join(testOutputDir, pageFile);
+			const content = readFileSync(pagePath, "utf-8");
+
+			// Verify keywords remain unchanged
+			expect(content).toMatch(/keywords: "test, keyword, another"/);
+		});
+	});
 });


### PR DESCRIPTION
## Summary
Closes #507

## Changes
- Added double quote escaping to the `keywords` field in YAML frontmatter generation
- Applied the same `.replace(/"/g, '\"')` pattern used for `title` and `description` fields
- Prevents YAML syntax errors when keywords contain double quotes

## Testing
- Added 4 comprehensive test cases for YAML frontmatter escaping:
  - Keywords with double quotes
  - Title with double quotes (regression test)
  - Description with double quotes (regression test)
  - Keywords without quotes (edge case)
- All 451 tests passed successfully

## Impact
- Fixes YAML frontmatter injection vulnerability
- No breaking changes
- Consistent with existing security practices