### PR TITLE
docs: fix CrawlConfig type definition inconsistencies in design doc

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -243,8 +243,11 @@ interface CrawlConfig {
   sameDomain: boolean;
   includePattern: RegExp | null;
   excludePattern: RegExp | null;
+  /** リクエスト間隔（ミリ秒） */
   delay: number;
+  /** リクエストタイムアウト（ミリ秒） */
   timeout: number;
+  /** SPAページ待機時間（ミリ秒） */
   spaWait: number;
   headed: boolean;
   diff: boolean;
@@ -284,8 +287,8 @@ interface CrawledPage {
 interface CrawlResult {
   crawledAt: string;
   baseUrl: string;
-  /** クロール設定の一部（実際にはmaxDepthとsameDomainのみ保存される） */
-  config: Partial<CrawlConfig>;
+  /** 保存対象の設定項目（maxDepth, sameDomain のみ） */
+  config: Pick<CrawlConfig, "maxDepth" | "sameDomain">;
   totalPages: number;
   pages: CrawledPage[];
   specs: DetectedSpec[];


### PR DESCRIPTION
## 概要

設計書 (`docs/design.md`) の型定義と実装の不整合を修正しました。

## 変更内容

### 1. CrawlConfig の単位コメント追加
- `delay`, `timeout`, `spaWait` フィールドに「（ミリ秒）」を追加
- 実装 (`link-crawler/src/types.ts`) と設計書が一致

### 2. CrawlResult.config の型定義明確化
- `Partial<CrawlConfig>` → `Pick<CrawlConfig, "maxDepth" | "sameDomain">`
- コメントも「保存対象の設定項目（maxDepth, sameDomain のみ）」に変更
- 実際の動作を正確に反映

## 影響
- ドキュメントのみの変更（コードの変更なし）
- 新規開発者のオンボーディング改善
- 型定義の誤解を防止

## チェックリスト
- [x] delay, timeout, spaWait にミリ秒のコメントを追加
- [x] CrawlResult.config を Pick 型に変更
- [x] 設計書と実装の整合性を確認

Closes #748