### PR TITLE
fix: Biome lint error - metadata: any in crawler/index.ts

### DIFF
--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -4,7 +4,7 @@ import { OutputWriter } from "../output/writer.js";
 import { htmlToMarkdown } from "../parser/converter.js";
 import { extractContent, extractMetadata } from "../parser/extractor.js";
 import { extractLinks } from "../parser/links.js";
-import type { CrawlConfig, Fetcher, FetchResult } from "../types.js";
+import type { CrawlConfig, Fetcher, FetchResult, PageMetadata } from "../types.js";
 import type { RuntimeAdapter } from "../utils/runtime.js";
 import { createRuntimeAdapter } from "../utils/runtime.js";
 import { CrawlLogger } from "./logger.js";
@@ -295,7 +295,7 @@ export class Crawler {
 		markdown: string,
 		depth: number,
 		links: string[],
-		metadata: any,
+		metadata: PageMetadata,
 		title: string | null,
 		hash: string,
 	): void {


### PR DESCRIPTION
## Summary

Fixes Biome lint error by replacing `any` type with proper `PageMetadata` type in the `savePage` method.

## Changes

- Added `PageMetadata` to imports from `../types.js`
- Changed `metadata: any` to `metadata: PageMetadata` in `savePage` method (line 298)

## Verification

- ✅ `bun run check` - Biome lint passed (0 errors)
- ✅ `bun run typecheck` - TypeScript type check passed
- ✅ `bun run test` - All 657 tests passed

Closes #700