### PR TITLE
fix: 差分クロール時に削除されたページをindex.jsonから除外

### DIFF
--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -70,6 +70,11 @@ export class Crawler {
 			await this.fetcher?.close?.();
 		}
 
+		// 差分モード時: 訪問済みURLを渡す
+		if (this.config.diff) {
+			this.writer.setVisitedUrls(this.visited);
+		}
+
 		const indexPath = this.writer.saveIndex();
 		const result = this.writer.getResult();
 

--- a/link-crawler/src/output/writer.ts
+++ b/link-crawler/src/output/writer.ts
@@ -158,4 +158,9 @@ export class OutputWriter {
 	getIndexManager(): IndexManager {
 		return this.indexManager;
 	}
+
+	/** 訪問済みURLを設定（差分クロール時のマージ範囲制限用） */
+	setVisitedUrls(urls: Set<string>): void {
+		this.indexManager.setVisitedUrls(urls);
+	}
 }


### PR DESCRIPTION
## Summary
Closes #551

## Changes
- IndexManagerに訪問済みURL情報を設定する機能を追加
- mergeExistingPages()で訪問されたページのみマージするよう変更
- Crawlerから訪問済みURLをOutputWriterに渡すよう変更
- 差分クロール時の動作テストを追加

## Implementation
差分クロール時、Crawlerが訪問したURLのSetをIndexManagerに渡すことで、削除されたページや範囲外になったページを自動的に除外します。

### Before
- 全ての既存ページがマージされる
- 削除されたページが永久に残る

### After  
- 訪問されたページのみマージされる
- 削除されたページは自動的に除外される

## Testing
- 差分クロール時の動作テストを3つ追加
- 全てのテストがパス (30/30)

## Backward Compatibility
訪問済みURLが設定されていない場合は既存の動作を維持します。