### PR TITLE
fix: リンクパーサーが tel:, ftp:, data: URI をフィルタしていない

### DIFF
--- a/link-crawler/src/parser/links.ts
+++ b/link-crawler/src/parser/links.ts
@@ -49,7 +49,12 @@ export function extractLinks(dom: JSDOM, visited: Set<string>, config: CrawlConf
 			!href ||
 			href.startsWith("#") ||
 			href.startsWith("javascript:") ||
-			href.startsWith("mailto:")
+			href.startsWith("mailto:") ||
+			href.startsWith("tel:") ||
+			href.startsWith("ftp:") ||
+			href.startsWith("data:") ||
+			href.startsWith("blob:") ||
+			href.startsWith("file:")
 		) {
 			continue;
 		}

--- a/link-crawler/tests/unit/links.test.ts
+++ b/link-crawler/tests/unit/links.test.ts
@@ -305,6 +305,91 @@ describe("extractLinks", () => {
 		expect(links[0]).toBe("https://example.com/page");
 	});
 
+	it("should exclude tel: links", () => {
+		const html = `
+			<html>
+				<body>
+					<a href="tel:+1234567890">Phone</a>
+					<a href="/page">Page</a>
+				</body>
+			</html>
+		`;
+		const visited = new Set<string>();
+		const dom = new JSDOM(html, { url: "https://example.com" });
+		const links = extractLinks(dom, visited, baseConfig);
+
+		expect(links).toHaveLength(1);
+		expect(links[0]).toBe("https://example.com/page");
+	});
+
+	it("should exclude ftp: links", () => {
+		const html = `
+			<html>
+				<body>
+					<a href="ftp://ftp.example.com/file">FTP</a>
+					<a href="/page">Page</a>
+				</body>
+			</html>
+		`;
+		const visited = new Set<string>();
+		const dom = new JSDOM(html, { url: "https://example.com" });
+		const links = extractLinks(dom, visited, baseConfig);
+
+		expect(links).toHaveLength(1);
+		expect(links[0]).toBe("https://example.com/page");
+	});
+
+	it("should exclude data: URIs", () => {
+		const html = `
+			<html>
+				<body>
+					<a href="data:text/plain;base64,SGVsbG8gV29ybGQ=">Data</a>
+					<a href="/page">Page</a>
+				</body>
+			</html>
+		`;
+		const visited = new Set<string>();
+		const dom = new JSDOM(html, { url: "https://example.com" });
+		const links = extractLinks(dom, visited, baseConfig);
+
+		expect(links).toHaveLength(1);
+		expect(links[0]).toBe("https://example.com/page");
+	});
+
+	it("should exclude blob: URIs", () => {
+		const html = `
+			<html>
+				<body>
+					<a href="blob:https://example.com/uuid">Blob</a>
+					<a href="/page">Page</a>
+				</body>
+			</html>
+		`;
+		const visited = new Set<string>();
+		const dom = new JSDOM(html, { url: "https://example.com" });
+		const links = extractLinks(dom, visited, baseConfig);
+
+		expect(links).toHaveLength(1);
+		expect(links[0]).toBe("https://example.com/page");
+	});
+
+	it("should exclude file: URIs", () => {
+		const html = `
+			<html>
+				<body>
+					<a href="file:///path/to/file">File</a>
+					<a href="/page">Page</a>
+				</body>
+			</html>
+		`;
+		const visited = new Set<string>();
+		const dom = new JSDOM(html, { url: "https://example.com" });
+		const links = extractLinks(dom, visited, baseConfig);
+
+		expect(links).toHaveLength(1);
+		expect(links[0]).toBe("https://example.com/page");
+	});
+
 	it("should exclude visited links", () => {
 		const html = `
 			<html>


### PR DESCRIPTION
## Summary
Closes #515

## Changes
- `tel:`, `ftp:`, `data:`, `blob:`, `file:` プロトコルをフィルタリングに追加
- 各プロトコルの除外テストを5つ追加
- 既存のテストは全て維持され、パスを確認済み

## Testing
- ✅ 452 tests passed (including 5 new tests)
- ✅ 各プロトコル（tel:, ftp:, data:, blob:, file:）がフィルタされることを確認
- ✅ 既存の機能への影響なし

## Details
`src/parser/links.ts` の `extractLinks` 関数で、HTTP/HTTPS以外のプロトコルスキームを持つリンクを除外するようにしました。これにより、tel:（電話番号）、ftp:（FTPプロトコル）、data:（インラインデータ）、blob:（Blobオブジェクト）、file:（ローカルファイル）のリンクがクロール対象から除外され、不要なフェッチ試行とエラーログが削減されます。