### PR TITLE
fix: mainブランチのBiome CI失敗（lint/format 5エラー）

### DIFF
--- a/link-crawler/src/crawler/fetcher.ts
+++ b/link-crawler/src/crawler/fetcher.ts
@@ -95,6 +95,7 @@ export class PlaywrightFetcher implements Fetcher {
 				return null;
 			}
 			// 制御文字のチェックを追加
+			// biome-ignore lint/suspicious/noControlCharactersInRegex: Intentional check for control characters in URLs
 			if (/[\x00-\x1f\x7f]/.test(url)) {
 				return null;
 			}

--- a/link-crawler/src/error-handler.ts
+++ b/link-crawler/src/error-handler.ts
@@ -1,5 +1,5 @@
-import { ConfigError, CrawlError, DependencyError, FetchError, TimeoutError } from "./errors.js";
 import { EXIT_CODES } from "./constants.js";
+import { ConfigError, CrawlError, DependencyError, FetchError, TimeoutError } from "./errors.js";
 
 export interface ErrorHandlerResult {
 	message: string;

--- a/link-crawler/tests/unit/error-handler.test.ts
+++ b/link-crawler/tests/unit/error-handler.test.ts
@@ -7,9 +7,15 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { handleError } from "../../src/error-handler.js";
-import { ConfigError, CrawlError, DependencyError, FetchError, TimeoutError } from "../../src/errors.js";
 import { EXIT_CODES } from "../../src/constants.js";
+import { handleError } from "../../src/error-handler.js";
+import {
+	ConfigError,
+	CrawlError,
+	DependencyError,
+	FetchError,
+	TimeoutError,
+} from "../../src/errors.js";
 
 describe("Error Handler", () => {
 	describe("DependencyError handling", () => {
@@ -53,7 +59,9 @@ describe("Error Handler", () => {
 			const error = new FetchError("HTTP 404 Not Found", "https://example.com/missing");
 			const result = handleError(error);
 
-			expect(result.message).toBe("✗ Fetch error at https://example.com/missing: HTTP 404 Not Found");
+			expect(result.message).toBe(
+				"✗ Fetch error at https://example.com/missing: HTTP 404 Not Found",
+			);
 			expect(result.exitCode).toBe(EXIT_CODES.CRAWL_ERROR);
 		});
 


### PR DESCRIPTION
## 概要

mainブランチのBiome CI失敗を修正しました。5つのlint/formatエラーをすべて解消しています。

## 修正内容

### 1. 制御文字正規表現の警告抑制
- **ファイル**: 
- **変更**: 意図的な制御文字チェックに `biome-ignore` コメントを追加
- **理由**: URLの制御文字検出は意図的な実装のため、lintルールを抑制

### 2. import順序の修正（自動修正）
- **ファイル**: 
  - `link-crawler/src/error-handler.ts`
  - `link-crawler/tests/unit/error-handler.test.ts`
- **変更**: BiomeのorganizeImportsルールに従いimport文を並び替え

### 3. フォーマット適用
- **ファイル**: `link-crawler/tests/unit/error-handler.test.ts`
- **変更**: 長い行を複数行に分割してフォーマット適用

## 検証結果

✅ `bun run check` - Biomeチェック成功（0エラー）
✅ `bun run typecheck` - TypeScriptコンパイル成功

## 関連Issue

Closes #754