### PR TITLE
refactor: restrict slugify to ASCII-only for cross-platform compatibility

### DIFF
--- a/link-crawler/src/output/writer.ts
+++ b/link-crawler/src/output/writer.ts
@@ -14,7 +14,7 @@ function slugify(text: string | null | undefined, maxLength = 50): string {
 	return text
 		.toLowerCase()
 		.trim()
-		.replace(/[^\p{L}\p{N}\s_-]/gu, "") // Unicode文字・数字・スペース・アンダースコア・ハイフン以外を除去
+		.replace(/[^a-z0-9\s_-]/g, "") // ASCII英数字・スペース・アンダースコア・ハイフン以外を除去
 		.replace(/[\s_]+/g, "-") // スペースとアンダースコアをハイフンに
 		.replace(/-+/g, "-") // 連続するハイフンを1つに
 		.replace(/^-+|-+$/g, "") // 先頭・末尾のハイフンを除去

--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -342,8 +342,8 @@ describe("OutputWriter", () => {
 				{ ...defaultMetadata, title: "日本語タイトル" },
 				null,
 			);
-			// Japanese characters are now preserved by slugify
-			expect(pageFile).toBe("pages/page-001-日本語タイトル.md");
+			// Non-ASCII characters are removed, resulting in sequential number only
+			expect(pageFile).toBe("pages/page-001.md");
 		});
 
 		it("should handle mixed alphanumeric and Japanese", () => {
@@ -356,8 +356,8 @@ describe("OutputWriter", () => {
 				{ ...defaultMetadata, title: "日本語Englishタイトル123" },
 				null,
 			);
-			// Both ASCII and Japanese characters are preserved
-			expect(pageFile).toBe("pages/page-001-日本語englishタイトル123.md");
+			// Non-ASCII characters are removed, only ASCII remains
+			expect(pageFile).toBe("pages/page-001-english123.md");
 		});
 
 		it("should handle Chinese titles (simplified)", () => {
@@ -370,7 +370,8 @@ describe("OutputWriter", () => {
 				{ ...defaultMetadata, title: "配置指南" },
 				null,
 			);
-			expect(pageFile).toBe("pages/page-001-配置指南.md");
+			// Non-ASCII characters are removed, resulting in sequential number only
+			expect(pageFile).toBe("pages/page-001.md");
 		});
 
 		it("should handle Chinese titles (traditional)", () => {
@@ -383,7 +384,8 @@ describe("OutputWriter", () => {
 				{ ...defaultMetadata, title: "設定指南" },
 				null,
 			);
-			expect(pageFile).toBe("pages/page-001-設定指南.md");
+			// Non-ASCII characters are removed, resulting in sequential number only
+			expect(pageFile).toBe("pages/page-001.md");
 		});
 
 		it("should handle Korean titles", () => {
@@ -396,7 +398,8 @@ describe("OutputWriter", () => {
 				{ ...defaultMetadata, title: "시작하기 가이드" },
 				null,
 			);
-			expect(pageFile).toBe("pages/page-001-시작하기-가이드.md");
+			// Non-ASCII characters are removed, resulting in sequential number only
+			expect(pageFile).toBe("pages/page-001.md");
 		});
 
 		it("should remove emoji from titles", () => {
@@ -409,7 +412,7 @@ describe("OutputWriter", () => {
 				{ ...defaultMetadata, title: "Getting Started 🚀 Guide 😊" },
 				null,
 			);
-			// Emoji are removed, but spaces between words become hyphens
+			// Emoji and non-ASCII characters are removed, spaces become hyphens
 			expect(pageFile).toBe("pages/page-001-getting-started-guide.md");
 		});
 
@@ -426,9 +429,8 @@ describe("OutputWriter", () => {
 				{ ...defaultMetadata, title: longTitle },
 				null,
 			);
-			// Should be truncated to 50 characters
-			const expectedSlug = longTitle.slice(0, 50);
-			expect(pageFile).toBe(`pages/page-001-${expectedSlug}.md`);
+			// All non-ASCII characters are removed, resulting in sequential number only
+			expect(pageFile).toBe("pages/page-001.md");
 		});
 
 		it("should handle Arabic titles", () => {
@@ -441,7 +443,8 @@ describe("OutputWriter", () => {
 				{ ...defaultMetadata, title: "دليل البدء" },
 				null,
 			);
-			expect(pageFile).toBe("pages/page-001-دليل-البدء.md");
+			// Non-ASCII characters are removed, resulting in sequential number only
+			expect(pageFile).toBe("pages/page-001.md");
 		});
 
 		it("should handle Cyrillic titles", () => {
@@ -454,7 +457,36 @@ describe("OutputWriter", () => {
 				{ ...defaultMetadata, title: "Руководство по началу работы" },
 				null,
 			);
-			expect(pageFile).toBe("pages/page-001-руководство-по-началу-работы.md");
+			// Non-ASCII characters are removed, resulting in sequential number only
+			expect(pageFile).toBe("pages/page-001.md");
+		});
+
+		it("should remove all non-ASCII characters from mixed title", () => {
+			const writer = new OutputWriter(defaultConfig);
+			const pageFile = writer.savePage(
+				"https://example.com",
+				"# Content",
+				0,
+				[],
+				{ ...defaultMetadata, title: "Hello世界World" },
+				null,
+			);
+			// Non-ASCII characters (世界) are removed, "HelloWorld" becomes "helloworld"
+			expect(pageFile).toBe("pages/page-001-helloworld.md");
+		});
+
+		it("should fallback to sequential number when title becomes empty after slugify", () => {
+			const writer = new OutputWriter(defaultConfig);
+			const pageFile = writer.savePage(
+				"https://example.com",
+				"# Content",
+				0,
+				[],
+				{ ...defaultMetadata, title: "日本語のみ" },
+				null,
+			);
+			// All characters are non-ASCII and removed, resulting in empty string
+			expect(pageFile).toBe("pages/page-001.md");
 		});
 	});
 


### PR DESCRIPTION
## Summary
Closes #780

## Changes
- Changed `slugify` function regex from Unicode (`\p{L}\p{N}`) to ASCII-only (`[a-z0-9]`)
- Updated all tests to expect non-ASCII characters to be removed from filenames
- Added tests for mixed ASCII/non-ASCII titles and empty-after-slugify cases

## Motivation
The previous implementation allowed non-ASCII characters (Japanese, Chinese, Korean, etc.) in filenames, which can cause issues in:
- Windows environments (encoding problems)
- Old CI environments (UTF-8 filename support)
- ZIP compression tools (character corruption)
- Cross-platform Git operations (filename normalization differences)

## Testing
- All 44 writer tests pass
- Verified non-ASCII characters are properly removed
- Filenames now contain only ASCII alphanumeric characters and hyphens
- Sequential numbering ensures uniqueness when titles become empty

## Impact
- Existing crawl data: Files with non-ASCII names will remain unchanged
- New crawls: Generate ASCII-only filenames
- Original titles preserved in frontmatter and index.json