### PR TITLE
fix: Biome lintエラー - writer.test.ts の未使用変数 writer2

### DIFF
--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -540,7 +540,7 @@ describe("OutputWriter", () => {
 			expect(readFileSync(pagePath, "utf-8")).toContain("# Old Content");
 
 			// 2. 2回目のクロール（非 diff モード）
-			const _writer2 = new OutputWriter({ ...defaultConfig, diff: false });
+			new OutputWriter({ ...defaultConfig, diff: false });
 
 			// ディレクトリが削除されたため、ファイルが存在しないことを確認
 			expect(() => readFileSync(pagePath, "utf-8")).toThrow();


### PR DESCRIPTION
## 概要

Biome lint で検出された未使用変数エラーを修正しました。

## 変更内容

- `link-crawler/tests/unit/writer.test.ts` (543行目)
  - `const writer2 = new OutputWriter(...)` → `new OutputWriter(...)`
  - コンストラクタの副作用（ディレクトリクリーンアップ）をテストするため、変数への代入を削除

## テスト結果

- ✅ `writer.test.ts` の全テストがパス
- ✅ 該当テストケース「should delete and recreate directories in non-diff mode」が正常に動作

## 影響範囲

- テストコードのみの変更
- プロダクションコードへの影響なし

Closes #580