### PR TITLE
fix: Biome CI failures in test files

### DIFF
--- a/link-crawler/src/crawler/logger.ts
+++ b/link-crawler/src/crawler/logger.ts
@@ -8,7 +8,10 @@ export class CrawlLogger implements Logger {
 	private skippedCount = 0;
 	private debug: boolean;
 
-	constructor(private config: CrawlConfig, debug?: boolean) {
+	constructor(
+		private config: CrawlConfig,
+		debug?: boolean,
+	) {
 		this.debug = debug ?? process.env.DEBUG === "1";
 	}
 


### PR DESCRIPTION
## 概要
Biome CI の失敗を修正。mainブランチで発生していた6件のlint/formatエラーを解消。

Closes #790

## 変更内容

### tests/integration/crawl-cli.test.ts (5件修正)

1. **`any` 型を `unknown` に変更** (3箇所)
   - 行62, 86, 101: `catch (error: any)` → `catch (error: unknown)`
   - 型ガードを追加してエラーオブジェクトの `status` プロパティに安全にアクセス
   
2. **未使用importの削除**
   - `writeFileSync` を import から削除

3. **フォーマット修正**
   - `execSync` 呼び出しの整形

### tests/unit/crawl.test.ts (1件修正)

1. **フォーマット修正**
   - 末尾の余分な空白削除
   - インデント修正

## 検証

✅ `bun run check` - Biome lint/format パス
✅ `bun run typecheck` - TypeScript型チェック パス
✅ `bun run test` - 全テスト パス (767 tests)

## レビューポイント

- `unknown` 型への変更により型安全性が向上
- 既存のテストの挙動は変更なし
- フォーマットは自動修正で統一