### PR TITLE
fix: TypeScript型エラー - tests/unit/crawler.test.ts:416

### DIFF
--- a/link-crawler/tests/unit/crawler.test.ts
+++ b/link-crawler/tests/unit/crawler.test.ts
@@ -413,7 +413,7 @@ info:
 
 			// fetcherPromiseを解決
 			if (resolveFetcher) {
-				resolveFetcher(mockFetcher);
+				(resolveFetcher as (value: Fetcher) => void)(mockFetcher);
 			}
 
 			// cleanup()が完了するまで待機


### PR DESCRIPTION
## 概要
`bun run typecheck` で発生していたTypeScript型エラーを修正しました。

## 🚨 致命的 (P0)

### TypeScript型エラー（crawler.test.ts:416）

**問題**:
- 行416付近で `resolveFetcher(mockFetcher)` の呼び出しが `This expression is not callable. Type 'never' has no call signatures.` エラーになっていた
- `resolveFetcher` 変数の型推論が `((value: Fetcher) => void) | null` として宣言されているが、`if (resolveFetcher)` のnullチェック後でもTypeScriptが正しく型を絞り込めていなかった

**修正内容**:
型アサーションを追加して型を明示化：
```typescript
// 修正前
if (resolveFetcher) {
    resolveFetcher(mockFetcher);
}

// 修正後
if (resolveFetcher) {
    (resolveFetcher as (value: Fetcher) => void)(mockFetcher);
}
```

**検証結果**:
- ✅ `bun run typecheck` がエラーなしで完了
- ✅ `bun run test` が全テストパス（645テスト）

## 変更内容
- `link-crawler/tests/unit/crawler.test.ts`: 型アサーションを追加（1箇所）

Closes #689