### PR TITLE
fix: Biome フォーマッターエラー (post-processor.ts)

### DIFF
--- a/link-crawler/src/crawler/post-processor.ts
+++ b/link-crawler/src/crawler/post-processor.ts
@@ -45,9 +45,7 @@ export class PostProcessor {
 		// - merge: full.md出力のため
 		// - chunks: チャンク分割のため
 		const needsFullContent = this.config.merge || this.config.chunks;
-		const fullMdContent = needsFullContent
-			? this.merger.buildFullContent(pages, contents)
-			: "";
+		const fullMdContent = needsFullContent ? this.merger.buildFullContent(pages, contents) : "";
 
 		// Merger出力 (full.md書き込み)
 		if (this.config.merge && fullMdContent) {


### PR DESCRIPTION
## 概要

プロジェクトレビューで発見されたBiomeフォーマッターエラーの修正。

## 変更内容

- `link-crawler/src/crawler/post-processor.ts` の48-50行目の三項演算子を1行にインライン化

### Before
```typescript
const fullMdContent = needsFullContent
    ? this.merger.buildFullContent(pages, contents)
    : "";
```

### After
```typescript
const fullMdContent = needsFullContent ? this.merger.buildFullContent(pages, contents) : "";
```

## 影響範囲

- フォーマットのみの変更
- ロジックに影響なし

## 検証

- ✅ `bun run lint` → エラー0件
- ✅ `bun run typecheck` → エラーなし
- ✅ `bun run test` → 全テストパス (708件)

Closes #744