### PR TITLE
docs: verify coverage/ .gitignore configuration is working correctly

### DIFF
--- a/docs/verification/issue-826-coverage-gitignore-verification.md
+++ b/docs/verification/issue-826-coverage-gitignore-verification.md
@@ -1,0 +1,50 @@
+# Issue #826 Verification: coverage/ .gitignore Configuration
+
+## Issue Summary
+Issue #826 reported that `link-crawler/coverage/coverage-summary.json` might be tracked by Git, suggesting the `.gitignore` configuration was not working properly.
+
+## Investigation Results
+
+### 1. .gitignore Configuration
+```bash
+$ cat link-crawler/.gitignore | grep coverage
+coverage/
+```
+✅ The `coverage/` pattern exists in `link-crawler/.gitignore`
+
+### 2. Git Tracking Status
+```bash
+$ git ls-files link-crawler/coverage/
+(no output)
+```
+✅ No files in `link-crawler/coverage/` are tracked by Git
+
+### 3. Coverage Generation Test
+```bash
+$ cd link-crawler && bun run test:coverage
+```
+Results:
+- Coverage files were successfully generated in `link-crawler/coverage/`
+- Generated files include: `coverage-summary.json`, HTML reports, etc.
+- Git status: "nothing to commit, working tree clean"
+- All coverage files remain untracked ✅
+
+## Completion Conditions
+
+- [x] `link-crawler/coverage/` is excluded from Git tracking
+- [x] `git ls-files link-crawler/coverage/` returns empty
+
+## Conclusion
+
+The `.gitignore` configuration is **working correctly**. The coverage directory and all its contents are properly excluded from Git tracking. No changes to `.gitignore` are necessary.
+
+The issue may have been based on:
+1. A misunderstanding about file tracking status
+2. A previously resolved issue
+3. Confusion between file existence and Git tracking
+
+## Verification Date
+2026-02-08
+
+## Verified By
+Automated testing and Git status verification


### PR DESCRIPTION
## Summary

Issue #826 reported that `link-crawler/coverage/coverage-summary.json` might be tracked by Git. This PR provides verification that the `.gitignore` configuration is working correctly.

## Investigation Results

✅ **Configuration Verified:**
- `link-crawler/.gitignore` contains `coverage/` pattern
- `git ls-files link-crawler/coverage/` returns empty (not tracked)
- Test coverage generation confirmed files remain untracked

## Changes

- Added verification document: `docs/verification/issue-826-coverage-gitignore-verification.md`
- No code changes required - configuration is already correct

## Completion Conditions

- [x] `link-crawler/coverage/` is excluded from Git tracking
- [x] `git ls-files link-crawler/coverage/` returns empty

## Testing

```bash
# All tests pass
cd link-crawler && bun run test
# 779 tests passed

# Coverage generation works correctly
cd link-crawler && bun run test:coverage
# Coverage files generated but not tracked by Git

# Verification
git ls-files link-crawler/coverage/
# (no output) ✓
```

## Conclusion

The `.gitignore` configuration is **working as intended**. No changes to `.gitignore` are necessary. The issue may have been based on a misunderstanding about file tracking status.

Closes #826