### PR TITLE
fix: preserve pages/ and specs/ directories in diff mode

### DIFF
--- a/link-crawler/src/output/writer.ts
+++ b/link-crawler/src/output/writer.ts
@@ -42,14 +42,14 @@ export class OutputWriter {
 			this.logger,
 		);
 
-		// ディレクトリをクリーンアップしてから作成
+		// ディレクトリをクリーンアップしてから作成（diff モードでは既存ファイルを保持）
 		const pagesDir = join(config.outputDir, FILENAME.PAGES_DIR);
 		const specsDir = join(config.outputDir, FILENAME.SPECS_DIR);
 
-		if (existsSync(pagesDir)) {
+		if (!config.diff && existsSync(pagesDir)) {
 			rmSync(pagesDir, { recursive: true, force: true });
 		}
-		if (existsSync(specsDir)) {
+		if (!config.diff && existsSync(specsDir)) {
 			rmSync(specsDir, { recursive: true, force: true });
 		}
 


### PR DESCRIPTION
## Summary

Fixes #567

Modified OutputWriter to skip directory deletion when diff mode is enabled, ensuring that existing page and spec files are preserved when they are skipped during differential crawls.

## Changes

- Modified link-crawler/src/output/writer.ts:
  - Added condition before rmSync operations to skip deletion in diff mode
  - Updated comment to document diff mode behavior
  
- Added comprehensive test coverage in link-crawler/tests/unit/writer.test.ts:
  - Test: Existing files preserved in diff mode
  - Test: Spec files preserved in diff mode
  - Test: Non-diff mode still cleans directories

## Testing

- All 500 tests pass
- Added 3 new test cases specifically for diff mode behavior
- Manual verification completed

## Impact

- Before: Diff mode deleted pages/ and specs/, causing skipped pages to lose their .md files
- After: Diff mode preserves directories and files, only updating changed pages

## Related

- Implementation plan: docs/plans/issue-567-plan.md
- Addresses bug found during project review