### PR TITLE
fix: remove incorrect default value from --no-robots option

### DIFF
--- a/link-crawler/src/crawl.ts
+++ b/link-crawler/src/crawl.ts
@@ -34,7 +34,7 @@ program
 	.option("--no-merge", "Skip merged output file")
 	.option("--chunks", "Enable chunked output files", false)
 	.option("--keep-session", "Keep .playwright-cli directory after crawl (for debugging)", false)
-	.option("--no-robots", "Ignore robots.txt (not recommended)", false)
+	.option("--no-robots", "Ignore robots.txt (not recommended)")
 	.version(packageJson.version)
 	.parse();
 


### PR DESCRIPTION
## Summary

Fixes #699

This PR fixes a critical bug where the `--no-robots` option was incorrectly defaulting to ignoring robots.txt due to an explicit `false` default value that overrode Commander.js's `--no-` prefix mechanism.

## Changes

- Removed the `false` default value from the `--no-robots` option in `link-crawler/src/crawl.ts`

## Impact

**Before**: robots.txt was ignored by default  
**After**: robots.txt is respected by default (as documented)

## Testing

- ✅ All 657 tests pass
- ✅ Commander.js behavior verified:
  - Default: `robots = true` (respects robots.txt)
  - With `--no-robots`: `robots = false` (ignores robots.txt)

## Verification

```bash
cd link-crawler
bun run test     # All tests pass
bun run check    # Lint passes (pre-existing warning unrelated)
```

Closes #699