### PR TITLE
docs: Mergerコンストラクタの未使用パラメータを削除

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -613,7 +613,6 @@ if (hasher.isChanged(url, newHash)) {
 
 ```typescript
 class Merger {
-  constructor(_outputDir: string)
   stripTitle(markdown: string): string
   buildFullContent(pages: CrawledPage[], pageContents: Map<string, string>): string
 }
@@ -640,7 +639,7 @@ class Merger {
 
 **本番コードでの使用（PostProcessor）:**
 ```typescript
-const merger = new Merger(outputDir);
+const merger = new Merger();
 
 // メモリ上でコンテンツを生成
 const fullContent = merger.buildFullContent(pages, pageContents);


### PR DESCRIPTION
## 概要

設計書 (`docs/design.md`) のセクション 9.1 に記載されていた Merger クラスの `constructor(_outputDir: string)` を削除し、実際の実装と一致させました。

## 変更内容

- `docs/design.md` セクション 9.1 のインターフェース定義から `constructor(_outputDir: string)` を削除
- 使用例の `new Merger(outputDir)` を `new Merger()` に修正

## 動作確認

- 実装コード (`link-crawler/src/output/merger.ts`) と設計書が一致していることを確認
- ドキュメント修正のみのため、既存テストに影響なし

Closes #825