### PR TITLE
refactor: Merger.writeFull() が本番コードで未使用（デッドコード）

### DIFF
--- a/link-crawler/src/crawler/post-processor.ts
+++ b/link-crawler/src/crawler/post-processor.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Chunker } from "../output/chunker.js";
 import { Merger } from "../output/merger.js";
@@ -46,14 +46,8 @@ export class PostProcessor {
 		// Merger実行 (--no-merge時はスキップ)
 		if (this.config.merge) {
 			this.logger.logMergerStart();
-			
-			// メモリ上で内容を生成
-			fullMdContent = this.merger.buildFullContent(pages, contents);
-			
-			// ディスクに書き込み
-			const outputPath = join(this.config.outputDir, "full.md");
-			writeFileSync(outputPath, fullMdContent);
-			
+			const outputPath = this.merger.writeFull(pages, contents);
+			fullMdContent = readFileSync(outputPath, "utf-8"); // chunks用に読み直し
 			this.logger.logMergerComplete(outputPath);
 		} else if (this.config.chunks) {
 			// mergeなしでchunksのみの場合は、Mergerを使ってメモリから結合内容を生成


### PR DESCRIPTION
## 概要

Closes #710

`Merger.writeFull()` が本番コードから呼ばれていないデッドコードであった問題を修正しました。

## 変更内容

- **PostProcessor.process()**: `merger.buildFullContent()` + `writeFileSync()` → `merger.writeFull()` に統一
- **import文**: 不要になった `writeFileSync` を削除
- **結果**: `writeFull()` が実際に本番コードで使用されるようになりました

## 設計の明確化

この変更により、以下の責務分離が明確になります：

- **Merger**: ページ内容の結合とファイル書き込み
  - `buildFullContent()`: メモリ上で結合内容を生成（mergeなしでchunks時に使用）
  - `writeFull()`: 結合してファイルに書き込み（merge時に使用）

- **PostProcessor**: 処理のオーケストレーション
  - 設定に応じて Merger と Chunker を呼び出す
  - ファイルI/Oの直接実行は避け、各クラスのメソッドに委譲

## テスト結果

- ✅ 全699テストがパス
- ✅ 型チェックOK
- ✅ 既存の動作に影響なし

## 完了条件

- [x] PostProcessor.process() が `merger.writeFull()` を使用するように変更
- [x] 不要な `writeFileSync` import を削除
- [x] 全てのテストがパス
- [x] 設計書（docs/design.md）と実装が一致