### PR TITLE
docs: 設計書の CrawlConfig 型定義に version フィールドを追加

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -254,6 +254,8 @@ interface CrawlConfig {
   keepSession: boolean;
   /** robots.txt を尊重するか（デフォルト: true） */
   respectRobots: boolean;
+  /** クローラーのバージョン（package.jsonから取得） */
+  version: string;
 }
 
 /** ページメタデータ */


### PR DESCRIPTION
## 概要

プロジェクト全体レビューで発見された問題を修正。

`docs/design.md` セクション5.1の `CrawlConfig` 型定義に `version` フィールドが記載されていなかったため追加しました。実装（`link-crawler/src/types.ts`）では `version: string` が存在するため、ドキュメントと実装の乖離を解消します。

## 変更内容

- `docs/design.md` の `CrawlConfig` インターフェースに `version: string` フィールドを追加
- JSDocコメント `/** クローラーのバージョン（package.jsonから取得） */` を付与

## 影響

この乖離が Issue #729（テストのモック作成時に version フィールド欠落）の根本原因でした。

## 検証

- [x] 実装（`link-crawler/src/types.ts`）と設計書が一致している
- [x] コメントが適切に付与されている

Closes #731