### PR TITLE
docs: Vitest設定にglobalSetupの行を追加

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -251,6 +251,7 @@ export default defineConfig({
 	test: {
 		globals: true,
 		include: ["tests/**/*.test.ts"],
+		globalSetup: "./tests/global-setup.ts",
 		globalTeardown: "./tests/global-teardown.ts",
 		// Enable file-level parallelism for faster test execution
 		// forks pool provides complete isolation between test files


### PR DESCRIPTION
## 概要

`docs/development.md` のセクション5.2のVitest設定スニペットに、実際の `vitest.config.ts` には存在する `globalSetup: "./tests/global-setup.ts"` の行が欠落していたため、追加しました。

## 変更内容

- `docs/development.md` のVitest設定に `globalSetup` 行を追加
- これにより、ドキュメントと実際のコード(`link-crawler/vitest.config.ts`)が一致

## 検証

```bash
# ドキュメントと実際の設定が一致することを確認
grep -A 2 'globalSetup\|globalTeardown' link-crawler/vitest.config.ts
grep -A 2 'globalSetup\|globalTeardown' docs/development.md
```

Closes #798