### PR TITLE
fix: extractor.ts のデッドコードを修正し、フォールバックパスのコードブロック保護を正しく動作させる

### DIFF
--- a/link-crawler/src/parser/extractor.ts
+++ b/link-crawler/src/parser/extractor.ts
@@ -67,9 +67,11 @@ function protectCodeBlocks(doc: Document): Map<string, string> {
 			placeholder.setAttribute("data-codeblock-id", markerId);
 			placeholder.setAttribute("data-codeblock-placeholder", "true");
 			placeholder.textContent = marker;
+
+			// 元の要素を記録してから置換（ネスト検出のため）
+			processedElements.add(el);
 			el.replaceWith(placeholder);
 
-			processedElements.add(placeholder);
 			index++;
 		}
 	}


### PR DESCRIPTION
Closes #611

## 変更内容

`src/parser/extractor.ts` の `protectCodeBlocks` 関数で、`processedElements` に追加する要素を修正しました。

### 問題
- `processedElements.add(placeholder)` していたため、後続の `processedElements.has(el)` や `processedElements.has(parent)` が常に false を返していました
- これにより、ネストされたコードブロックの検出が機能していませんでした

### 修正
- `processedElements.add(el)` を `el.replaceWith(placeholder)` の前に移動
- placeholder ではなく、元の要素 `el` を Set に追加するように変更

### 影響
- ネストされたコードブロックが正しくスキップされるようになります
- 全 522 テストがパス ✓
- デッドコードの修正により、コードの意図が明確になります

## テスト結果
```
 Test Files  19 passed (19)
      Tests  522 passed (522)
   Duration  10.74s
```

## 関連ドキュメント
- 詳細分析: docs/findings/issue-581-unreachable-code.md
- 実装計画: docs/plans/issue-611-plan.md