### PR TITLE
feat: add --max-pages option for safe crawl limits

### DIFF
--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -19,6 +19,7 @@ crawl <url> [options]
 | オプション | 短縮 | デフォルト | 説明 |
 |-----------|------|-----------|------|
 | `--depth <num>` | `-d` | `1` | 最大クロール深度（上限10） |
+| `--max-pages <num>` | | `無制限` | 最大クロールページ数（0=無制限） |
 | `--delay <ms>` | | `500` | リクエスト間隔（ミリ秒） |
 | `--timeout <sec>` | | `30` | リクエストタイムアウト（秒） |
 | `--wait <ms>` | | `2000` | ページレンダリング待機時間（ミリ秒） |
@@ -117,6 +118,12 @@ crawl https://slow-site.example.com --wait 5000
 
 # サーバー負荷軽減のためリクエスト間隔延長
 crawl https://docs.example.com --delay 2000
+
+# 最大100ページまでクロール
+crawl https://docs.example.com --max-pages 100
+
+# 深度は大きくてもページ数で制限
+crawl https://docs.example.com -d 10 --max-pages 50
 ```
 
 ---

--- a/link-crawler/src/config.ts
+++ b/link-crawler/src/config.ts
@@ -39,9 +39,15 @@ export function parseConfig(options: Record<string, unknown>, startUrl: string):
 		Math.min(Number.isNaN(depthValue) ? DEFAULTS.MAX_DEPTH : depthValue, DEFAULTS.MAX_DEPTH_LIMIT),
 	);
 
+	// Parse maxPages value safely (0 or negative = unlimited)
+	const maxPagesValue = Number(options.maxPages);
+	const maxPages =
+		Number.isNaN(maxPagesValue) || maxPagesValue <= 0 ? null : Math.floor(maxPagesValue);
+
 	const config: CrawlConfig = {
 		startUrl,
 		maxDepth,
+		maxPages,
 		outputDir,
 		sameDomain: options.sameDomain !== false,
 		includePattern: parsePattern(options.include as string | undefined, "include"),

--- a/link-crawler/src/constants.ts
+++ b/link-crawler/src/constants.ts
@@ -4,6 +4,8 @@ export const DEFAULTS = {
 	MAX_DEPTH: 1,
 	/** 最大深度上限 */
 	MAX_DEPTH_LIMIT: 10,
+	/** 最大クロールページ数（nullは無制限） */
+	MAX_PAGES_DEFAULT: null,
 	/** 出力ディレクトリ */
 	OUTPUT_DIR: "./.context",
 	/** リクエスト間の遅延(ms) */

--- a/link-crawler/src/crawl.ts
+++ b/link-crawler/src/crawl.ts
@@ -19,6 +19,7 @@ program
 	.description("Crawl technical documentation sites recursively")
 	.argument("<url>", "Starting URL to crawl")
 	.option("-d, --depth <num>", "Maximum crawl depth", "1")
+	.option("--max-pages <num>", "Maximum number of pages to crawl (0 = unlimited)")
 	.option("-o, --output <dir>", "Output directory (default: ./.context/<site-name>/)")
 	.option("--same-domain", "Only follow same-domain links", true)
 	.option("--no-same-domain", "Follow cross-domain links")

--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -22,6 +22,8 @@ export class Crawler {
 	/** メモリ内のページ内容 (--no-pages時に使用) */
 	private pageContents = new Map<string, string>();
 	private fetcherPromise?: Promise<Fetcher>;
+	/** 最大ページ数到達ログの重複防止 */
+	private maxPagesReachedLogged = false;
 
 	constructor(
 		private config: CrawlConfig,
@@ -87,6 +89,15 @@ export class Crawler {
 
 	/** 再帰クロール */
 	private async crawl(url: string, depth: number): Promise<void> {
+		// Check max pages limit (if set)
+		if (this.config.maxPages !== null && this.visited.size >= this.config.maxPages) {
+			if (!this.maxPagesReachedLogged) {
+				this.logger.logMaxPagesReached(this.config.maxPages);
+				this.maxPagesReachedLogged = true;
+			}
+			return;
+		}
+
 		if (depth > this.config.maxDepth || this.visited.has(url)) {
 			return;
 		}

--- a/link-crawler/src/crawler/logger.ts
+++ b/link-crawler/src/crawler/logger.ts
@@ -17,6 +17,9 @@ export class CrawlLogger {
 		console.log(`\n🕷️  Link Crawler v2.0`);
 		console.log(`   URL: ${this.config.startUrl}`);
 		console.log(`   Depth: ${this.config.maxDepth}`);
+		if (this.config.maxPages !== null) {
+			console.log(`   Max pages: ${this.config.maxPages}`);
+		}
 		console.log(`   Output: ${this.config.outputDir}`);
 		console.log(`   Mode: playwright-cli`);
 		console.log(`   Same domain only: ${this.config.sameDomain}`);
@@ -75,6 +78,11 @@ export class CrawlLogger {
 		const indent = "  ".repeat(depth);
 		console.log(`${indent}  ⏭️  Skipped (unchanged)`);
 		this.skippedCount++;
+	}
+
+	/** 最大ページ数到達ログ */
+	logMaxPagesReached(limit: number): void {
+		console.log(`\n⚠️  Max pages limit reached (${limit})`);
 	}
 
 	/** 仕様ファイル検出ログ */

--- a/link-crawler/src/types.ts
+++ b/link-crawler/src/types.ts
@@ -2,6 +2,8 @@
 export interface CrawlConfig {
 	startUrl: string;
 	maxDepth: number;
+	/** 最大クロールページ数（nullは無制限） */
+	maxPages: number | null;
 	outputDir: string;
 	sameDomain: boolean;
 	includePattern: RegExp | null;

--- a/link-crawler/tests/unit/max-pages.test.ts
+++ b/link-crawler/tests/unit/max-pages.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import { parseConfig } from "../../src/config.js";
+
+describe("--max-pages option", () => {
+	const baseUrl = "https://example.com";
+
+	test("default is null (unlimited)", () => {
+		const config = parseConfig({}, baseUrl);
+		expect(config.maxPages).toBeNull();
+	});
+
+	test("accepts positive integer", () => {
+		const config = parseConfig({ maxPages: "100" }, baseUrl);
+		expect(config.maxPages).toBe(100);
+	});
+
+	test("treats 0 as unlimited", () => {
+		const config = parseConfig({ maxPages: "0" }, baseUrl);
+		expect(config.maxPages).toBeNull();
+	});
+
+	test("treats negative as unlimited", () => {
+		const config = parseConfig({ maxPages: "-10" }, baseUrl);
+		expect(config.maxPages).toBeNull();
+	});
+
+	test("floors decimal values", () => {
+		const config = parseConfig({ maxPages: "50.7" }, baseUrl);
+		expect(config.maxPages).toBe(50);
+	});
+
+	test("treats invalid input as unlimited", () => {
+		const config = parseConfig({ maxPages: "abc" }, baseUrl);
+		expect(config.maxPages).toBeNull();
+	});
+
+	test("accepts large numbers", () => {
+		const config = parseConfig({ maxPages: "10000" }, baseUrl);
+		expect(config.maxPages).toBe(10000);
+	});
+
+	test("handles string '1'", () => {
+		const config = parseConfig({ maxPages: "1" }, baseUrl);
+		expect(config.maxPages).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary

Implements GitHub Issue #643 by adding a `--max-pages` option to limit the total number of pages crawled, preventing unintentional large-scale crawls on big documentation sites.

## Changes

- **Types**: Add `maxPages: number | null` to `CrawlConfig`
- **Constants**: Add `MAX_PAGES_DEFAULT: null` (unlimited by default)
- **Config Parser**: Parse `--max-pages` option with safe validation
- **CLI**: Add `--max-pages <num>` option
- **Crawler**: Check page limit before each crawl, log warning when reached
- **Logger**: Add `logMaxPagesReached()` method and show limit in start log
- **Tests**: Add 8 comprehensive unit tests for edge cases
- **Docs**: Update CLI spec with option description and usage examples

## Testing

✅ All 579 existing tests pass
✅ 8 new unit tests added covering:
- Default (null/unlimited)
- Positive integers
- Zero (unlimited)
- Negative (unlimited)
- Decimals (floored)
- Invalid input (unlimited)
- Edge cases

## Verification

```bash
# Test with limit
bun run link-crawler/src/crawl.ts https://example.com --max-pages 5

# Verify help text
bun run link-crawler/src/crawl.ts --help | grep max-pages
```

Closes #643