### PR TITLE
refactor: 未使用の FileError クラスを削除

### DIFF
--- a/link-crawler/src/errors.ts
+++ b/link-crawler/src/errors.ts
@@ -40,18 +40,6 @@ export class ConfigError extends CrawlError {
 	}
 }
 
-/** ファイル入出力エラー */
-export class FileError extends CrawlError {
-	constructor(
-		message: string,
-		public readonly filePath: string,
-		cause?: Error,
-	) {
-		super(message, "FILE_ERROR", cause);
-		this.name = "FileError";
-	}
-}
-
 /** 依存関係エラー */
 export class DependencyError extends CrawlError {
 	constructor(

--- a/link-crawler/tests/unit/errors.test.ts
+++ b/link-crawler/tests/unit/errors.test.ts
@@ -4,7 +4,6 @@ import {
 	CrawlError,
 	DependencyError,
 	FetchError,
-	FileError,
 	TimeoutError,
 } from "../../src/errors.js";
 
@@ -85,31 +84,6 @@ describe("ConfigError", () => {
 
 	it("should inherit from CrawlError", () => {
 		const error = new ConfigError("Test");
-
-		expect(error).toBeInstanceOf(CrawlError);
-	});
-});
-
-describe("FileError", () => {
-	it("should create file error with filePath", () => {
-		const error = new FileError("Cannot read file", "/path/to/file.txt");
-
-		expect(error.message).toBe("Cannot read file");
-		expect(error.filePath).toBe("/path/to/file.txt");
-		expect(error.code).toBe("FILE_ERROR");
-		expect(error.name).toBe("FileError");
-	});
-
-	it("should create file error with cause", () => {
-		const cause = new Error("Permission denied");
-		const error = new FileError("Cannot write file", "/path/to/file.txt", cause);
-
-		expect(error.cause).toBe(cause);
-		expect(error.toString()).toContain("Permission denied");
-	});
-
-	it("should inherit from CrawlError", () => {
-		const error = new FileError("Test", "/path");
 
 		expect(error).toBeInstanceOf(CrawlError);
 	});


### PR DESCRIPTION
## Summary
Closes #759

未使用の `FileError` クラスをコードベースから削除しました。

## Changes
- ❌ `link-crawler/src/errors.ts`: `FileError` クラス定義を削除 (12行)
- ❌ `link-crawler/tests/unit/errors.test.ts`: `FileError` のimportとテストを削除 (26行)

## Impact
- **Production code**: 影響なし（使用箇所なし）
- **Test code**: 該当テストケースのみ削除
- **Dependencies**: 影響なし（独立したクラス）

## Testing
```bash
✅ All 744 tests passed
✅ TypeCheck passed
✅ No FileError references in src/
```

## Rationale
`FileError` はファイルI/Oエラー用に定義されていましたが、プロダクションコードで一度も使用されていませんでした。
ファイルI/Oエラーは現在 try-catch + ログ出力で処理されています。
将来的に必要になった場合は、その時点で再導入を検討します（Git履歴に残ります）。