### PR TITLE
docs: バージョン番号を動的に取得するように改善

### DIFF
--- a/link-crawler/src/config.ts
+++ b/link-crawler/src/config.ts
@@ -35,7 +35,7 @@ function parsePattern(pattern: string | undefined, name: string): RegExp | null 
 	}
 }
 
-export function parseConfig(options: Record<string, unknown>, startUrl: string): CrawlConfig {
+export function parseConfig(options: Record<string, unknown>, startUrl: string, version: string): CrawlConfig {
 	// Validate startUrl format
 	let parsed: URL;
 	try {
@@ -96,6 +96,7 @@ export function parseConfig(options: Record<string, unknown>, startUrl: string):
 		chunks: options.chunks === true,
 		keepSession: Boolean(options.keepSession),
 		respectRobots: options.robots !== false,
+		version,
 	};
 
 	// Warn when all output formats are disabled

--- a/link-crawler/src/crawl.ts
+++ b/link-crawler/src/crawl.ts
@@ -83,7 +83,7 @@ async function main(): Promise<void> {
 	);
 
 	try {
-		const config = parseConfig(options, startUrl);
+		const config = parseConfig(options, startUrl, packageJson.version);
 		crawler = new Crawler(config);
 		await crawler.run();
 		process.exit(EXIT_CODES.SUCCESS);

--- a/link-crawler/src/crawler/logger.ts
+++ b/link-crawler/src/crawler/logger.ts
@@ -14,7 +14,7 @@ export class CrawlLogger implements Logger {
 
 	/** クロール開始ログ */
 	logStart(): void {
-		console.log(`\n🕷️  Link Crawler v2.0`);
+		console.log(`\n🕷️  Link Crawler v${this.config.version}`);
 		console.log(`   URL: ${this.config.startUrl}`);
 		console.log(`   Depth: ${this.config.maxDepth}`);
 		if (this.config.maxPages !== null) {

--- a/link-crawler/src/types.ts
+++ b/link-crawler/src/types.ts
@@ -22,6 +22,8 @@ export interface CrawlConfig {
 	keepSession: boolean;
 	/** robots.txt を尊重するか（デフォルト: true） */
 	respectRobots: boolean;
+	/** クローラーのバージョン（package.jsonから取得） */
+	version: string;
 }
 
 /** フェッチ結果 */

--- a/link-crawler/tests/integration/crawler.test.ts
+++ b/link-crawler/tests/integration/crawler.test.ts
@@ -101,6 +101,7 @@ const getDefaultConfig = (): CrawlConfig => ({
 	chunks: true,
 	keepSession: false,
 	respectRobots: true,
+	version: "test-version",
 });
 
 describe("CrawlerEngine Integration", () => {

--- a/link-crawler/tests/unit/config.test.ts
+++ b/link-crawler/tests/unit/config.test.ts
@@ -4,7 +4,7 @@ import { ConfigError } from "../../src/errors.js";
 
 describe("parseConfig", () => {
 	it("should parse config with default values", () => {
-		const config = parseConfig({}, "https://example.com");
+		const config = parseConfig({}, "https://example.com", "test-version");
 
 		expect(config.startUrl).toBe("https://example.com");
 		expect(config.maxDepth).toBe(1);
@@ -31,6 +31,7 @@ describe("parseConfig", () => {
 				timeout: 60,
 			},
 			"https://example.com",
+			"test-version",
 		);
 
 		expect(config.maxDepth).toBe(3);
@@ -40,55 +41,55 @@ describe("parseConfig", () => {
 	});
 
 	it("should cap maxDepth at 10", () => {
-		const config = parseConfig({ depth: 100 }, "https://example.com");
+		const config = parseConfig({ depth: 100 }, "https://example.com", "test-version");
 
 		expect(config.maxDepth).toBe(10);
 	});
 
 	it("should handle depth 0 correctly", () => {
-		const config = parseConfig({ depth: 0 }, "https://example.com");
+		const config = parseConfig({ depth: 0 }, "https://example.com", "test-version");
 
 		expect(config.maxDepth).toBe(0);
 	});
 
 	it("should handle depth as string '0' correctly", () => {
-		const config = parseConfig({ depth: "0" }, "https://example.com");
+		const config = parseConfig({ depth: "0" }, "https://example.com", "test-version");
 
 		expect(config.maxDepth).toBe(0);
 	});
 
 	it("should handle delay 0 correctly", () => {
-		const config = parseConfig({ delay: 0 }, "https://example.com");
+		const config = parseConfig({ delay: 0 }, "https://example.com", "test-version");
 
 		expect(config.delay).toBe(0);
 	});
 
 	it("should handle delay as string '0' correctly", () => {
-		const config = parseConfig({ delay: "0" }, "https://example.com");
+		const config = parseConfig({ delay: "0" }, "https://example.com", "test-version");
 
 		expect(config.delay).toBe(0);
 	});
 
 	it("should handle timeout 0 correctly", () => {
-		const config = parseConfig({ timeout: 0 }, "https://example.com");
+		const config = parseConfig({ timeout: 0 }, "https://example.com", "test-version");
 
 		expect(config.timeout).toBe(1000); // Minimum timeout is 1 second
 	});
 
 	it("should handle timeout as string '0' correctly", () => {
-		const config = parseConfig({ timeout: "0" }, "https://example.com");
+		const config = parseConfig({ timeout: "0" }, "https://example.com", "test-version");
 
 		expect(config.timeout).toBe(1000); // Minimum timeout is 1 second
 	});
 
 	it("should handle spaWait 0 correctly", () => {
-		const config = parseConfig({ wait: 0 }, "https://example.com");
+		const config = parseConfig({ wait: 0 }, "https://example.com", "test-version");
 
 		expect(config.spaWait).toBe(0);
 	});
 
 	it("should handle spaWait as string '0' correctly", () => {
-		const config = parseConfig({ wait: "0" }, "https://example.com");
+		const config = parseConfig({ wait: "0" }, "https://example.com", "test-version");
 
 		expect(config.spaWait).toBe(0);
 	});
@@ -100,6 +101,7 @@ describe("parseConfig", () => {
 				exclude: "\\.pdf$",
 			},
 			"https://example.com",
+			"test-version",
 		);
 
 		expect(config.includePattern).toBeInstanceOf(RegExp);
@@ -109,34 +111,34 @@ describe("parseConfig", () => {
 	});
 
 	it("should parse keepSession option", () => {
-		const configWithKeep = parseConfig({ keepSession: true }, "https://example.com");
+		const configWithKeep = parseConfig({ keepSession: true }, "https://example.com", "test-version");
 		expect(configWithKeep.keepSession).toBe(true);
 
-		const configWithoutKeep = parseConfig({ keepSession: false }, "https://example.com");
+		const configWithoutKeep = parseConfig({ keepSession: false }, "https://example.com", "test-version");
 		expect(configWithoutKeep.keepSession).toBe(false);
 
-		const configDefault = parseConfig({}, "https://example.com");
+		const configDefault = parseConfig({}, "https://example.com", "test-version");
 		expect(configDefault.keepSession).toBe(false);
 	});
 
 	it("should generate site-specific output directory from URL", () => {
-		const config1 = parseConfig({}, "https://nextjs.org/docs");
+		const config1 = parseConfig({}, "https://nextjs.org/docs", "test-version");
 		expect(config1.outputDir).toBe("./.context/nextjs-docs");
 
-		const config2 = parseConfig({}, "https://docs.python.org/3/");
+		const config2 = parseConfig({}, "https://docs.python.org/3/", "test-version");
 		expect(config2.outputDir).toBe("./.context/python-3");
 
-		const config3 = parseConfig({}, "https://www.example.com");
+		const config3 = parseConfig({}, "https://www.example.com", "test-version");
 		expect(config3.outputDir).toBe("./.context/example");
 	});
 
 	it("should allow custom output directory to override default", () => {
-		const config = parseConfig({ output: "./custom-dir" }, "https://nextjs.org/docs");
+		const config = parseConfig({ output: "./custom-dir" }, "https://nextjs.org/docs", "test-version");
 		expect(config.outputDir).toBe("./custom-dir");
 	});
 
 	it("should allow legacy ./.context directory to be specified explicitly", () => {
-		const config = parseConfig({ output: "./.context" }, "https://nextjs.org/docs");
+		const config = parseConfig({ output: "./.context" }, "https://nextjs.org/docs", "test-version");
 		expect(config.outputDir).toBe("./.context");
 	});
 });
@@ -144,27 +146,27 @@ describe("parseConfig", () => {
 describe("parseConfig - regex pattern validation", () => {
 	it("should throw ConfigError for invalid include pattern", () => {
 		expect(() => {
-			parseConfig({ include: "[invalid" }, "https://example.com");
+			parseConfig({ include: "[invalid" }, "https://example.com", "test-version");
 		}).toThrow(ConfigError);
 
 		expect(() => {
-			parseConfig({ include: "[invalid" }, "https://example.com");
+			parseConfig({ include: "[invalid" }, "https://example.com", "test-version");
 		}).toThrowError(/Invalid include pattern/);
 	});
 
 	it("should throw ConfigError for invalid exclude pattern", () => {
 		expect(() => {
-			parseConfig({ exclude: "(unclosed" }, "https://example.com");
+			parseConfig({ exclude: "(unclosed" }, "https://example.com", "test-version");
 		}).toThrow(ConfigError);
 
 		expect(() => {
-			parseConfig({ exclude: "(unclosed" }, "https://example.com");
+			parseConfig({ exclude: "(unclosed" }, "https://example.com", "test-version");
 		}).toThrowError(/Invalid exclude pattern/);
 	});
 
 	it("should include original regex error in message", () => {
 		expect(() => {
-			parseConfig({ include: "[invalid" }, "https://example.com");
+			parseConfig({ include: "[invalid" }, "https://example.com", "test-version");
 		}).toThrowError(/(?:missing terminating|Unterminated character class)/);
 	});
 
@@ -175,6 +177,7 @@ describe("parseConfig - regex pattern validation", () => {
 				exclude: "\\.pdf$",
 			},
 			"https://example.com",
+			"test-version",
 		);
 
 		expect(config.includePattern).toBeInstanceOf(RegExp);
@@ -185,7 +188,7 @@ describe("parseConfig - regex pattern validation", () => {
 
 	it("should set configKey in ConfigError", () => {
 		try {
-			parseConfig({ include: "[invalid" }, "https://example.com");
+			parseConfig({ include: "[invalid" }, "https://example.com", "test-version");
 			expect.fail("Should have thrown ConfigError");
 		} catch (error) {
 			expect(error).toBeInstanceOf(ConfigError);
@@ -193,7 +196,7 @@ describe("parseConfig - regex pattern validation", () => {
 		}
 
 		try {
-			parseConfig({ exclude: "(unclosed" }, "https://example.com");
+			parseConfig({ exclude: "(unclosed" }, "https://example.com", "test-version");
 			expect.fail("Should have thrown ConfigError");
 		} catch (error) {
 			expect(error).toBeInstanceOf(ConfigError);
@@ -206,7 +209,7 @@ describe("parseConfig - output format warnings", () => {
 	it("should warn when all output formats are disabled", () => {
 		const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-		parseConfig({ pages: false, merge: false, chunks: false }, "https://example.com");
+		parseConfig({ pages: false, merge: false, chunks: false }, "https://example.com", "test-version");
 
 		expect(consoleSpy).toHaveBeenCalledWith(
 			"⚠️  Warning: All output formats are disabled (--no-pages --no-merge without --chunks).",
@@ -221,7 +224,7 @@ describe("parseConfig - output format warnings", () => {
 	it("should not warn when at least one output format is enabled - pages", () => {
 		const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-		parseConfig({ pages: true, merge: false, chunks: false }, "https://example.com");
+		parseConfig({ pages: true, merge: false, chunks: false }, "https://example.com", "test-version");
 
 		expect(consoleSpy).not.toHaveBeenCalled();
 
@@ -231,7 +234,7 @@ describe("parseConfig - output format warnings", () => {
 	it("should not warn when at least one output format is enabled - merge", () => {
 		const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-		parseConfig({ pages: false, merge: true, chunks: false }, "https://example.com");
+		parseConfig({ pages: false, merge: true, chunks: false }, "https://example.com", "test-version");
 
 		expect(consoleSpy).not.toHaveBeenCalled();
 
@@ -241,7 +244,7 @@ describe("parseConfig - output format warnings", () => {
 	it("should not warn when at least one output format is enabled - chunks", () => {
 		const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-		parseConfig({ pages: false, merge: false, chunks: true }, "https://example.com");
+		parseConfig({ pages: false, merge: false, chunks: true }, "https://example.com", "test-version");
 
 		expect(consoleSpy).not.toHaveBeenCalled();
 
@@ -251,7 +254,7 @@ describe("parseConfig - output format warnings", () => {
 	it("should not warn with default configuration", () => {
 		const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-		parseConfig({}, "https://example.com");
+		parseConfig({}, "https://example.com", "test-version");
 
 		expect(consoleSpy).not.toHaveBeenCalled();
 
@@ -301,35 +304,35 @@ describe("parseConfig - URL validation", () => {
 	});
 
 	it("should accept valid URLs", () => {
-		const config1 = parseConfig({}, "https://example.com");
+		const config1 = parseConfig({}, "https://example.com", "test-version");
 		expect(config1.startUrl).toBe("https://example.com");
 
-		const config2 = parseConfig({}, "http://localhost:3000");
+		const config2 = parseConfig({}, "http://localhost:3000", "test-version");
 		expect(config2.startUrl).toBe("http://localhost:3000");
 
-		const config3 = parseConfig({}, "https://example.com/path/to/page");
+		const config3 = parseConfig({}, "https://example.com/path/to/page", "test-version");
 		expect(config3.startUrl).toBe("https://example.com/path/to/page");
 	});
 });
 
 describe("parseConfig - negative value validation", () => {
 	it("should clamp negative delay to 0", () => {
-		const config = parseConfig({ delay: -100 }, "https://example.com");
+		const config = parseConfig({ delay: -100 }, "https://example.com", "test-version");
 		expect(config.delay).toBe(0);
 	});
 
 	it("should clamp negative timeout to 1 second (1000ms)", () => {
-		const config = parseConfig({ timeout: -10 }, "https://example.com");
+		const config = parseConfig({ timeout: -10 }, "https://example.com", "test-version");
 		expect(config.timeout).toBe(1000);
 	});
 
 	it("should clamp negative spaWait to 0", () => {
-		const config = parseConfig({ wait: -500 }, "https://example.com");
+		const config = parseConfig({ wait: -500 }, "https://example.com", "test-version");
 		expect(config.spaWait).toBe(0);
 	});
 
 	it("should clamp negative depth to 0", () => {
-		const config = parseConfig({ depth: -5 }, "https://example.com");
+		const config = parseConfig({ depth: -5 }, "https://example.com", "test-version");
 		expect(config.maxDepth).toBe(0);
 	});
 
@@ -342,6 +345,7 @@ describe("parseConfig - negative value validation", () => {
 				depth: -999999,
 			},
 			"https://example.com",
+			"test-version",
 		);
 
 		expect(config.delay).toBe(0);
@@ -353,32 +357,32 @@ describe("parseConfig - negative value validation", () => {
 
 describe("parseConfig - boundary value validation", () => {
 	it("should allow delay of exactly 0", () => {
-		const config = parseConfig({ delay: 0 }, "https://example.com");
+		const config = parseConfig({ delay: 0 }, "https://example.com", "test-version");
 		expect(config.delay).toBe(0);
 	});
 
 	it("should allow depth of exactly 0", () => {
-		const config = parseConfig({ depth: 0 }, "https://example.com");
+		const config = parseConfig({ depth: 0 }, "https://example.com", "test-version");
 		expect(config.maxDepth).toBe(0);
 	});
 
 	it("should allow spaWait of exactly 0", () => {
-		const config = parseConfig({ wait: 0 }, "https://example.com");
+		const config = parseConfig({ wait: 0 }, "https://example.com", "test-version");
 		expect(config.spaWait).toBe(0);
 	});
 
 	it("should enforce minimum timeout of 1 second (1000ms)", () => {
-		const config = parseConfig({ timeout: 0.5 }, "https://example.com");
+		const config = parseConfig({ timeout: 0.5 }, "https://example.com", "test-version");
 		expect(config.timeout).toBe(1000);
 	});
 
 	it("should allow timeout of exactly 1 second", () => {
-		const config = parseConfig({ timeout: 1 }, "https://example.com");
+		const config = parseConfig({ timeout: 1 }, "https://example.com", "test-version");
 		expect(config.timeout).toBe(1000);
 	});
 
 	it("should allow timeout greater than 1 second", () => {
-		const config = parseConfig({ timeout: 5 }, "https://example.com");
+		const config = parseConfig({ timeout: 5 }, "https://example.com", "test-version");
 		expect(config.timeout).toBe(5000);
 	});
 
@@ -391,6 +395,7 @@ describe("parseConfig - boundary value validation", () => {
 				depth: 5,
 			},
 			"https://example.com",
+			"test-version",
 		);
 
 		expect(config.delay).toBe(100);
@@ -403,11 +408,11 @@ describe("parseConfig - boundary value validation", () => {
 describe("parseConfig - ReDoS protection", () => {
 	it("should reject patterns with nested quantifiers", () => {
 		expect(() => {
-			parseConfig({ include: "(a+)+" }, "https://example.com");
+			parseConfig({ include: "(a+)+" }, "https://example.com", "test-version");
 		}).toThrow(ConfigError);
 
 		expect(() => {
-			parseConfig({ include: "(a+)+" }, "https://example.com");
+			parseConfig({ include: "(a+)+" }, "https://example.com", "test-version");
 		}).toThrowError(/catastrophic backtracking/);
 	});
 
@@ -416,18 +421,18 @@ describe("parseConfig - ReDoS protection", () => {
 
 		for (const pattern of dangerousPatterns) {
 			expect(() => {
-				parseConfig({ include: pattern }, "https://example.com");
+				parseConfig({ include: pattern }, "https://example.com", "test-version");
 			}).toThrowError(/catastrophic backtracking/);
 		}
 	});
 
 	it("should reject nested quantifiers in exclude pattern", () => {
 		expect(() => {
-			parseConfig({ exclude: "(b+)+" }, "https://example.com");
+			parseConfig({ exclude: "(b+)+" }, "https://example.com", "test-version");
 		}).toThrow(ConfigError);
 
 		expect(() => {
-			parseConfig({ exclude: "(b+)+" }, "https://example.com");
+			parseConfig({ exclude: "(b+)+" }, "https://example.com", "test-version");
 		}).toThrowError(/catastrophic backtracking/);
 	});
 
@@ -441,14 +446,14 @@ describe("parseConfig - ReDoS protection", () => {
 
 		for (const pattern of safePatterns) {
 			expect(() => {
-				parseConfig({ include: pattern }, "https://example.com");
+				parseConfig({ include: pattern }, "https://example.com", "test-version");
 			}).not.toThrow();
 		}
 	});
 
 	it("should set configKey in ConfigError for ReDoS pattern", () => {
 		try {
-			parseConfig({ include: "(a+)+" }, "https://example.com");
+			parseConfig({ include: "(a+)+" }, "https://example.com", "test-version");
 			expect.fail("Should have thrown ConfigError");
 		} catch (error) {
 			expect(error).toBeInstanceOf(ConfigError);
@@ -456,7 +461,7 @@ describe("parseConfig - ReDoS protection", () => {
 		}
 
 		try {
-			parseConfig({ exclude: "(b+)+" }, "https://example.com");
+			parseConfig({ exclude: "(b+)+" }, "https://example.com", "test-version");
 			expect.fail("Should have thrown ConfigError");
 		} catch (error) {
 			expect(error).toBeInstanceOf(ConfigError);
@@ -470,11 +475,11 @@ describe("parseConfig - pattern length limit", () => {
 		const longPattern = "a".repeat(201);
 
 		expect(() => {
-			parseConfig({ include: longPattern }, "https://example.com");
+			parseConfig({ include: longPattern }, "https://example.com", "test-version");
 		}).toThrow(ConfigError);
 
 		expect(() => {
-			parseConfig({ include: longPattern }, "https://example.com");
+			parseConfig({ include: longPattern }, "https://example.com", "test-version");
 		}).toThrowError(/pattern too long/);
 	});
 
@@ -482,7 +487,7 @@ describe("parseConfig - pattern length limit", () => {
 		const maxPattern = "a".repeat(200);
 
 		expect(() => {
-			parseConfig({ include: maxPattern }, "https://example.com");
+			parseConfig({ include: maxPattern }, "https://example.com", "test-version");
 		}).not.toThrow();
 	});
 
@@ -490,11 +495,11 @@ describe("parseConfig - pattern length limit", () => {
 		const longPattern = "b".repeat(201);
 
 		expect(() => {
-			parseConfig({ exclude: longPattern }, "https://example.com");
+			parseConfig({ exclude: longPattern }, "https://example.com", "test-version");
 		}).toThrow(ConfigError);
 
 		expect(() => {
-			parseConfig({ exclude: longPattern }, "https://example.com");
+			parseConfig({ exclude: longPattern }, "https://example.com", "test-version");
 		}).toThrowError(/pattern too long/);
 	});
 
@@ -502,7 +507,7 @@ describe("parseConfig - pattern length limit", () => {
 		const longPattern = "a".repeat(201);
 
 		try {
-			parseConfig({ include: longPattern }, "https://example.com");
+			parseConfig({ include: longPattern }, "https://example.com", "test-version");
 			expect.fail("Should have thrown ConfigError");
 		} catch (error) {
 			expect(error).toBeInstanceOf(ConfigError);
@@ -513,12 +518,12 @@ describe("parseConfig - pattern length limit", () => {
 
 describe("parseConfig - URL scheme validation", () => {
 	it("should accept https URLs", () => {
-		const config = parseConfig({}, "https://example.com");
+		const config = parseConfig({}, "https://example.com", "test-version");
 		expect(config.startUrl).toBe("https://example.com");
 	});
 
 	it("should accept http URLs", () => {
-		const config = parseConfig({}, "http://localhost:3000");
+		const config = parseConfig({}, "http://localhost:3000", "test-version");
 		expect(config.startUrl).toBe("http://localhost:3000");
 	});
 
@@ -575,73 +580,73 @@ describe("parseConfig - URL scheme validation", () => {
 
 describe("parseConfig - maxPages validation", () => {
 	it("should set maxPages to null by default (unlimited)", () => {
-		const config = parseConfig({}, "https://example.com");
+		const config = parseConfig({}, "https://example.com", "test-version");
 		expect(config.maxPages).toBeNull();
 	});
 
 	it("should parse positive integer maxPages", () => {
-		const config = parseConfig({ maxPages: 100 }, "https://example.com");
+		const config = parseConfig({ maxPages: 100 }, "https://example.com", "test-version");
 		expect(config.maxPages).toBe(100);
 	});
 
 	it("should parse maxPages as string", () => {
-		const config = parseConfig({ maxPages: "50" }, "https://example.com");
+		const config = parseConfig({ maxPages: "50" }, "https://example.com", "test-version");
 		expect(config.maxPages).toBe(50);
 	});
 
 	it("should set maxPages to null when 0 (unlimited)", () => {
-		const config = parseConfig({ maxPages: 0 }, "https://example.com");
+		const config = parseConfig({ maxPages: 0 }, "https://example.com", "test-version");
 		expect(config.maxPages).toBeNull();
 	});
 
 	it("should set maxPages to null when negative (unlimited)", () => {
-		const config = parseConfig({ maxPages: -1 }, "https://example.com");
+		const config = parseConfig({ maxPages: -1 }, "https://example.com", "test-version");
 		expect(config.maxPages).toBeNull();
 
-		const config2 = parseConfig({ maxPages: -100 }, "https://example.com");
+		const config2 = parseConfig({ maxPages: -100 }, "https://example.com", "test-version");
 		expect(config2.maxPages).toBeNull();
 	});
 
 	it("should set maxPages to null when NaN (unlimited)", () => {
-		const config = parseConfig({ maxPages: "abc" }, "https://example.com");
+		const config = parseConfig({ maxPages: "abc" }, "https://example.com", "test-version");
 		expect(config.maxPages).toBeNull();
 
-		const config2 = parseConfig({ maxPages: "not-a-number" }, "https://example.com");
+		const config2 = parseConfig({ maxPages: "not-a-number" }, "https://example.com", "test-version");
 		expect(config2.maxPages).toBeNull();
 	});
 
 	it("should floor decimal maxPages values", () => {
-		const config = parseConfig({ maxPages: 42.7 }, "https://example.com");
+		const config = parseConfig({ maxPages: 42.7 }, "https://example.com", "test-version");
 		expect(config.maxPages).toBe(42);
 
-		const config2 = parseConfig({ maxPages: 99.9 }, "https://example.com");
+		const config2 = parseConfig({ maxPages: 99.9 }, "https://example.com", "test-version");
 		expect(config2.maxPages).toBe(99);
 	});
 
 	it("should handle very large maxPages values", () => {
-		const config = parseConfig({ maxPages: 1000000 }, "https://example.com");
+		const config = parseConfig({ maxPages: 1000000 }, "https://example.com", "test-version");
 		expect(config.maxPages).toBe(1000000);
 	});
 });
 
 describe("parseConfig - respectRobots validation", () => {
 	it("should set respectRobots to true by default", () => {
-		const config = parseConfig({}, "https://example.com");
+		const config = parseConfig({}, "https://example.com", "test-version");
 		expect(config.respectRobots).toBe(true);
 	});
 
 	it("should set respectRobots to false when robots option is false", () => {
-		const config = parseConfig({ robots: false }, "https://example.com");
+		const config = parseConfig({ robots: false }, "https://example.com", "test-version");
 		expect(config.respectRobots).toBe(false);
 	});
 
 	it("should set respectRobots to true when robots option is true", () => {
-		const config = parseConfig({ robots: true }, "https://example.com");
+		const config = parseConfig({ robots: true }, "https://example.com", "test-version");
 		expect(config.respectRobots).toBe(true);
 	});
 
 	it("should set respectRobots to true when robots option is undefined", () => {
-		const config = parseConfig({ robots: undefined }, "https://example.com");
+		const config = parseConfig({ robots: undefined }, "https://example.com", "test-version");
 		expect(config.respectRobots).toBe(true);
 	});
 });

--- a/link-crawler/tests/unit/logger.test.ts
+++ b/link-crawler/tests/unit/logger.test.ts
@@ -28,6 +28,7 @@ describe("CrawlLogger", () => {
 			chunks: false,
 			keepSession: false,
 			respectRobots: true,
+			version: "2.0.0",
 		};
 	});
 
@@ -40,7 +41,7 @@ describe("CrawlLogger", () => {
 			const logger = new CrawlLogger(baseConfig);
 			logger.logStart();
 
-			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("🕷️  Link Crawler v2.0"));
+			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("🕷️  Link Crawler v2.0.0"));
 			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("https://example.com"));
 		});
 

--- a/link-crawler/tests/unit/max-pages.test.ts
+++ b/link-crawler/tests/unit/max-pages.test.ts
@@ -5,42 +5,42 @@ describe("--max-pages option", () => {
 	const baseUrl = "https://example.com";
 
 	test("default is null (unlimited)", () => {
-		const config = parseConfig({}, baseUrl);
+		const config = parseConfig({}, baseUrl, "test-version");
 		expect(config.maxPages).toBeNull();
 	});
 
 	test("accepts positive integer", () => {
-		const config = parseConfig({ maxPages: "100" }, baseUrl);
+		const config = parseConfig({ maxPages: "100" }, baseUrl, "test-version");
 		expect(config.maxPages).toBe(100);
 	});
 
 	test("treats 0 as unlimited", () => {
-		const config = parseConfig({ maxPages: "0" }, baseUrl);
+		const config = parseConfig({ maxPages: "0" }, baseUrl, "test-version");
 		expect(config.maxPages).toBeNull();
 	});
 
 	test("treats negative as unlimited", () => {
-		const config = parseConfig({ maxPages: "-10" }, baseUrl);
+		const config = parseConfig({ maxPages: "-10" }, baseUrl, "test-version");
 		expect(config.maxPages).toBeNull();
 	});
 
 	test("floors decimal values", () => {
-		const config = parseConfig({ maxPages: "50.7" }, baseUrl);
+		const config = parseConfig({ maxPages: "50.7" }, baseUrl, "test-version");
 		expect(config.maxPages).toBe(50);
 	});
 
 	test("treats invalid input as unlimited", () => {
-		const config = parseConfig({ maxPages: "abc" }, baseUrl);
+		const config = parseConfig({ maxPages: "abc" }, baseUrl, "test-version");
 		expect(config.maxPages).toBeNull();
 	});
 
 	test("accepts large numbers", () => {
-		const config = parseConfig({ maxPages: "10000" }, baseUrl);
+		const config = parseConfig({ maxPages: "10000" }, baseUrl, "test-version");
 		expect(config.maxPages).toBe(10000);
 	});
 
 	test("handles string '1'", () => {
-		const config = parseConfig({ maxPages: "1" }, baseUrl);
+		const config = parseConfig({ maxPages: "1" }, baseUrl, "test-version");
 		expect(config.maxPages).toBe(1);
 	});
 });


### PR DESCRIPTION
## 概要

`CrawlLogger` のバージョン表示を `package.json` から動的に取得するように改善しました。

## 変更内容

- ✅ `CrawlConfig` に `version` フィールドを追加
- ✅ `parseConfig()` が `package.json` から読み込んだバージョンを受け取るように変更
- ✅ `crawl.ts` で `packageJson.version` を `parseConfig()` に渡す
- ✅ `CrawlLogger.logStart()` でハードコードされた `v2.0` を削除し、`config.version` を使用
- ✅ 関連するテストファイルを更新

## 動作確認

```bash
cd link-crawler && bun run src/crawl.ts https://example.com -d 0
# 出力: 🕷️  Link Crawler v2.0.0
```

バージョン表示が正しく `v2.0.0` と表示されることを確認しました。

## テスト

- 個別テスト実行時: 全てパス
- 統合テスト: パス
- config/logger/max-pages テスト: パス

Closes #724