### PR TITLE
fix: --depth 0 が正しく動作しない問題を修正

### DIFF
--- a/link-crawler/src/config.ts
+++ b/link-crawler/src/config.ts
@@ -25,9 +25,16 @@ export function parseConfig(options: Record<string, unknown>, startUrl: string):
 	const defaultOutputDir = `./.context/${generateSiteName(startUrl)}`;
 	const outputDir = String(options.output || defaultOutputDir);
 
+	// Parse depth value safely (handle 0 correctly)
+	const depthValue = Number(options.depth);
+	const maxDepth = Math.min(
+		Number.isNaN(depthValue) ? DEFAULTS.MAX_DEPTH : depthValue,
+		DEFAULTS.MAX_DEPTH_LIMIT,
+	);
+
 	const config: CrawlConfig = {
 		startUrl,
-		maxDepth: Math.min(Number(options.depth) || DEFAULTS.MAX_DEPTH, DEFAULTS.MAX_DEPTH_LIMIT),
+		maxDepth,
 		outputDir,
 		sameDomain: options.sameDomain !== false,
 		includePattern: parsePattern(options.include as string | undefined, "include"),

--- a/link-crawler/tests/unit/config.test.ts
+++ b/link-crawler/tests/unit/config.test.ts
@@ -45,6 +45,18 @@ describe("parseConfig", () => {
 		expect(config.maxDepth).toBe(10);
 	});
 
+	it("should handle depth 0 correctly", () => {
+		const config = parseConfig({ depth: 0 }, "https://example.com");
+
+		expect(config.maxDepth).toBe(0);
+	});
+
+	it("should handle depth as string '0' correctly", () => {
+		const config = parseConfig({ depth: "0" }, "https://example.com");
+
+		expect(config.maxDepth).toBe(0);
+	});
+
 	it("should parse include/exclude patterns", () => {
 		const config = parseConfig(
 			{


### PR DESCRIPTION
## Summary
Closes #548

## Changes
- `config.ts` で `||` 演算子を使用していたため、`Number(0)` が falsy として扱われデフォルト値に置き換えられていた
- `Number.isNaN()` を使用した安全な実装に変更
- depth 0 および文字列 '0' の処理に対するテストケースを追加

## Testing
- ✅ 全ての単体テスト (496 tests) がパス
- ✅ depth 0 の新しいテストケースを追加
- ✅ 既存のテストに影響なし