### PR TITLE
fix: remove asterisk from regex escape pattern in robots.ts matchPath

### DIFF
--- a/link-crawler/src/crawler/robots.ts
+++ b/link-crawler/src/crawler/robots.ts
@@ -132,7 +132,7 @@ export class RobotsChecker {
 			// 正規表現の特殊文字をエスケープしつつ、*を.*に変換
 			const regexStr = pattern
 				.split("*")
-				.map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+				.map((s) => s.replace(/[.+?^${}()|[\]\\]/g, "\\$&"))
 				.join(".*");
 			const regex = new RegExp(`^${regexStr}${exactEnd ? "$" : ""}`);
 			return regex.test(path);


### PR DESCRIPTION
## Summary

Removes the asterisk () character from the regex escape pattern in   method. The  character cannot exist in the parts after , making its inclusion in the escape pattern unnecessary and potentially confusing.

## Changes

- Updated regex escape pattern from  to 
- This is a cosmetic fix to clarify code intent without changing functionality

## Testing

- All 708 tests pass
- Specifically, all 29 robots.ts tests pass
- No functional changes detected

## Impact

- **Risk**: Very Low (cosmetic change only)
- **Breaking Changes**: None
- **Test Coverage**: Comprehensive existing coverage

Closes #723