### PR TITLE
refactor: remove unused _outputDir parameter from Merger constructor

### DIFF
--- a/link-crawler/src/crawler/logger.ts
+++ b/link-crawler/src/crawler/logger.ts
@@ -8,7 +8,10 @@ export class CrawlLogger implements Logger {
 	private skippedCount = 0;
 	private debug: boolean;
 
-	constructor(private config: CrawlConfig, debug?: boolean) {
+	constructor(
+		private config: CrawlConfig,
+		debug?: boolean,
+	) {
 		this.debug = debug ?? process.env.DEBUG === "1";
 	}
 

--- a/link-crawler/src/crawler/post-processor.ts
+++ b/link-crawler/src/crawler/post-processor.ts
@@ -19,7 +19,7 @@ export class PostProcessor {
 		logger?: CrawlLogger,
 	) {
 		this.logger = logger ?? new CrawlLogger(config);
-		this.merger = new Merger(config.outputDir);
+		this.merger = new Merger();
 		this.chunker = new Chunker(config.outputDir);
 	}
 

--- a/link-crawler/src/output/merger.ts
+++ b/link-crawler/src/output/merger.ts
@@ -5,9 +5,6 @@ import type { CrawledPage } from "../types.js";
  * 全ページを結合してfull.mdを生成
  */
 export class Merger {
-	// biome-ignore lint/complexity/noUselessConstructor: Maintaining API compatibility
-	constructor(_outputDir: string) {}
-
 	/**
 	 * Markdownから先頭のH1タイトルを除去
 	 * frontmatterがある場合は考慮する

--- a/link-crawler/tests/unit/merger.test.ts
+++ b/link-crawler/tests/unit/merger.test.ts
@@ -35,7 +35,7 @@ describe("Merger", () => {
 
 	describe("stripTitle", () => {
 		it("should remove H1 title from markdown", () => {
-			const merger = new Merger(testOutputDir);
+			const merger = new Merger();
 			const markdown = "# Page Title\n\nSome content here.";
 
 			const result = merger.stripTitle(markdown);
@@ -44,7 +44,7 @@ describe("Merger", () => {
 		});
 
 		it("should handle markdown without H1", () => {
-			const merger = new Merger(testOutputDir);
+			const merger = new Merger();
 			const markdown = "Some content without title.";
 
 			const result = merger.stripTitle(markdown);
@@ -53,7 +53,7 @@ describe("Merger", () => {
 		});
 
 		it("should skip frontmatter and remove H1", () => {
-			const merger = new Merger(testOutputDir);
+			const merger = new Merger();
 			const markdown = `---
 url: https://example.com
 title: "Test"
@@ -69,7 +69,7 @@ Content after title.`;
 		});
 
 		it("should remove multiple blank lines after title", () => {
-			const merger = new Merger(testOutputDir);
+			const merger = new Merger();
 			const markdown = "# Title\n\n\n\nContent";
 
 			const result = merger.stripTitle(markdown);
@@ -80,7 +80,7 @@ Content after title.`;
 
 	describe("buildFullContent", () => {
 		it("should build full markdown content without writing to file", () => {
-			const merger = new Merger(testOutputDir);
+			const merger = new Merger();
 			const pages = [createPage("https://example.com/page1", "Page 1", "pages/page-001.md")];
 			const pageContents = new Map([["pages/page-001.md", "# Page 1\n\nThis is content."]]);
 
@@ -92,7 +92,7 @@ Content after title.`;
 		});
 
 		it("should merge multiple pages with separators", () => {
-			const merger = new Merger(testOutputDir);
+			const merger = new Merger();
 			const pages = [
 				createPage("https://example.com/page1", "Page 1", "pages/page-001.md"),
 				createPage("https://example.com/page2", "Page 2", "pages/page-002.md"),
@@ -113,7 +113,7 @@ Content after title.`;
 		});
 
 		it("should handle empty pages array", () => {
-			const merger = new Merger(testOutputDir);
+			const merger = new Merger();
 			const pages: CrawledPage[] = [];
 			const pageContents = new Map<string, string>();
 
@@ -123,7 +123,7 @@ Content after title.`;
 		});
 
 		it("should use URL as title when title is null", () => {
-			const merger = new Merger(testOutputDir);
+			const merger = new Merger();
 			const pages = [createPage("https://example.com/page1", null, "pages/page-001.md")];
 			const pageContents = new Map([["pages/page-001.md", "# Original Title\n\nContent"]]);
 
@@ -134,7 +134,7 @@ Content after title.`;
 		});
 
 		it("should strip frontmatter and title from content", () => {
-			const merger = new Merger(testOutputDir);
+			const merger = new Merger();
 			const pages = [createPage("https://example.com/page1", "Page 1", "pages/page-001.md")];
 			const pageContents = new Map([
 				[
@@ -162,7 +162,7 @@ Content after frontmatter`,
 
 	describe("buildFullContent + writeFileSync", () => {
 		it("should write full.md file", () => {
-			const merger = new Merger(testOutputDir);
+			const merger = new Merger();
 			const pages = [createPage("https://example.com/page1", "Page 1", "pages/page-001.md")];
 			const pageContents = new Map([["pages/page-001.md", "# Page 1\n\nThis is content."]]);
 
@@ -178,7 +178,7 @@ Content after frontmatter`,
 		});
 
 		it("should merge multiple pages with separators", () => {
-			const merger = new Merger(testOutputDir);
+			const merger = new Merger();
 			const pages = [
 				createPage("https://example.com/page1", "Page 1", "pages/page-001.md"),
 				createPage("https://example.com/page2", "Page 2", "pages/page-002.md"),
@@ -199,7 +199,7 @@ Content after frontmatter`,
 		});
 
 		it("should handle duplicate titles across pages", () => {
-			const merger = new Merger(testOutputDir);
+			const merger = new Merger();
 			const pages = [
 				createPage("https://example.com/page1", "Same Title", "pages/page-001.md"),
 				createPage("https://example.com/page2", "Same Title", "pages/page-002.md"),
@@ -223,7 +223,7 @@ Content after frontmatter`,
 		});
 
 		it("should handle empty content in pageContents", () => {
-			const merger = new Merger(testOutputDir);
+			const merger = new Merger();
 			const pages = [createPage("https://example.com/page1", "Page 1", "pages/page-001.md")];
 			const pageContents = new Map<string, string>([]);
 
@@ -239,7 +239,7 @@ Content after frontmatter`,
 		});
 
 		it("should handle pages with empty markdown content", () => {
-			const merger = new Merger(testOutputDir);
+			const merger = new Merger();
 			const pages = [createPage("https://example.com/page1", "Page 1", "pages/page-001.md")];
 			const pageContents = new Map([["pages/page-001.md", ""]]);
 
@@ -253,7 +253,7 @@ Content after frontmatter`,
 		});
 
 		it("should handle many pages efficiently", () => {
-			const merger = new Merger(testOutputDir);
+			const merger = new Merger();
 			const pages: CrawledPage[] = [];
 			const pageContents = new Map<string, string>();
 


### PR DESCRIPTION
## 概要

`Merger` クラスのコンストラクタから未使用の `_outputDir` パラメータを削除しました。

## 変更内容

- `Merger` クラスから不要な空のコンストラクタを削除
- `biome-ignore lint/complexity/noUselessConstructor` コメントを削除
- 全ての `Merger` インスタンス化箇所を更新（パラメータなしに変更）
- `Merger` はメモリ上での文字列操作のみを担当（ファイルI/Oは `PostProcessor` が担当）

## テスト結果

✅ 全テスト成功
- Test Files: 26 passed (26)
- Tests: 773 passed (773)

## レビューポイント

- リファクタリングのみで機能変更なし
- API がシンプル化され、責務が明確化
- 全てのテストがパス

Closes #799