### PR TITLE
refactor: OutputWriter の循環的依存構造を改善

### DIFF
--- a/link-crawler/src/crawler/logger.ts
+++ b/link-crawler/src/crawler/logger.ts
@@ -1,10 +1,10 @@
-import type { CrawlConfig } from "../types.js";
+import type { CrawlConfig, Logger } from "../types.js";
 
 /**
  * クロールログ出力クラス
  * ログ出力の責務を分離
  */
-export class CrawlLogger {
+export class CrawlLogger implements Logger {
 	private skippedCount = 0;
 	private debug: boolean;
 

--- a/link-crawler/src/output/index-manager.ts
+++ b/link-crawler/src/output/index-manager.ts
@@ -1,7 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import type { CrawlLogger } from "../crawler/logger.js";
-import type { CrawledPage, CrawlResult, PageMetadata } from "../types.js";
+import type { CrawledPage, CrawlResult, Logger, PageMetadata } from "../types.js";
 
 /**
  * CrawlResult型の型ガード関数
@@ -33,7 +32,7 @@ export class IndexManager {
 		private outputDir: string,
 		private baseUrl: string,
 		private config: { maxDepth: number; sameDomain: boolean; diff?: boolean },
-		private logger?: CrawlLogger,
+		private logger?: Logger,
 	) {
 		// 既存のindex.jsonを読み込み
 		this.loadExistingIndex();

--- a/link-crawler/src/output/writer.ts
+++ b/link-crawler/src/output/writer.ts
@@ -1,9 +1,8 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { FILENAME, SPEC_PATTERNS } from "../constants.js";
-import type { CrawlLogger } from "../crawler/logger.js";
 import { computeHash } from "../diff/hasher.js";
-import type { CrawlConfig, CrawledPage, PageMetadata } from "../types.js";
+import type { CrawlConfig, CrawledPage, Logger, PageMetadata } from "../types.js";
 import { IndexManager } from "./index-manager.js";
 
 /** 文字列をslug形式に変換（小文字化、スペース→ハイフン、特殊文字除去） */
@@ -29,7 +28,7 @@ export class OutputWriter {
 
 	constructor(
 		private config: CrawlConfig,
-		private logger?: CrawlLogger,
+		private logger?: Logger,
 	) {
 		this.indexManager = new IndexManager(
 			config.outputDir,

--- a/link-crawler/src/types.ts
+++ b/link-crawler/src/types.ts
@@ -73,3 +73,10 @@ export interface Fetcher {
 	fetch(url: string): Promise<FetchResult | null>;
 	close?(): Promise<void>;
 }
+
+/** ロガーインターフェース（output モジュールが依存） */
+export interface Logger {
+	logIndexFormatError(path: string): void;
+	logIndexLoadError(error: string): void;
+	logDebug(message: string, data?: unknown): void;
+}


### PR DESCRIPTION
## Summary
Closes #653

## Changes
- Add Logger interface to types.ts for output module dependencies
- Update OutputWriter and IndexManager to depend on Logger interface instead of CrawlLogger
- Make CrawlLogger explicitly implement Logger interface
- Remove reverse dependency from output/ to crawler/

## Architecture Improvements
- **Dependency Inversion Principle (DIP)**: output module now depends on abstraction (Logger) instead of concrete implementation (CrawlLogger)
- **Module Independence**: output/ module is now independent of crawler/ module
- **Improved Testability**: output module can be tested independently with mock loggers

## Testing
- ✅ All 571 unit/integration tests passed
- ✅ Type check passed
- ✅ Lint check passed
- ✅ No regressions introduced

## Files Changed
- `link-crawler/src/types.ts` - Added Logger interface (3 methods)
- `link-crawler/src/output/writer.ts` - Updated to use Logger interface
- `link-crawler/src/output/index-manager.ts` - Updated to use Logger interface
- `link-crawler/src/crawler/logger.ts` - Implements Logger interface

## Impact
- Net +5 lines (Logger interface definition)
- No breaking changes
- All existing functionality preserved