### PR TITLE
docs: テストファイル一覧にconstants.testとcrawler-error-handling.testを追加

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -67,8 +67,10 @@ link-crawler/
 │   ├── unit/                    # ユニットテスト
 │   │   ├── chunker.test.ts
 │   │   ├── config.test.ts
+│   │   ├── constants.test.ts
 │   │   ├── converter.test.ts
 │   │   ├── crawler.test.ts
+│   │   ├── crawler-error-handling.test.ts
 │   │   ├── errors.test.ts
 │   │   ├── extractor.test.ts
 │   │   ├── fetcher.test.ts


### PR DESCRIPTION
## 概要

docs/development.md のテストファイル一覧を実ファイルと一致させるため、不足していた2つのテストファイルを追加しました。

## 変更内容

- `tests/unit/constants.test.ts` を追加
- `tests/unit/crawler-error-handling.test.ts` を追加

## 検証

```bash
# 実ファイルとドキュメントの一覧が一致することを確認
ls link-crawler/tests/unit/*.test.ts link-crawler/tests/integration/*.test.ts | xargs -n1 basename | sort
```

Closes #615