### PR TITLE
fix(docs): 設計書のHTTPステータスコード判定ロジックがコードと不一致

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -524,8 +524,8 @@ class PlaywrightFetcher implements Fetcher {
 
     // HTTPメタデータ（ステータスコード・content-type）を取得
     const { statusCode, contentType } = await this.getHttpMetadata();
-    if (statusCode !== null && statusCode !== 200) {
-      // 200以外はスキップ
+    if (statusCode !== null && (statusCode < 200 || statusCode >= 300)) {
+      // 2xx範囲外はスキップ
       return null;
     }
 
@@ -610,7 +610,7 @@ class PlaywrightFetcher implements Fetcher {
 **実装の主な特徴：**
 - `runtime.spawn()` によるコマンド実行（stdout/stderrを分離取得）
 - タイムアウト処理（`Promise.race` による競合）
-- HTTPステータスコード確認（200以外をスキップ）
+- HTTPステータスコード確認（2xx範囲外をスキップ）
 - エラーページ検出（chrome-error://をスキップ）
 - セッション後のクリーンアップ（`.playwright-cli` ディレクトリ削除）
 


### PR DESCRIPTION
## Summary
Closes #558

## Changes
設計書（`docs/design.md`）のHTTPステータスコード判定ロジックを実装コードと一致させる修正。

### 修正内容
- **Before**: `statusCode !== 200` (200のみ許可)
- **After**: `statusCode < 200 || statusCode >= 300` (2xx範囲を許可)

### 修正箇所
1. §6.2 PlaywrightFetcher 実装例内のステータスコード判定 (line 527)
2. 同セクションのコメント「200以外はスキップ」→「2xx範囲外はスキップ」(line 528)
3. 実装の主な特徴の説明文 (line 613)

### 理由
実装コード（`link-crawler/src/crawler/fetcher.ts`）では201 Created、204 No Content等の2xxレスポンスも正常として処理している。設計書が古いままになっていたため、実装と一致させる。

## Testing
- ✅ 設計書と実装コードの整合性を確認
- ✅ 全ての「200以外」「statusCode !== 200」の記載を更新済み
- ✅ ドキュメント変更のため、コード実行に影響なし