### PR TITLE
fix: remove tab characters from empty lines in fetcher.ts

### DIFF
--- a/link-crawler/src/crawler/fetcher.ts
+++ b/link-crawler/src/crawler/fetcher.ts
@@ -174,10 +174,10 @@ export class PlaywrightFetcher implements Fetcher {
 			if (logMatch) {
 				// 相対パスから絶対パスを構築
 				const logPath = normalize(logMatch[1]);
-				
+
 				// パストラバーサル防止: cwdの外を参照していないことを確認
 				const cwd = this.runtime.cwd();
-				
+
 				// 絶対パスの場合は直接使用、相対パスの場合はcwdと結合
 				const fullPath = isAbsolute(logPath) ? logPath : join(cwd, logPath);
 				const resolvedPath = resolve(fullPath);


### PR DESCRIPTION
Closes #824

## 概要
Biomeフォーマッタが検出していた `fetcher.ts` の空行のタブ文字を削除しました。

## 変更内容
- `link-crawler/src/crawler/fetcher.ts` の177行目と180行目の空行からタブ文字を削除

## 検証
- ✅ `bun run check` - エラー0件
- ✅ `bun run typecheck` - 成功  
- ✅ `bun run test` - 全779テストがパス

## 影響範囲
なし（フォーマットのみの変更、ロジックへの影響なし）