### PR TITLE
docs: fix vitest.config.ts coverage.exclude in development.md

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -263,7 +263,7 @@ export default defineConfig({
 			provider: "v8",
 			reporter: ["text", "html", "json-summary"],
 			include: ["src/**/*.ts"],
-			exclude: ["src/crawl.ts"],
+			exclude: [],
 		},
 	},
 });


### PR DESCRIPTION
## 概要

`docs/development.md` の vitest.config.ts 設定記載を実際のコードと一致させる修正

## 変更内容

- **ファイル**: `docs/development.md` セクション5.2
- **修正箇所**: `coverage.exclude` の値
  - Before: `exclude: ["src/crawl.ts"]`
  - After: `exclude: []`

## 検証

```bash
# 実際のファイルと一致することを確認済み
diff <(grep -A 5 "coverage:" link-crawler/vitest.config.ts) <(grep -A 5 "coverage:" docs/development.md)
# ✅ Files match perfectly!
```

## 影響

- ドキュメント修正のみ、コード変更なし
- テスト実行への影響なし

Closes #760