### PR TITLE
docs: add error-handler.ts to development.md file tree

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -34,6 +34,7 @@ link-crawler/
 │   ├── types.ts                # 型定義
 │   ├── constants.ts            # 定数定義
 │   ├── errors.ts               # エラークラス
+│   ├── error-handler.ts        # エラーハンドリング
 │   │
 │   ├── crawler/
 │   │   ├── index.ts            # CrawlerEngine


### PR DESCRIPTION
## 概要

`docs/development.md` のセクション2「プロジェクト構成」のファイルツリーに、実在する `src/error-handler.ts` が記載されていなかった問題を修正しました。

## 変更内容

- `docs/development.md` のファイルツリーに `error-handler.ts` を追加
- テストファイル一覧には既に `error-handler.test.ts` が記載されていたため、ソースファイル側のみ追加

## 検証

```bash
# error-handler.ts が記載されていることを確認
grep -n "error-handler" docs/development.md
# Line 37: src/error-handler.ts (新規追加)
# Line 81: tests/.../error-handler.test.ts (既存)

# 既存テストが全てパス
cd link-crawler && bun run test
# Test Files: 26 passed (26)
# Tests: 779 passed (779)
```

Closes #838