### PR TITLE
fix(link-crawler): extract links before DOM mutation

### DIFF
--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -242,13 +242,13 @@ export class Crawler {
 			description: metadata.description?.substring(0, 100),
 		});
 
+		// リンク抽出（extractContent() が DOM を破壊的に変更する可能性があるため先に実行）
+		const links = extractLinks(dom, this.visited, this.config);
+		this.logger.logDebug("Links extracted", { linkCount: links.length, links: links.slice(0, 5) });
+
 		// コンテンツ抽出（JSDOMを渡す）
 		const { title, content } = extractContent(dom);
 		this.logger.logDebug("Content extracted", { title, contentLength: content?.length || 0 });
-
-		// リンク抽出（JSDOMを渡す）
-		const links = extractLinks(dom, this.visited, this.config);
-		this.logger.logDebug("Links extracted", { linkCount: links.length, links: links.slice(0, 5) });
 
 		// Markdown変換
 		const markdown = content ? htmlToMarkdown(content) : "";

--- a/link-crawler/tests/unit/crawler-link-extraction-order.test.ts
+++ b/link-crawler/tests/unit/crawler-link-extraction-order.test.ts
@@ -1,0 +1,124 @@
+import { existsSync } from "node:fs";
+import { mkdir, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CrawlConfig, Fetcher, FetchResult } from "../../src/types.js";
+
+// Force Readability to fail so extractContent() uses the fallback path.
+// The fallback path removes nav/header/footer/aside elements, which would break link extraction
+// if extractLinks() runs after extractContent().
+vi.mock("@mozilla/readability", () => {
+	return {
+		Readability: class {
+			parse(): null {
+				return null;
+			}
+		},
+	};
+});
+
+// Import AFTER mocking.
+const { Crawler } = await import("../../src/crawler/index.js");
+
+class MockFetcher implements Fetcher {
+	private responses = new Map<string, FetchResult>();
+
+	setResponse(url: string, result: FetchResult | null): void {
+		this.responses.set(url, result as FetchResult);
+	}
+
+	async fetch(url: string): Promise<FetchResult | null> {
+		return this.responses.get(url) ?? null;
+	}
+
+	async close(): Promise<void> {
+		// no-op
+	}
+}
+
+describe("Crawler - link extraction order", () => {
+	const testDir = join(fileURLToPath(import.meta.url), "..", ".test-crawler-link-extraction-order");
+	let mockFetcher: MockFetcher;
+	let baseConfig: CrawlConfig;
+
+	beforeEach(async () => {
+		await rm(testDir, { recursive: true, force: true });
+		await mkdir(testDir, { recursive: true });
+
+		mockFetcher = new MockFetcher();
+		baseConfig = {
+			startUrl: "https://example.com",
+			maxDepth: 1,
+			maxPages: null,
+			outputDir: testDir,
+			sameDomain: true,
+			includePattern: null,
+			excludePattern: null,
+			delay: 0,
+			timeout: 30000,
+			spaWait: 0,
+			headed: false,
+			diff: false,
+			pages: true,
+			merge: false,
+			chunks: false,
+			keepSession: false,
+			respectRobots: false,
+		};
+	});
+
+	afterEach(async () => {
+		await rm(testDir, { recursive: true, force: true });
+	});
+
+	it("should crawl links from <nav> even when extractContent() fallback removes it", async () => {
+		const rootHtml = `
+			<!DOCTYPE html>
+			<html>
+				<head><title>Root</title></head>
+				<body>
+					<nav>
+						<a href="/page1">Page 1</a>
+					</nav>
+					<p>Some short content</p>
+				</body>
+			</html>
+		`;
+
+		const page1Html = `
+			<!DOCTYPE html>
+			<html>
+				<head><title>Page 1</title></head>
+				<body>
+					<p>Content</p>
+				</body>
+			</html>
+		`;
+
+		mockFetcher.setResponse("https://example.com", {
+			html: rootHtml,
+			finalUrl: "https://example.com",
+			contentType: "text/html",
+		});
+		mockFetcher.setResponse("https://example.com/page1", {
+			html: page1Html,
+			finalUrl: "https://example.com/page1",
+			contentType: "text/html",
+		});
+
+		const crawler = new Crawler(baseConfig, mockFetcher);
+		await crawler.run();
+
+		const indexPath = join(testDir, "index.json");
+		expect(existsSync(indexPath)).toBe(true);
+
+		const indexContent = await readFile(indexPath, "utf-8");
+		const indexData = JSON.parse(indexContent);
+
+		expect(indexData.totalPages).toBe(2);
+		const urls = indexData.pages.map((p: { url: string }) => p.url);
+		expect(urls).toContain("https://example.com");
+		expect(urls).toContain("https://example.com/page1");
+	});
+});


### PR DESCRIPTION
## Problem
`extractContent()` can mutate the shared JSDOM document (code-block placeholders and fallback cleanup that removes `<nav>/<header>/<footer>/<aside>`). When `extractLinks()` runs *after* `extractContent()`, link discovery can miss important navigation links on pages that fall back.

## Root Cause
`Crawler.processHtmlPage()` extracted content before links, so `extractLinks()` sometimes saw a mutated DOM.

## Fix
- Call `extractLinks()` before `extractContent()` in `processHtmlPage()`.
- Add a unit test that forces Readability to fail (fallback path) and verifies links in `<nav>` are still crawled.

## Test
```bash
cd link-crawler
npm install
npx vitest run
```

Closes #712.