### PR TITLE
docs: fix specs/ output documentation inconsistency

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -561,6 +561,23 @@ class Hasher {
 - `Hasher`: 純粋なロジッククラス（ハッシュ比較のみ）
 - `IndexManager`: ファイルI/O（`index.json`の読み書き）
 
+**IndexManagerのconfig引数:**
+
+`IndexManager`のコンストラクタは以下の形式でconfigを受け取ります：
+
+```typescript
+constructor(
+  outputDir: string,
+  baseUrl: string,
+  config: { maxDepth: number; sameDomain: boolean; diff?: boolean },
+  logger?: Logger
+)
+```
+
+configパラメータの役割：
+- `maxDepth`, `sameDomain`: `index.json`に保存される設定項目（`CrawlResult.config`として記録）
+- `diff`: 内部制御フラグ（差分クロール時の既存ページマージに使用、`index.json`には含まれない）
+
 **使用例:**
 
 ```typescript

--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -72,6 +72,7 @@ bun run src/crawl.ts https://nextjs.org/docs -d 2
 | `full.md` | 全ページ結合（AIコンテキスト用） |
 | `chunks/*.md` | 見出しベース分割（`--chunks`有効時） |
 | `pages/*.md` | ページ単位 |
+| `specs/*.yaml` | API仕様ファイル（検出時のみ） |
 | `index.json` | メタデータ・ハッシュ |
 
 **詳細な仕様は [CLI仕様書](../docs/cli-spec.md) を参照してください。**


### PR DESCRIPTION
## 概要

CLI仕様書の `specs/` ディレクトリに関する記述とSKILL.mdの出力ファイル表の不整合を修正しました。

## 変更内容

### 1. SKILL.md の出力ファイル表に specs/ を追加

- `specs/*.yaml` 行を追加（「検出時のみ」の注記付き）
- CLI仕様書との整合性を確保

### 2. 設計書の IndexManager config 説明を明確化

- IndexManager コンストラクタの config パラメータの役割を明記
- `maxDepth`, `sameDomain`: index.json に保存される設定項目
- `diff`: 内部制御フラグ（index.json には含まれない）

## 影響範囲

- ドキュメントのみの変更
- 実装コードの変更なし

## 確認済み

- [x] SKILL.md, cli-spec.md, design.md の整合性を確認
- [x] specs 機能が実装済みであることを確認
- [x] ドキュメント記述が実装と一致することを確認

Closes #816