### PR TITLE
fix: Update test mocks to include maxPages and respectRobots fields

### DIFF
--- a/link-crawler/tests/integration/crawler.test.ts
+++ b/link-crawler/tests/integration/crawler.test.ts
@@ -86,6 +86,7 @@ function createTestHtml(options: {
 const getDefaultConfig = (): CrawlConfig => ({
 	startUrl: "https://example.com",
 	maxDepth: 2,
+	maxPages: null,
 	outputDir: testOutputDir,
 	sameDomain: true,
 	includePattern: null,
@@ -99,6 +100,7 @@ const getDefaultConfig = (): CrawlConfig => ({
 	merge: true,
 	chunks: true,
 	keepSession: false,
+	respectRobots: true,
 });
 
 describe("CrawlerEngine Integration", () => {

--- a/link-crawler/tests/unit/crawler-error-handling.test.ts
+++ b/link-crawler/tests/unit/crawler-error-handling.test.ts
@@ -16,6 +16,7 @@ describe("Crawler - Error Handling", () => {
 			startUrl: "https://example.com",
 			outputDir: "/tmp/test-output",
 			maxDepth: 2,
+			maxPages: null,
 			delay: 0,
 			timeout: 5000,
 			spaWait: 100,
@@ -28,6 +29,7 @@ describe("Crawler - Error Handling", () => {
 			chunks: false,
 			headed: false,
 			keepSession: false,
+			respectRobots: true,
 		};
 
 		// Fetcherモック

--- a/link-crawler/tests/unit/crawler.test.ts
+++ b/link-crawler/tests/unit/crawler.test.ts
@@ -40,6 +40,7 @@ describe("Crawler", () => {
 		baseConfig = {
 			startUrl: "https://example.com",
 			maxDepth: 2,
+			maxPages: null,
 			outputDir: testDir,
 			sameDomain: true,
 			includePattern: null,
@@ -53,6 +54,7 @@ describe("Crawler", () => {
 			merge: false,
 			chunks: false,
 			keepSession: false,
+			respectRobots: true,
 		};
 	});
 

--- a/link-crawler/tests/unit/fetcher.test.ts
+++ b/link-crawler/tests/unit/fetcher.test.ts
@@ -18,6 +18,7 @@ const mockRmSync = fs.rmSync as ReturnType<typeof vi.fn>;
 const createMockConfig = (overrides: Partial<CrawlConfig> = {}): CrawlConfig => ({
 	startUrl: "https://example.com",
 	maxDepth: 1,
+	maxPages: null,
 	outputDir: "./output",
 	sameDomain: true,
 	includePattern: null,
@@ -31,6 +32,7 @@ const createMockConfig = (overrides: Partial<CrawlConfig> = {}): CrawlConfig => 
 	merge: true,
 	chunks: true,
 	keepSession: false,
+	respectRobots: true,
 	...overrides,
 });
 

--- a/link-crawler/tests/unit/links.test.ts
+++ b/link-crawler/tests/unit/links.test.ts
@@ -82,6 +82,7 @@ describe("shouldCrawl", () => {
 	const baseConfig: CrawlConfig = {
 		startUrl: "https://example.com",
 		maxDepth: 2,
+		maxPages: null,
 		outputDir: "./output",
 		sameDomain: true,
 		includePattern: null,
@@ -95,6 +96,7 @@ describe("shouldCrawl", () => {
 		merge: true,
 		chunks: true,
 		keepSession: false,
+		respectRobots: true,
 	};
 
 	it("should return true for unvisited URL", () => {
@@ -182,6 +184,7 @@ describe("extractLinks", () => {
 	const baseConfig: CrawlConfig = {
 		startUrl: "https://example.com",
 		maxDepth: 2,
+		maxPages: null,
 		outputDir: "./output",
 		sameDomain: true,
 		includePattern: null,
@@ -195,6 +198,7 @@ describe("extractLinks", () => {
 		merge: true,
 		chunks: true,
 		keepSession: false,
+		respectRobots: true,
 	};
 
 	it("should extract links from HTML", () => {

--- a/link-crawler/tests/unit/logger.test.ts
+++ b/link-crawler/tests/unit/logger.test.ts
@@ -13,6 +13,7 @@ describe("CrawlLogger", () => {
 		baseConfig = {
 			startUrl: "https://example.com",
 			maxDepth: 2,
+			maxPages: null,
 			outputDir: "./output",
 			sameDomain: true,
 			includePattern: null,
@@ -26,6 +27,7 @@ describe("CrawlLogger", () => {
 			merge: false,
 			chunks: false,
 			keepSession: false,
+			respectRobots: true,
 		};
 	});
 

--- a/link-crawler/tests/unit/post-processor.test.ts
+++ b/link-crawler/tests/unit/post-processor.test.ts
@@ -41,6 +41,7 @@ describe("PostProcessor", () => {
 		baseConfig = {
 			startUrl: "https://example.com",
 			maxDepth: 2,
+			maxPages: null,
 			outputDir: testOutputDir,
 			sameDomain: true,
 			includePattern: null,
@@ -54,6 +55,7 @@ describe("PostProcessor", () => {
 			merge: true,
 			chunks: true,
 			keepSession: false,
+			respectRobots: true,
 		};
 
 		// Create a mock logger

--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -9,6 +9,7 @@ const testOutputDir = "./test-output-writer";
 const defaultConfig: CrawlConfig = {
 	startUrl: "https://example.com",
 	maxDepth: 2,
+	maxPages: null,
 	outputDir: testOutputDir,
 	sameDomain: true,
 	includePattern: null,
@@ -22,6 +23,7 @@ const defaultConfig: CrawlConfig = {
 	merge: true,
 	chunks: true,
 	keepSession: false,
+	respectRobots: true,
 };
 
 const defaultMetadata: PageMetadata = {


### PR DESCRIPTION
## Summary

Fixes type check failures by adding missing `maxPages` and `respectRobots` fields to all CrawlConfig mock objects in test files.

## Changes

- Added `maxPages: null` to all test config mocks (unlimited pages)
- Added `respectRobots: true` to all test config mocks (default behavior)
- Updated 8 test files:
  - tests/integration/crawler.test.ts
  - tests/unit/crawler-error-handling.test.ts
  - tests/unit/crawler.test.ts
  - tests/unit/fetcher.test.ts
  - tests/unit/links.test.ts
  - tests/unit/logger.test.ts
  - tests/unit/post-processor.test.ts
  - tests/unit/writer.test.ts

## Test Results

✅ All 611 tests passing
✅ Type check passing
✅ Lint passing

Closes #660