### PR TITLE
fix: テストコードの CrawlConfig 型エラー修正（version プロパティ欠落）

### DIFF
--- a/link-crawler/tests/unit/config.test.ts
+++ b/link-crawler/tests/unit/config.test.ts
@@ -265,37 +265,37 @@ describe("parseConfig - output format warnings", () => {
 describe("parseConfig - URL validation", () => {
 	it("should throw ConfigError for invalid URL", () => {
 		expect(() => {
-			parseConfig({}, "not-a-url");
+			parseConfig({}, "not-a-url", "test-version");
 		}).toThrow(ConfigError);
 
 		expect(() => {
-			parseConfig({}, "not-a-url");
+			parseConfig({}, "not-a-url", "test-version");
 		}).toThrowError(/Invalid URL: not-a-url/);
 	});
 
 	it("should throw ConfigError for empty string URL", () => {
 		expect(() => {
-			parseConfig({}, "");
+			parseConfig({}, "", "test-version");
 		}).toThrow(ConfigError);
 
 		expect(() => {
-			parseConfig({}, "");
+			parseConfig({}, "", "test-version");
 		}).toThrowError(/Invalid URL/);
 	});
 
 	it("should throw ConfigError for malformed URL", () => {
 		expect(() => {
-			parseConfig({}, "://missing-protocol");
+			parseConfig({}, "://missing-protocol", "test-version");
 		}).toThrow(ConfigError);
 
 		expect(() => {
-			parseConfig({}, "just some text");
+			parseConfig({}, "just some text", "test-version");
 		}).toThrow(ConfigError);
 	});
 
 	it("should set configKey to 'startUrl' in ConfigError", () => {
 		try {
-			parseConfig({}, "invalid-url");
+			parseConfig({}, "invalid-url", "test-version");
 			expect.fail("Should have thrown ConfigError");
 		} catch (error) {
 			expect(error).toBeInstanceOf(ConfigError);
@@ -529,47 +529,47 @@ describe("parseConfig - URL scheme validation", () => {
 
 	it("should reject file:// URLs", () => {
 		expect(() => {
-			parseConfig({}, "file:///etc/passwd");
+			parseConfig({}, "file:///etc/passwd", "test-version");
 		}).toThrow(ConfigError);
 
 		expect(() => {
-			parseConfig({}, "file:///etc/passwd");
+			parseConfig({}, "file:///etc/passwd", "test-version");
 		}).toThrowError(/Unsupported protocol.*file:/);
 	});
 
 	it("should reject javascript: URLs", () => {
 		expect(() => {
-			parseConfig({}, "javascript:alert(1)");
+			parseConfig({}, "javascript:alert(1)", "test-version");
 		}).toThrow(ConfigError);
 
 		expect(() => {
-			parseConfig({}, "javascript:alert(1)");
+			parseConfig({}, "javascript:alert(1)", "test-version");
 		}).toThrowError(/Unsupported protocol.*javascript:/);
 	});
 
 	it("should reject ftp:// URLs", () => {
 		expect(() => {
-			parseConfig({}, "ftp://example.com");
+			parseConfig({}, "ftp://example.com", "test-version");
 		}).toThrow(ConfigError);
 
 		expect(() => {
-			parseConfig({}, "ftp://example.com");
+			parseConfig({}, "ftp://example.com", "test-version");
 		}).toThrowError(/Unsupported protocol.*ftp:/);
 	});
 
 	it("should reject data: URLs", () => {
 		expect(() => {
-			parseConfig({}, "data:text/html,<html></html>");
+			parseConfig({}, "data:text/html,<html></html>", "test-version");
 		}).toThrow(ConfigError);
 
 		expect(() => {
-			parseConfig({}, "data:text/html,<html></html>");
+			parseConfig({}, "data:text/html,<html></html>", "test-version");
 		}).toThrowError(/Unsupported protocol.*data:/);
 	});
 
 	it("should set configKey to 'startUrl' in ConfigError for unsupported protocol", () => {
 		try {
-			parseConfig({}, "file:///etc/passwd");
+			parseConfig({}, "file:///etc/passwd", "test-version");
 			expect.fail("Should have thrown ConfigError");
 		} catch (error) {
 			expect(error).toBeInstanceOf(ConfigError);

--- a/link-crawler/tests/unit/crawler-error-handling.test.ts
+++ b/link-crawler/tests/unit/crawler-error-handling.test.ts
@@ -30,6 +30,7 @@ describe("Crawler - Error Handling", () => {
 			headed: false,
 			keepSession: false,
 			respectRobots: true,
+			version: "test-version",
 		};
 
 		// Fetcherモック

--- a/link-crawler/tests/unit/crawler.test.ts
+++ b/link-crawler/tests/unit/crawler.test.ts
@@ -55,6 +55,7 @@ describe("Crawler", () => {
 			chunks: false,
 			keepSession: false,
 			respectRobots: true,
+			version: "test-version",
 		};
 	});
 

--- a/link-crawler/tests/unit/fetcher.test.ts
+++ b/link-crawler/tests/unit/fetcher.test.ts
@@ -33,6 +33,7 @@ const createMockConfig = (overrides: Partial<CrawlConfig> = {}): CrawlConfig => 
 	chunks: true,
 	keepSession: false,
 	respectRobots: true,
+	version: "test-version",
 	...overrides,
 });
 

--- a/link-crawler/tests/unit/links.test.ts
+++ b/link-crawler/tests/unit/links.test.ts
@@ -97,6 +97,7 @@ describe("shouldCrawl", () => {
 		chunks: true,
 		keepSession: false,
 		respectRobots: true,
+		version: "test-version",
 	};
 
 	it("should return true for unvisited URL", () => {
@@ -199,6 +200,7 @@ describe("extractLinks", () => {
 		chunks: true,
 		keepSession: false,
 		respectRobots: true,
+		version: "test-version",
 	};
 
 	it("should extract links from HTML", () => {

--- a/link-crawler/tests/unit/post-processor.test.ts
+++ b/link-crawler/tests/unit/post-processor.test.ts
@@ -56,6 +56,7 @@ describe("PostProcessor", () => {
 			chunks: true,
 			keepSession: false,
 			respectRobots: true,
+			version: "test-version",
 		};
 
 		// Create a mock logger

--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -24,6 +24,7 @@ const defaultConfig: CrawlConfig = {
 	chunks: true,
 	keepSession: false,
 	respectRobots: true,
+	version: "test-version",
 };
 
 const defaultMetadata: PageMetadata = {


### PR DESCRIPTION
## Summary
Closes #729

## Changes
- **config.test.ts**: parseConfig() 呼び出しに第3引数 `version` を追加（16箇所）
- **crawler.test.ts**: baseConfig に `version: "test-version"` を追加
- **crawler-error-handling.test.ts**: config に `version: "test-version"` を追加
- **fetcher.test.ts**: createMockConfig() に `version: "test-version"` を追加
- **links.test.ts**: baseConfig に `version: "test-version"` を追加（2箇所）
- **post-processor.test.ts**: baseConfig に `version: "test-version"` を追加
- **writer.test.ts**: defaultConfig に `version: "test-version"` を追加

全ての version 値は `"test-version"` で統一

## Testing
✅ `bun run typecheck`: 0 errors (修正前: 23 errors)
✅ `bun run test`: 708 tests passed

## Impact
- テストコードのみの変更
- 実行時の動作は変更なし（Vitestは型チェックしないため既にテストはパス）
- CI/CDでの型チェック失敗を防ぐ