### PR TITLE
docs: fix relative paths in maintenance.md reference links

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -149,5 +149,5 @@ chmod +x .git/hooks/post-merge
 ## 参考リンク
 
 - [Git Worktree Documentation](https://git-scm.com/docs/git-worktree)
-- [プロジェクトの .gitignore](./.gitignore)
-- [クリーンアップスクリプト](./scripts/cleanup-dev-artifacts.sh)
+- [プロジェクトの .gitignore](../.gitignore)
+- [クリーンアップスクリプト](../scripts/cleanup-dev-artifacts.sh)


### PR DESCRIPTION
## 概要

`docs/maintenance.md` の参考リンクセクションで、相対パスが不正確だった問題を修正しました。

## 変更内容

| ファイル | Before | After |
|----------|--------|-------|
| docs/maintenance.md | `./scripts/cleanup-dev-artifacts.sh` | `../scripts/cleanup-dev-artifacts.sh` |
| docs/maintenance.md | `./.gitignore` | `../.gitignore` |

## 理由

`docs/maintenance.md` は `docs/` ディレクトリ内にあるため、ルート直下のファイルを参照するには `../` を使用する必要があります。

## テスト

- ドキュメント修正のみ（コード変更なし）
- リンクがルート直下の正しいファイルを指すことを確認

Closes #828