### PR TITLE
fix: 再クロール時にchunks/pages内の古いファイルを削除

### DIFF
--- a/link-crawler/src/output/chunker.ts
+++ b/link-crawler/src/output/chunker.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 /**
@@ -91,8 +91,11 @@ export class Chunker {
 			return [];
 		}
 
-		// chunksディレクトリ作成
+		// chunksディレクトリ作成（古いチャンクを削除してから）
 		const chunksDir = join(this.outputDir, "chunks");
+		if (existsSync(chunksDir)) {
+			rmSync(chunksDir, { recursive: true, force: true });
+		}
 		mkdirSync(chunksDir, { recursive: true });
 
 		const outputPaths: string[] = [];

--- a/link-crawler/src/output/writer.ts
+++ b/link-crawler/src/output/writer.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { FILENAME, SPEC_PATTERNS } from "../constants.js";
 import type { CrawlLogger } from "../crawler/logger.js";
@@ -42,9 +42,19 @@ export class OutputWriter {
 			this.logger,
 		);
 
-		// ディレクトリ作成
-		mkdirSync(join(config.outputDir, FILENAME.PAGES_DIR), { recursive: true });
-		mkdirSync(join(config.outputDir, FILENAME.SPECS_DIR), { recursive: true });
+		// ディレクトリをクリーンアップしてから作成
+		const pagesDir = join(config.outputDir, FILENAME.PAGES_DIR);
+		const specsDir = join(config.outputDir, FILENAME.SPECS_DIR);
+
+		if (existsSync(pagesDir)) {
+			rmSync(pagesDir, { recursive: true, force: true });
+		}
+		if (existsSync(specsDir)) {
+			rmSync(specsDir, { recursive: true, force: true });
+		}
+
+		mkdirSync(pagesDir, { recursive: true });
+		mkdirSync(specsDir, { recursive: true });
 	}
 
 	/** 既存ページのハッシュを取得 */


### PR DESCRIPTION
## Summary
Closes #549

## Changes
- Chunker.writeChunks() で既存chunksディレクトリを削除してから再作成
- OutputWriter コンストラクタで pages/specs ディレクトリをクリーンアップ
- chunker.test.ts に古いファイル削除のテストを追加

## Testing
- 新規テスト追加: 古いチャンクファイルが再書き込み時に削除されることを確認
- 全495テスト全てパス
- エッジケース確認: 3→2チャンクの減少、内容の更新確認

## Details
再クロール時に、以前のクロールで生成された古いファイルが残留する問題を修正しました。

### Before
1回目: 10ページ → chunk-001.md 〜 chunk-010.md 生成
2回目: 5ページ → chunk-001.md 〜 chunk-005.md 上書き
**問題**: chunk-006.md 〜 chunk-010.md が古いまま残る

### After
再クロール時にディレクトリを削除してから再作成するため、古いファイルは残りません。