### PR TITLE
test: add test cases for maxPages and respectRobots config parsing

### DIFF
--- a/link-crawler/tests/unit/config.test.ts
+++ b/link-crawler/tests/unit/config.test.ts
@@ -572,3 +572,76 @@ describe("parseConfig - URL scheme validation", () => {
 		}
 	});
 });
+
+describe("parseConfig - maxPages validation", () => {
+	it("should set maxPages to null by default (unlimited)", () => {
+		const config = parseConfig({}, "https://example.com");
+		expect(config.maxPages).toBeNull();
+	});
+
+	it("should parse positive integer maxPages", () => {
+		const config = parseConfig({ maxPages: 100 }, "https://example.com");
+		expect(config.maxPages).toBe(100);
+	});
+
+	it("should parse maxPages as string", () => {
+		const config = parseConfig({ maxPages: "50" }, "https://example.com");
+		expect(config.maxPages).toBe(50);
+	});
+
+	it("should set maxPages to null when 0 (unlimited)", () => {
+		const config = parseConfig({ maxPages: 0 }, "https://example.com");
+		expect(config.maxPages).toBeNull();
+	});
+
+	it("should set maxPages to null when negative (unlimited)", () => {
+		const config = parseConfig({ maxPages: -1 }, "https://example.com");
+		expect(config.maxPages).toBeNull();
+
+		const config2 = parseConfig({ maxPages: -100 }, "https://example.com");
+		expect(config2.maxPages).toBeNull();
+	});
+
+	it("should set maxPages to null when NaN (unlimited)", () => {
+		const config = parseConfig({ maxPages: "abc" }, "https://example.com");
+		expect(config.maxPages).toBeNull();
+
+		const config2 = parseConfig({ maxPages: "not-a-number" }, "https://example.com");
+		expect(config2.maxPages).toBeNull();
+	});
+
+	it("should floor decimal maxPages values", () => {
+		const config = parseConfig({ maxPages: 42.7 }, "https://example.com");
+		expect(config.maxPages).toBe(42);
+
+		const config2 = parseConfig({ maxPages: 99.9 }, "https://example.com");
+		expect(config2.maxPages).toBe(99);
+	});
+
+	it("should handle very large maxPages values", () => {
+		const config = parseConfig({ maxPages: 1000000 }, "https://example.com");
+		expect(config.maxPages).toBe(1000000);
+	});
+});
+
+describe("parseConfig - respectRobots validation", () => {
+	it("should set respectRobots to true by default", () => {
+		const config = parseConfig({}, "https://example.com");
+		expect(config.respectRobots).toBe(true);
+	});
+
+	it("should set respectRobots to false when robots option is false", () => {
+		const config = parseConfig({ robots: false }, "https://example.com");
+		expect(config.respectRobots).toBe(false);
+	});
+
+	it("should set respectRobots to true when robots option is true", () => {
+		const config = parseConfig({ robots: true }, "https://example.com");
+		expect(config.respectRobots).toBe(true);
+	});
+
+	it("should set respectRobots to true when robots option is undefined", () => {
+		const config = parseConfig({ robots: undefined }, "https://example.com");
+		expect(config.respectRobots).toBe(true);
+	});
+});


### PR DESCRIPTION
## 概要
config.tsのparseConfig関数に追加されたmaxPagesとrespectRobotsオプションのパース処理に対するテストケースを追加しました。

## 変更内容
- `tests/unit/config.test.ts`にmaxPages検証テストを追加（8ケース）
  - デフォルト値（null = 無制限）
  - 正の整数
  - 文字列として渡される数値
  - 0（無制限）
  - 負数（無制限）
  - NaN（無制限）
  - 小数の切り捨て
  - 非常に大きな値

- `tests/unit/config.test.ts`にrespectRobots検証テストを追加（4ケース）
  - デフォルト値（true）
  - false指定時
  - true明示指定時
  - undefined指定時

## テスト結果
- ✅ 全テストパス (638 tests)
- ✅ 型チェックエラー0件
- ✅ 既存テストへの影響なし

## 関連Issue
Closes #677