### PR TITLE
refactor: CrawlResult.config の型を Partial<CrawlConfig> から Pick<CrawlConfig, ...> に変更

### DIFF
--- a/link-crawler/src/types.ts
+++ b/link-crawler/src/types.ts
@@ -68,7 +68,7 @@ export interface DetectedSpec {
 export interface CrawlResult {
 	crawledAt: string;
 	baseUrl: string;
-	config: Partial<CrawlConfig>;
+	config: Pick<CrawlConfig, "maxDepth" | "sameDomain">;
 	totalPages: number;
 	pages: CrawledPage[];
 	specs: DetectedSpec[];


### PR DESCRIPTION
## 概要

`CrawlResult.config` の型を `Partial<CrawlConfig>` から `Pick<CrawlConfig, "maxDepth" | "sameDomain">` に変更し、型安全性を向上させました。

## 変更内容

- `link-crawler/src/types.ts` の `CrawlResult.config` 型定義を変更
- 実際に保存される2つのプロパティ（`maxDepth` と `sameDomain`）のみを明示的に指定

## 影響範囲

- 型レベルの変更のみで、実行時の動作は変わりません
- 既存の実装（`index-manager.ts`）は既に2つのプロパティのみを使用しているため、影響なし

## テスト結果

- ✅ TypeScript型チェック: 成功
- ✅ 全テスト (747件): 成功

## 設計との整合性

設計書（design.md）に記載されている型定義と一致するようになりました。

Closes #758