### PR TITLE
refactor: Unify DEBUG logging via debug flag injection

### DIFF
--- a/link-crawler/src/crawler/fetcher.ts
+++ b/link-crawler/src/crawler/fetcher.ts
@@ -37,17 +37,20 @@ export class PlaywrightFetcher implements Fetcher {
 	private playwrightPath: string = "playwright-cli";
 	private runtime: RuntimeAdapter;
 	private pathConfig: PlaywrightPathConfig;
+	private debug: boolean;
 
 	constructor(
 		private config: CrawlConfig,
 		runtime?: RuntimeAdapter,
 		pathConfig?: PlaywrightPathConfig,
+		debug?: boolean,
 	) {
 		this.runtime = runtime ?? createRuntimeAdapter();
 		this.pathConfig = pathConfig ?? {
 			nodePaths: PATHS.NODE_PATHS,
 			cliPaths: PATHS.PLAYWRIGHT_PATHS,
 		};
+		this.debug = debug ?? false;
 	}
 
 	/** Playwright CLIが利用可能かチェック */
@@ -212,7 +215,7 @@ export class PlaywrightFetcher implements Fetcher {
 					await this.runCli(["session-stop"]);
 				} catch (cleanupError) {
 					// クリーンアップエラーは無視（セッションが既に閉じている可能性）
-					if (process.env.DEBUG === "1") {
+					if (this.debug) {
 						console.log(`[DEBUG] session-stop on timeout failed: ${cleanupError}`);
 					}
 				}
@@ -234,7 +237,7 @@ export class PlaywrightFetcher implements Fetcher {
 			await this.runCli(["session-stop"]);
 		} catch (error) {
 			// セッションが既に閉じている場合は無視（デバッグログのみ）
-			if (process.env.DEBUG === "1") {
+			if (this.debug) {
 				console.log(`[DEBUG] session-stop failed (expected if already closed): ${error}`);
 			}
 		}
@@ -248,7 +251,7 @@ export class PlaywrightFetcher implements Fetcher {
 				}
 			} catch (error) {
 				// クリーンアップ失敗は無視（デバッグログのみ）
-				if (process.env.DEBUG === "1") {
+				if (this.debug) {
 					console.log(`[DEBUG] .playwright-cli cleanup failed: ${error}`);
 				}
 			}

--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -197,5 +197,6 @@ export class Crawler {
 async function createPlaywrightFetcher(config: CrawlConfig): Promise<Fetcher> {
 	// 動的インポートを使用してBun依存のモジュールを遅延ロード
 	const mod = await import("./fetcher.js");
-	return new mod.PlaywrightFetcher(config);
+	const debug = process.env.DEBUG === "1";
+	return new mod.PlaywrightFetcher(config, undefined, undefined, debug);
 }


### PR DESCRIPTION
## Summary

Fixes #566

This PR refactors the DEBUG logging implementation in `fetcher.ts` to eliminate duplication and improve maintainability.

## Problem

- `CrawlLogger` class provides `logDebug()` method that centralizes `process.env.DEBUG === "1"` checks
- However, `fetcher.ts` has 3 instances of direct `process.env.DEBUG === "1"` checks:
  - Line 215: Timeout session cleanup error
  - Line 237: session-stop failure
  - Line 251: .playwright-cli directory cleanup failure
- This violates the Single Responsibility Principle and makes future changes harder

## Solution

- Added `debug: boolean` flag to `PlaywrightFetcher` constructor (optional, defaults to false)
- Replaced 3 instances of `process.env.DEBUG === "1"` with `this.debug`
- Updated `createPlaywrightFetcher` factory to evaluate `DEBUG` env var and pass to constructor
- Maintains backward compatibility (debug is optional parameter)

## Design Choice

Why inject a boolean flag instead of `CrawlLogger` instance?
- Keeps `PlaywrightFetcher` independent of logging implementation details
- Maintains separation of concerns
- Simpler to test
- No circular dependencies

## Testing

- All 497 tests pass
- Lint checks pass
- Backward compatible (existing code continues to work)

## Changes

- `link-crawler/src/crawler/fetcher.ts`: Added debug flag field and constructor parameter, replaced 3 DEBUG checks
- `link-crawler/src/crawler/index.ts`: Updated factory to evaluate and pass DEBUG flag

## Verification

```bash
cd link-crawler
bun run test      # All tests pass
bun run check     # Lint passes
```