### PR TITLE
refactor: CrawlLogger の debug フラグをコンストラクタ注入に変更

### DIFF
--- a/link-crawler/src/crawler/logger.ts
+++ b/link-crawler/src/crawler/logger.ts
@@ -8,8 +8,8 @@ export class CrawlLogger implements Logger {
 	private skippedCount = 0;
 	private debug: boolean;
 
-	constructor(private config: CrawlConfig) {
-		this.debug = process.env.DEBUG === "1";
+	constructor(private config: CrawlConfig, debug?: boolean) {
+		this.debug = debug ?? process.env.DEBUG === "1";
 	}
 
 	/** クロール開始ログ */


### PR DESCRIPTION
## 概要

`CrawlLogger` のテスタビリティを改善するため、`debug` フラグをコンストラクタパラメータとして注入できるようにしました。

## 変更内容

### 主要な変更
- `CrawlLogger` のコンストラクタに `debug?: boolean` パラメータを追加
- デフォルト値として `process.env.DEBUG === '1'` を維持（後方互換性）
- `PlaywrightFetcher` と同じ依存注入パターンに統一

### テスト
- デバッグログ機能の包括的なテストケースを追加（6件）
- 全テストパス（773 tests）
- 環境変数の動作確認を含む

## 設計上の利点

1. **テスタビリティ**: 環境変数に依存せずデバッグログの挙動をテスト可能
2. **一貫性**: `PlaywrightFetcher` と同じパターンに統一
3. **後方互換性**: 既存コードの変更不要
4. **依存注入**: テスト時に特定の値を注入可能

## テスト結果

```
✓ tests/unit/logger.test.ts (26 tests)
  ✓ debug logging (6 new tests)
    ✓ should respect debug parameter when explicitly set to true
    ✓ should not log debug messages when explicitly set to false
    ✓ should default to process.env.DEBUG when debug parameter is omitted
    ✓ should log debug message with data when provided
    ✓ should include debug enabled message in logStart when debug is true
    ✓ should not include debug message in logStart when debug is false

Test Files  26 passed (26)
     Tests  773 passed (773)
```

Closes #788