### PR TITLE
docs: CrawlConfigにversionフィールドを追加し、CrawlResult.configの説明を明確化

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -254,6 +254,8 @@ interface CrawlConfig {
   keepSession: boolean;
   /** robots.txt を尊重するか（デフォルト: true） */
   respectRobots: boolean;
+  /** クローラーのバージョン（package.jsonから取得） */
+  version: string;
 }
 
 /** ページメタデータ */
@@ -282,6 +284,7 @@ interface CrawledPage {
 interface CrawlResult {
   crawledAt: string;
   baseUrl: string;
+  /** クロール設定の一部（実際にはmaxDepthとsameDomainのみ保存される） */
   config: Partial<CrawlConfig>;
   totalPages: number;
   pages: CrawledPage[];


### PR DESCRIPTION
## 概要

設計書（`docs/design.md`）の型定義と実装の不一致を修正しました。

## 変更内容

### 1. CrawlConfig.versionフィールドの追加

実装（`src/types.ts`）に存在するが設計書に記載がなかった`version`フィールドを追加しました。

```typescript
/** クローラーのバージョン（package.jsonから取得） */
version: string;
```

### 2. CrawlResult.configの説明を明確化

設計書では`Partial<CrawlConfig>`と記載されていましたが、実際には`maxDepth`と`sameDomain`のみが保存される実装になっていたため、コメントで明記しました。

```typescript
/** クロール設定の一部（実際にはmaxDepthとsameDomainのみ保存される） */
config: Partial<CrawlConfig>;
```

## 検証

- ✅ 設計書と実装の型定義が一致していることを確認
- ✅ `IndexManager`の実装と説明が一致していることを確認

Closes #739