### PR TITLE
fix: vitest.config.ts の coverage.exclude が空配列で docs/development.md と不一致

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -263,7 +263,7 @@ export default defineConfig({
 			provider: "v8",
 			reporter: ["text", "html", "json-summary"],
 			include: ["src/**/*.ts"],
-			exclude: [],
+			exclude: ["src/crawl.ts", "src/types.ts", "src/types/**"],
 		},
 	},
 });

--- a/link-crawler/vitest.config.ts
+++ b/link-crawler/vitest.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
 			provider: "v8",
 			reporter: ["text", "html", "json-summary"],
 			include: ["src/**/*.ts"],
-			exclude: [],
+			exclude: ["src/crawl.ts", "src/types.ts", "src/types/**"],
 		},
 	},
 });


### PR DESCRIPTION
## Summary
Closes #768

## Changes
- `vitest.config.ts` の `coverage.exclude` に `src/crawl.ts`, `src/types.ts`, `src/types/**` を追加
- `docs/development.md` の設定例も同様に更新
- テスト不可能なファイル（エントリーポイント、型定義）をカバレッジレポートから除外

## Testing
- ✅ 全テストがパス（744 tests）
- ✅ カバレッジレポートで除外されたファイルが表示されないことを確認
- ✅ `docs/development.md` と `vitest.config.ts` の設定が一致

## 影響
- カバレッジレポートがより正確になる（テスト不可能なファイルが除外される）
- ドキュメントと実装の一貫性が確保される