### PR TITLE
fix(lint): extractor.ts の非nullアサーション警告を解消

### DIFF
--- a/link-crawler/src/parser/extractor.ts
+++ b/link-crawler/src/parser/extractor.ts
@@ -140,7 +140,8 @@ function extractAndPreserveCodeBlocks(doc: Document): {
 
 	// コンテンツにコードブロックが含まれていない場合、収集したものを追加
 	if (content && codeBlocks.length > 0) {
-		const hasCodeBlock = CODE_BLOCK_HTML_PATTERNS.some((pattern) => pattern.test(content!));
+		const currentContent = content;
+		const hasCodeBlock = CODE_BLOCK_HTML_PATTERNS.some((pattern) => pattern.test(currentContent));
 		if (!hasCodeBlock) {
 			content = `${codeBlocks.join("\n")}\n${content}`;
 		}


### PR DESCRIPTION
## Summary
Closes #559

## Changes
-  の143行目にあった非nullアサーション () を除去
- TypeScriptの型推論が効かないコンテキストでは、一時変数  を使用することで型を明示的に捉える
- コードの動作は変更なし

## Testing
- ✅  - 警告0件
- ✅ 
[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/Users/kawasakiisao/Desktop/ai/dict-skills/.worktrees/issue-559-fix-lint-extractor-ts-null[39m

 [32m✓[39m link-crawler/tests/unit/extractor.test.ts [2m([22m[2m81 tests[22m[2m)[22m[33m 7443[2mms[22m[39m
     [33m[2m✓[22m[39m should extract title from title tag [33m 880[2mms[22m[39m
     [33m[2m✓[22m[39m should extract content using Readability [33m 413[2mms[22m[39m
     [33m[2m✓[22m[39m should remove style tags in fallback mode [33m 444[2mms[22m[39m
     [33m[2m✓[22m[39m should handle HTML without readable content [33m 397[2mms[22m[39m
     [33m[2m✓[22m[39m should preserve standard pre/code blocks [33m 348[2mms[22m[39m
     [33m[2m✓[22m[39m should preserve shiki code blocks [33m 336[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m81 passed[39m[22m[90m (81)[39m
[2m   Start at [22m 16:16:41
[2m   Duration [22m 9.16s[2m (transform 375ms, setup 0ms, import 1.41s, tests 7.44s, environment 0ms)[22m - 全81テストパス
- ✅ 機能的な変更なし（既存の動作を維持）

## Details
修正前:
```typescript
const hasCodeBlock = CODE_BLOCK_HTML_PATTERNS.some((pattern) => pattern.test(content!));
```

修正後:
```typescript
const currentContent = content;
const hasCodeBlock = CODE_BLOCK_HTML_PATTERNS.some((pattern) => pattern.test(currentContent));
```

この修正により、Biomeの  ルール違反を解消しました。