### PR TITLE
fix(lint): fetcher.ts のフォーマットエラー修正

### DIFF
--- a/link-crawler/src/crawler/fetcher.ts
+++ b/link-crawler/src/crawler/fetcher.ts
@@ -174,10 +174,10 @@ export class PlaywrightFetcher implements Fetcher {
 			if (logMatch) {
 				// 相対パスから絶対パスを構築
 				const logPath = normalize(logMatch[1]);
-				
+
 				// パストラバーサル防止: cwdの外を参照していないことを確認
 				const cwd = this.runtime.cwd();
-				
+
 				// 絶対パスの場合は直接使用、相対パスの場合はcwdと結合
 				const fullPath = isAbsolute(logPath) ? logPath : join(cwd, logPath);
 				const resolvedPath = resolve(fullPath);


### PR DESCRIPTION
## 概要

`bun run check` で検出されていた `src/crawler/fetcher.ts` のBiomeフォーマットエラーを修正しました。

## 変更内容

- 177行目と180行目の空行からタブ文字を削除
- ロジックの変更なし（ホワイトスペースのみの修正）

## 検証

- ✅ `bun run check` - Biomeチェック: エラー0件
- ✅ `bun run typecheck` - TypeScript型チェック: エラー0件  
- ✅ `bun run test` - 全779テストがパス

## 関連Issue

Closes #814