### PR TITLE
fix: robots.txt パーサーがワイルドカード(*) と終端($) パターンに未対応

### DIFF
--- a/link-crawler/tests/unit/robots.test.ts
+++ b/link-crawler/tests/unit/robots.test.ts
@@ -222,4 +222,181 @@ Allow: /api/
 			expect(checker.isAllowed("https://docs.example.com/admin/")).toBe(false);
 		});
 	});
+
+	describe("Wildcard and end-of-line patterns", () => {
+		describe("Wildcard (*) patterns", () => {
+			it("should match wildcard at the end", () => {
+				const robotsTxt = `
+User-agent: *
+Disallow: /search*
+				`.trim();
+
+				const checker = new RobotsChecker(robotsTxt);
+				expect(checker.isAllowed("https://example.com/search")).toBe(false);
+				expect(checker.isAllowed("https://example.com/searching")).toBe(false);
+				expect(checker.isAllowed("https://example.com/search?q=test")).toBe(false);
+				expect(checker.isAllowed("https://example.com/other")).toBe(true);
+			});
+
+			it("should match wildcard in the middle", () => {
+				const robotsTxt = `
+User-agent: *
+Allow: /search*results
+				`.trim();
+
+				const checker = new RobotsChecker(robotsTxt);
+				expect(checker.isAllowed("https://example.com/searchresults")).toBe(true);
+				expect(checker.isAllowed("https://example.com/search123results")).toBe(true);
+				expect(checker.isAllowed("https://example.com/searchxyzresults")).toBe(true);
+				expect(checker.isAllowed("https://example.com/search")).toBe(true); // default allow
+			});
+
+			it("should match multiple wildcards", () => {
+				const robotsTxt = `
+User-agent: *
+Disallow: /*/admin/*
+				`.trim();
+
+				const checker = new RobotsChecker(robotsTxt);
+				expect(checker.isAllowed("https://example.com/site/admin/panel")).toBe(false);
+				expect(checker.isAllowed("https://example.com/app/admin/users")).toBe(false);
+				expect(checker.isAllowed("https://example.com/admin/")).toBe(true);
+			});
+
+			it("should handle wildcard at the beginning", () => {
+				const robotsTxt = `
+User-agent: *
+Disallow: */private
+				`.trim();
+
+				const checker = new RobotsChecker(robotsTxt);
+				expect(checker.isAllowed("https://example.com/private")).toBe(false);
+				expect(checker.isAllowed("https://example.com/docs/private")).toBe(false);
+				expect(checker.isAllowed("https://example.com/public")).toBe(true);
+			});
+		});
+
+		describe("End-of-line ($) patterns", () => {
+			it("should match exact end with $", () => {
+				const robotsTxt = `
+User-agent: *
+Disallow: /*.pdf$
+				`.trim();
+
+				const checker = new RobotsChecker(robotsTxt);
+				expect(checker.isAllowed("https://example.com/doc.pdf")).toBe(false);
+				expect(checker.isAllowed("https://example.com/folder/file.pdf")).toBe(false);
+				expect(checker.isAllowed("https://example.com/doc.pdf?download=1")).toBe(true);
+				expect(checker.isAllowed("https://example.com/doc.txt")).toBe(true);
+			});
+
+			it("should match exact path with $", () => {
+				const robotsTxt = `
+User-agent: *
+Disallow: /admin$
+				`.trim();
+
+				const checker = new RobotsChecker(robotsTxt);
+				expect(checker.isAllowed("https://example.com/admin")).toBe(false);
+				expect(checker.isAllowed("https://example.com/admin/")).toBe(true);
+				expect(checker.isAllowed("https://example.com/admin/users")).toBe(true);
+				expect(checker.isAllowed("https://example.com/administrator")).toBe(true);
+			});
+
+			it("should handle end-of-line without wildcard", () => {
+				const robotsTxt = `
+User-agent: *
+Disallow: /api/v1$
+				`.trim();
+
+				const checker = new RobotsChecker(robotsTxt);
+				expect(checker.isAllowed("https://example.com/api/v1")).toBe(false);
+				expect(checker.isAllowed("https://example.com/api/v1/")).toBe(true);
+				expect(checker.isAllowed("https://example.com/api/v2")).toBe(true);
+			});
+		});
+
+		describe("Combined patterns (* and $)", () => {
+			it("should handle wildcard with end-of-line", () => {
+				const robotsTxt = `
+User-agent: *
+Disallow: /*.json$
+Disallow: /*.xml$
+				`.trim();
+
+				const checker = new RobotsChecker(robotsTxt);
+				expect(checker.isAllowed("https://example.com/api/data.json")).toBe(false);
+				expect(checker.isAllowed("https://example.com/sitemap.xml")).toBe(false);
+				expect(checker.isAllowed("https://example.com/data.json?v=1")).toBe(true);
+				expect(checker.isAllowed("https://example.com/page.html")).toBe(true);
+			});
+
+			it("should handle complex patterns", () => {
+				const robotsTxt = `
+User-agent: *
+Disallow: /*/download/*.pdf$
+				`.trim();
+
+				const checker = new RobotsChecker(robotsTxt);
+				expect(checker.isAllowed("https://example.com/docs/download/file.pdf")).toBe(false);
+				expect(checker.isAllowed("https://example.com/docs/download/file.pdf?id=1")).toBe(
+					true,
+				);
+				expect(checker.isAllowed("https://example.com/docs/download/file.txt")).toBe(true);
+			});
+		});
+
+		describe("Longest match with patterns", () => {
+			it("should prioritize more specific patterns", () => {
+				const robotsTxt = `
+User-agent: *
+Disallow: /docs*
+Allow: /docs/public*
+				`.trim();
+
+				const checker = new RobotsChecker(robotsTxt);
+				expect(checker.isAllowed("https://example.com/docs/private")).toBe(false);
+				expect(checker.isAllowed("https://example.com/docs/public")).toBe(true);
+				expect(checker.isAllowed("https://example.com/docs/public/page")).toBe(true);
+			});
+
+			it("should handle overlapping wildcard patterns", () => {
+				const robotsTxt = `
+User-agent: *
+Disallow: /*
+Allow: /*.html$
+				`.trim();
+
+				const checker = new RobotsChecker(robotsTxt);
+				expect(checker.isAllowed("https://example.com/page.html")).toBe(true);
+				expect(checker.isAllowed("https://example.com/page.html?id=1")).toBe(false);
+				expect(checker.isAllowed("https://example.com/page.php")).toBe(false);
+			});
+		});
+
+		describe("Special characters in patterns", () => {
+			it("should handle regex special characters correctly", () => {
+				const robotsTxt = `
+User-agent: *
+Disallow: /api/v1.0*
+				`.trim();
+
+				const checker = new RobotsChecker(robotsTxt);
+				expect(checker.isAllowed("https://example.com/api/v1.0")).toBe(false);
+				expect(checker.isAllowed("https://example.com/api/v1.0/users")).toBe(false);
+				expect(checker.isAllowed("https://example.com/api/v1x0")).toBe(true);
+			});
+
+			it("should handle parentheses and brackets", () => {
+				const robotsTxt = `
+User-agent: *
+Disallow: /path(test)*
+				`.trim();
+
+				const checker = new RobotsChecker(robotsTxt);
+				expect(checker.isAllowed("https://example.com/path(test)123")).toBe(false);
+				expect(checker.isAllowed("https://example.com/pathtest123")).toBe(true);
+			});
+		});
+	});
 });


### PR DESCRIPTION
## 概要

`src/crawler/robots.ts` の `RobotsChecker` にワイルドカード (`*`) と終端マーカー (`$`) パターンのサポートを追加しました。

## 変更内容

### 実装 (`src/crawler/robots.ts`)
- `matchPath()` メソッドを拡張
- `*` ワイルドカード: 任意の文字列にマッチ
  - 例: `/search*` → `/search`, `/searching`, `/search?q=test`
- `$` 終端マーカー: パスの終端にマッチ
  - 例: `/*.pdf$` → `.pdf` で終わるパスのみ
- 正規表現の特殊文字を適切にエスケープ
- パフォーマンス最適化: `*` と `$` がない場合は既存の `startsWith()` を使用

### テスト (`tests/unit/robots.test.ts`)
- 10個の新しいテストスイートを追加:
  - Wildcard patterns (4 tests)
  - End-of-line patterns (3 tests)
  - Combined patterns (2 tests)
  - Longest match priority (2 tests)
  - Special character handling (2 tests)

## テスト結果

```
Test Files  21 passed (21)
Tests       624 passed (624)
```

全てのテストがパスしています（既存テスト含む）。

## 参考

- [Google Robots.txt Specification](https://developers.google.com/search/docs/crawling-indexing/robots/robots_txt)
- [RFC 9309 - Robots Exclusion Protocol](https://www.rfc-editor.org/rfc/rfc9309.html)

Closes #663