### PR TITLE
fix: add missing version property to baseConfig in crawler-link-extraction-order.test.ts

### DIFF
--- a/link-crawler/tests/unit/crawler-link-extraction-order.test.ts
+++ b/link-crawler/tests/unit/crawler-link-extraction-order.test.ts
@@ -65,6 +65,7 @@ describe("Crawler - link extraction order", () => {
 			chunks: false,
 			keepSession: false,
 			respectRobots: false,
+			version: "1.0.0",
 		};
 	});
 


### PR DESCRIPTION
## 概要

mainブランチのCI（Type Check）で発生していたTypeScriptエラーを修正。

## 問題

`tests/unit/crawler-link-extraction-order.test.ts` の `baseConfig` オブジェクトに `version` プロパティが欠落していた。

## 原因

- PR #718（リンク抽出順序のリグレッションテスト追加）が PR #734（CrawlConfig version修正）の後にマージされた
- PR #718作成時には `version` プロパティが不要だったため、含まれていなかった

## 修正内容

- `baseConfig` に `version: "1.0.0"` を追加

## テスト結果

- ✅ TypeCheck: パス
- ✅ 全テスト: 747件パス
- ✅ Biome lint: パス

Closes #756