### PR TITLE
fix: HTTPステータスコード200以外の正常レスポンスを受け入れる

### DIFF
--- a/link-crawler/src/crawler/fetcher.ts
+++ b/link-crawler/src/crawler/fetcher.ts
@@ -110,8 +110,8 @@ export class PlaywrightFetcher implements Fetcher {
 
 		// HTTPメタデータ（ステータスコード・content-type）を取得
 		const { statusCode, contentType } = await this.getHttpMetadata();
-		if (statusCode !== null && statusCode !== 200) {
-			// 200以外はスキップ
+		if (statusCode !== null && (statusCode < 200 || statusCode >= 300)) {
+			// 2xx以外はスキップ
 			return null;
 		}
 

--- a/link-crawler/tests/unit/fetcher.test.ts
+++ b/link-crawler/tests/unit/fetcher.test.ts
@@ -1144,6 +1144,212 @@ describe("PlaywrightFetcher", () => {
 			expect(result).toBeNull();
 		});
 
+		it("should fetch pages with 201 Created status code", async () => {
+			const config = createMockConfig();
+			const mockRuntime = createMockRuntime();
+			let callCount = 0;
+			mockRuntime.spawn = vi.fn().mockImplementation(() => {
+				callCount++;
+				if (callCount === 1) {
+					// checkPlaywrightCli
+					return Promise.resolve({
+						success: true,
+						stdout: "1.0.0",
+						stderr: "",
+						exitCode: 0,
+					} as SpawnResult);
+				}
+				if (callCount === 2) {
+					// open command
+					return Promise.resolve({
+						success: true,
+						stdout: "",
+						stderr: "",
+						exitCode: 0,
+					} as SpawnResult);
+				}
+				if (callCount === 3) {
+					// network command
+					return Promise.resolve({
+						success: true,
+						stdout: "[Network](../path/to/network.log)",
+						stderr: "",
+						exitCode: 0,
+					} as SpawnResult);
+				}
+				// eval command
+				return Promise.resolve({
+					success: true,
+					stdout: '### Result\n"<html>Created</html>"\n### Ran Playwright code',
+					stderr: "",
+					exitCode: 0,
+				} as SpawnResult);
+			});
+			mockRuntime.sleep = vi.fn().mockResolvedValue(undefined);
+			mockRuntime.readFile = vi.fn().mockResolvedValue("status: 201\ncontent-type: text/html");
+			mockExistsSync.mockReturnValue(true);
+
+			const fetcher = new PlaywrightFetcher(config, mockRuntime);
+			const result = await fetcher.fetch("https://example.com/created");
+
+			expect(result).not.toBeNull();
+			expect(result?.html).toBe("<html>Created</html>");
+		});
+
+		it("should fetch pages with 204 No Content status code", async () => {
+			const config = createMockConfig();
+			const mockRuntime = createMockRuntime();
+			let callCount = 0;
+			mockRuntime.spawn = vi.fn().mockImplementation(() => {
+				callCount++;
+				if (callCount === 1) {
+					// checkPlaywrightCli
+					return Promise.resolve({
+						success: true,
+						stdout: "1.0.0",
+						stderr: "",
+						exitCode: 0,
+					} as SpawnResult);
+				}
+				if (callCount === 2) {
+					// open command
+					return Promise.resolve({
+						success: true,
+						stdout: "",
+						stderr: "",
+						exitCode: 0,
+					} as SpawnResult);
+				}
+				if (callCount === 3) {
+					// network command
+					return Promise.resolve({
+						success: true,
+						stdout: "[Network](../path/to/network.log)",
+						stderr: "",
+						exitCode: 0,
+					} as SpawnResult);
+				}
+				// eval command
+				return Promise.resolve({
+					success: true,
+					stdout: '### Result\n""\n### Ran Playwright code',
+					stderr: "",
+					exitCode: 0,
+				} as SpawnResult);
+			});
+			mockRuntime.sleep = vi.fn().mockResolvedValue(undefined);
+			mockRuntime.readFile = vi.fn().mockResolvedValue("status: 204\ncontent-type: text/html");
+			mockExistsSync.mockReturnValue(true);
+
+			const fetcher = new PlaywrightFetcher(config, mockRuntime);
+			const result = await fetcher.fetch("https://example.com/nocontent");
+
+			expect(result).not.toBeNull();
+			expect(result?.html).toBe("");
+		});
+
+		it("should fetch pages with 206 Partial Content status code", async () => {
+			const config = createMockConfig();
+			const mockRuntime = createMockRuntime();
+			let callCount = 0;
+			mockRuntime.spawn = vi.fn().mockImplementation(() => {
+				callCount++;
+				if (callCount === 1) {
+					// checkPlaywrightCli
+					return Promise.resolve({
+						success: true,
+						stdout: "1.0.0",
+						stderr: "",
+						exitCode: 0,
+					} as SpawnResult);
+				}
+				if (callCount === 2) {
+					// open command
+					return Promise.resolve({
+						success: true,
+						stdout: "",
+						stderr: "",
+						exitCode: 0,
+					} as SpawnResult);
+				}
+				if (callCount === 3) {
+					// network command
+					return Promise.resolve({
+						success: true,
+						stdout: "[Network](../path/to/network.log)",
+						stderr: "",
+						exitCode: 0,
+					} as SpawnResult);
+				}
+				// eval command
+				return Promise.resolve({
+					success: true,
+					stdout: '### Result\n"<html>Partial</html>"\n### Ran Playwright code',
+					stderr: "",
+					exitCode: 0,
+				} as SpawnResult);
+			});
+			mockRuntime.sleep = vi.fn().mockResolvedValue(undefined);
+			mockRuntime.readFile = vi.fn().mockResolvedValue("status: 206\ncontent-type: text/html");
+			mockExistsSync.mockReturnValue(true);
+
+			const fetcher = new PlaywrightFetcher(config, mockRuntime);
+			const result = await fetcher.fetch("https://example.com/partial");
+
+			expect(result).not.toBeNull();
+			expect(result?.html).toBe("<html>Partial</html>");
+		});
+
+		it("should skip pages with 301 Moved Permanently status code", async () => {
+			const config = createMockConfig();
+			const mockRuntime = createMockRuntime();
+			let callCount = 0;
+			mockRuntime.spawn = vi.fn().mockImplementation(() => {
+				callCount++;
+				if (callCount === 1) {
+					// checkPlaywrightCli
+					return Promise.resolve({
+						success: true,
+						stdout: "1.0.0",
+						stderr: "",
+						exitCode: 0,
+					} as SpawnResult);
+				}
+				if (callCount === 2) {
+					// open command
+					return Promise.resolve({
+						success: true,
+						stdout: "",
+						stderr: "",
+						exitCode: 0,
+					} as SpawnResult);
+				}
+				if (callCount === 3) {
+					// network command
+					return Promise.resolve({
+						success: true,
+						stdout: "[Network](../path/to/network.log)",
+						stderr: "",
+						exitCode: 0,
+					} as SpawnResult);
+				}
+				return Promise.resolve({
+					success: true,
+					stdout: "",
+					stderr: "",
+					exitCode: 0,
+				} as SpawnResult);
+			});
+			mockRuntime.sleep = vi.fn().mockResolvedValue(undefined);
+			mockRuntime.readFile = vi.fn().mockResolvedValue("status: 301");
+			mockExistsSync.mockReturnValue(true);
+
+			const fetcher = new PlaywrightFetcher(config, mockRuntime);
+			const result = await fetcher.fetch("https://example.com/redirect");
+
+			expect(result).toBeNull();
+		});
+
 		it("should skip pages with ERR_HTTP_RESPONSE_CODE_FAILURE", async () => {
 			const config = createMockConfig();
 			const mockRuntime = createMockRuntime();


### PR DESCRIPTION
## Summary
Closes #550

## Changes
- 2xx系のステータスコード（200-299）をすべて正常なレスポンスとして処理するよう修正
- 3xx, 4xx, 5xxはスキップする既存動作を維持
- テストケースを追加（201 Created, 204 No Content, 206 Partial Content, 301 Moved Permanently）

## Modified Files
- `link-crawler/src/crawler/fetcher.ts` - ステータスコードチェック条件を変更
- `link-crawler/tests/unit/fetcher.test.ts` - テストケースを追加

## Testing
- 全469テストがパス
- 新規テスト:
  - ✅ 201 Created: 正常に処理される
  - ✅ 204 No Content: 正常に処理される
  - ✅ 206 Partial Content: 正常に処理される
  - ✅ 301 Moved Permanently: スキップされる
- 既存テスト:
  - ✅ 404 Not Found: スキップされる（既存動作維持）
  - ✅ 500 Internal Server Error: スキップされる（既存動作維持）

## Before
```typescript
if (statusCode !== null && statusCode !== 200) {
    // 200以外はスキップ
    return null;
}
```

## After
```typescript
if (statusCode !== null && (statusCode < 200 || statusCode >= 300)) {
    // 2xx以外はスキップ
    return null;
}
```