### PR TITLE
fix: 統合テストファイルの Biome lint/format エラー修正 (crawl-cli.test.ts)

### DIFF
--- a/link-crawler/tests/integration/crawl-cli.test.ts
+++ b/link-crawler/tests/integration/crawl-cli.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, rm, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rm } from "node:fs";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const TEST_OUTPUT_DIR = "tests/integration/.test-crawl-cli";
@@ -59,9 +59,10 @@ describe("crawl CLI integration", () => {
 			});
 			// Should not reach here
 			expect.fail("Should have thrown an error");
-		} catch (error: any) {
+		} catch (error: unknown) {
 			// Should exit with non-zero code
-			expect(error.status).toBeGreaterThan(0);
+			const err = error as { status: number };
+			expect(err.status).toBeGreaterThan(0);
 		}
 	});
 
@@ -71,22 +72,20 @@ describe("crawl CLI integration", () => {
 		const outputDir = `${TEST_OUTPUT_DIR}/output-example`;
 
 		try {
-			const result = execSync(
-				`bun run src/crawl.ts "https://example.com" -d 0 -o "${outputDir}"`,
-				{
-					encoding: "utf-8",
-					cwd: process.cwd(),
-					stdio: "pipe",
-					timeout: 30000,
-				},
-			);
+			const result = execSync(`bun run src/crawl.ts "https://example.com" -d 0 -o "${outputDir}"`, {
+				encoding: "utf-8",
+				cwd: process.cwd(),
+				stdio: "pipe",
+				timeout: 30000,
+			});
 
 			// Should complete successfully
 			expect(result).toContain("Crawl complete");
-		} catch (error: any) {
+		} catch (error: unknown) {
 			// If it times out or has network issues, that's okay
 			// The important thing is it didn't fail with INVALID_ARGUMENTS (exit code 2)
-			expect(error.status).not.toBe(2);
+			const err = error as { status: number };
+			expect(err.status).not.toBe(2);
 		}
 	}, 35000); // Increase timeout for real crawl
 
@@ -98,9 +97,10 @@ describe("crawl CLI integration", () => {
 				stdio: "pipe",
 			});
 			expect.fail("Should have thrown an error");
-		} catch (error: any) {
+		} catch (error: unknown) {
 			// Should exit with an error code (not 0)
-			expect(error.status).not.toBe(0);
+			const err = error as { status: number };
+			expect(err.status).not.toBe(0);
 		}
 	});
 });

--- a/link-crawler/tests/unit/crawl.test.ts
+++ b/link-crawler/tests/unit/crawl.test.ts
@@ -6,7 +6,7 @@
  *
  * Strategy:
  * - Test what we CAN test: version loading, imports, basic structure
- * - Focus on improving coverage rather than complex mocking scenarios  
+ * - Focus on improving coverage rather than complex mocking scenarios
  * - Signal handlers are tested indirectly through integration tests
  */
 
@@ -20,7 +20,7 @@ describe("crawl.ts entrypoint - code coverage", () => {
 		it("should have access to EXIT_CODES constants", () => {
 			//  crawl.ts uses EXIT_CODES from constants.js
 			expect(EXIT_CODES).toBeDefined();
-		expect(EXIT_CODES.SUCCESS).toBeDefined();
+			expect(EXIT_CODES.SUCCESS).toBeDefined();
 		});
 
 		it("should have access to handleError function", () => {
@@ -34,7 +34,7 @@ describe("crawl.ts entrypoint - code coverage", () => {
 		it("should handle ConfigError with correct exit code", () => {
 			const error = new ConfigError("Invalid config", "test");
 			const result = handleError(error);
-			
+
 			expect(result.exitCode).toBe(EXIT_CODES.INVALID_ARGUMENTS);
 			expect(result.message).toContain("Configuration error");
 		});
@@ -42,7 +42,7 @@ describe("crawl.ts entrypoint - code coverage", () => {
 		it("should handle DependencyError with correct exit code", () => {
 			const error = new DependencyError("Missing dependency", "playwright-cli");
 			const result = handleError(error);
-			
+
 			expect(result.exitCode).toBe(EXIT_CODES.DEPENDENCY_ERROR);
 			expect(result.message).toContain("Missing dependency");
 		});
@@ -50,7 +50,7 @@ describe("crawl.ts entrypoint - code coverage", () => {
 		it("should handle FetchError with correct exit code", () => {
 			const error = new FetchError("Network error", "https://example.com");
 			const result = handleError(error);
-			
+
 			expect(result.exitCode).toBe(EXIT_CODES.CRAWL_ERROR);
 			expect(result.message).toContain("Fetch error");
 		});
@@ -58,7 +58,7 @@ describe("crawl.ts entrypoint - code coverage", () => {
 		it("should handle unknown errors with GENERAL_ERROR code", () => {
 			const error = new Error("Unknown error");
 			const result = handleError(error);
-			
+
 			expect(result.exitCode).toBe(EXIT_CODES.GENERAL_ERROR);
 			expect(result.message).toContain("Fatal error");
 		});


### PR DESCRIPTION
## 概要

Issue #784 で報告された  の Biome lint/format エラーを修正しました。

## 変更内容

### 1. noExplicitAny エラー修正 (3箇所)
- `catch (error: any)` を `catch (error: unknown)` + 型アサーションに変更
- Lines: 62, 86, 101

### 2. noUnusedImports エラー修正
- 未使用の `writeFileSync` インポートを削除

### 3. フォーマット不整合修正
- `bun run fix` で Biome フォーマット規則に準拠
- `execSync` 呼び出しの整形
- `crawl.test.ts` の trailing whitespace と indentation も修正

## テスト結果

```bash
✅ bun run lint    # 0 errors (52 files checked)
✅ bun run test    # 767 tests passed
✅ bun run typecheck  # No TypeScript errors
```

## 関連Issue

Closes #784