### PR TITLE
docs: Bunバージョン表記を1.0+に統一

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -29,7 +29,7 @@
 
 | カテゴリ | 技術 | バージョン | 選定理由 |
 |----------|------|-----------|----------|
-| Runtime | Bun | 1.3.x | 高速起動、TypeScriptネイティブ |
+| Runtime | Bun | 1.0+ | 高速起動、TypeScriptネイティブ |
 | Language | TypeScript | 5.8.x | 型安全性 |
 | Linter/Formatter | Biome | 2.x | 高速、設定シンプル |
 | Test Framework | Vitest | 4.x | 高速、ESM対応、Bun互換 |

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,7 +6,7 @@
 
 | ツール | バージョン | インストール |
 |--------|-----------|-------------|
-| Bun | 1.3.x 以上 | `curl -fsSL https://bun.sh/install \| bash` |
+| Bun | 1.0以上 | `curl -fsSL https://bun.sh/install \| bash` |
 | playwright-cli | latest | `npm install -g @playwright/cli` |
 
 ### 1.2 セットアップ


### PR DESCRIPTION
## 変更内容

Bunバージョン表記を実態に合わせて統一しました。

### 変更ファイル
- `docs/design.md`: 1.3.x → 1.0+
- `docs/development.md`: 1.3.x 以上 → 1.0以上

### 確認事項
- ✅ README.mdの表記と整合
- ✅ 英語セクション: "1.0+"
- ✅ 日本語セクション: "1.0以上"

Closes #651