### PR TITLE
fix: Biome フォーマット違反（CI lint ジョブ失敗）

### DIFF
--- a/link-crawler/src/config.ts
+++ b/link-crawler/src/config.ts
@@ -35,7 +35,11 @@ function parsePattern(pattern: string | undefined, name: string): RegExp | null 
 	}
 }
 
-export function parseConfig(options: Record<string, unknown>, startUrl: string, version: string): CrawlConfig {
+export function parseConfig(
+	options: Record<string, unknown>,
+	startUrl: string,
+	version: string,
+): CrawlConfig {
 	// Validate startUrl format
 	let parsed: URL;
 	try {

--- a/link-crawler/tests/unit/config.test.ts
+++ b/link-crawler/tests/unit/config.test.ts
@@ -111,10 +111,18 @@ describe("parseConfig", () => {
 	});
 
 	it("should parse keepSession option", () => {
-		const configWithKeep = parseConfig({ keepSession: true }, "https://example.com", "test-version");
+		const configWithKeep = parseConfig(
+			{ keepSession: true },
+			"https://example.com",
+			"test-version",
+		);
 		expect(configWithKeep.keepSession).toBe(true);
 
-		const configWithoutKeep = parseConfig({ keepSession: false }, "https://example.com", "test-version");
+		const configWithoutKeep = parseConfig(
+			{ keepSession: false },
+			"https://example.com",
+			"test-version",
+		);
 		expect(configWithoutKeep.keepSession).toBe(false);
 
 		const configDefault = parseConfig({}, "https://example.com", "test-version");
@@ -133,7 +141,11 @@ describe("parseConfig", () => {
 	});
 
 	it("should allow custom output directory to override default", () => {
-		const config = parseConfig({ output: "./custom-dir" }, "https://nextjs.org/docs", "test-version");
+		const config = parseConfig(
+			{ output: "./custom-dir" },
+			"https://nextjs.org/docs",
+			"test-version",
+		);
 		expect(config.outputDir).toBe("./custom-dir");
 	});
 
@@ -209,7 +221,11 @@ describe("parseConfig - output format warnings", () => {
 	it("should warn when all output formats are disabled", () => {
 		const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-		parseConfig({ pages: false, merge: false, chunks: false }, "https://example.com", "test-version");
+		parseConfig(
+			{ pages: false, merge: false, chunks: false },
+			"https://example.com",
+			"test-version",
+		);
 
 		expect(consoleSpy).toHaveBeenCalledWith(
 			"⚠️  Warning: All output formats are disabled (--no-pages --no-merge without --chunks).",
@@ -224,7 +240,11 @@ describe("parseConfig - output format warnings", () => {
 	it("should not warn when at least one output format is enabled - pages", () => {
 		const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-		parseConfig({ pages: true, merge: false, chunks: false }, "https://example.com", "test-version");
+		parseConfig(
+			{ pages: true, merge: false, chunks: false },
+			"https://example.com",
+			"test-version",
+		);
 
 		expect(consoleSpy).not.toHaveBeenCalled();
 
@@ -234,7 +254,11 @@ describe("parseConfig - output format warnings", () => {
 	it("should not warn when at least one output format is enabled - merge", () => {
 		const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-		parseConfig({ pages: false, merge: true, chunks: false }, "https://example.com", "test-version");
+		parseConfig(
+			{ pages: false, merge: true, chunks: false },
+			"https://example.com",
+			"test-version",
+		);
 
 		expect(consoleSpy).not.toHaveBeenCalled();
 
@@ -244,7 +268,11 @@ describe("parseConfig - output format warnings", () => {
 	it("should not warn when at least one output format is enabled - chunks", () => {
 		const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-		parseConfig({ pages: false, merge: false, chunks: true }, "https://example.com", "test-version");
+		parseConfig(
+			{ pages: false, merge: false, chunks: true },
+			"https://example.com",
+			"test-version",
+		);
 
 		expect(consoleSpy).not.toHaveBeenCalled();
 
@@ -611,7 +639,11 @@ describe("parseConfig - maxPages validation", () => {
 		const config = parseConfig({ maxPages: "abc" }, "https://example.com", "test-version");
 		expect(config.maxPages).toBeNull();
 
-		const config2 = parseConfig({ maxPages: "not-a-number" }, "https://example.com", "test-version");
+		const config2 = parseConfig(
+			{ maxPages: "not-a-number" },
+			"https://example.com",
+			"test-version",
+		);
 		expect(config2.maxPages).toBeNull();
 	});
 


### PR DESCRIPTION
## 概要

プロジェクトレビューで発見された **P2（中優先度）** の問題を修正しました。

`bun run check`（Biome）がフォーマット違反を検出しており、CIの `lint` ジョブが失敗する状態を解消しました。

## 変更内容

### 修正ファイル

- `link-crawler/src/config.ts` - 関数シグネチャのフォーマット（1箇所）
- `link-crawler/tests/unit/config.test.ts` - 長い行のフォーマット（8箇所）

### 具体的な変更

```typescript
// Before
export function parseConfig(options: Record<string, unknown>, startUrl: string, version: string): CrawlConfig {

// After
export function parseConfig(
	options: Record<string, unknown>,
	startUrl: string,
	version: string,
): CrawlConfig {
```

複数行にまたがる `parseConfig()` 呼び出しも同様にフォーマットしました。

## 修正方法

```bash
cd link-crawler
bun run fix
```

Biome の自動修正機能を使用して、全ての違反を修正しました。

## 検証結果

✅ `bun run check` - エラー0件でパス
✅ `bun run test` - 全708テストがパス

## 関連Issue

Closes #736