### PR TITLE
refactor: fix unreachable code after program.help()

### DIFF
--- a/link-crawler/src/crawl.ts
+++ b/link-crawler/src/crawl.ts
@@ -17,7 +17,7 @@ const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
 program
 	.name("crawl")
 	.description("Crawl technical documentation sites recursively")
-	.argument("<url>", "Starting URL to crawl")
+	.argument("[url]", "Starting URL to crawl")
 	.option("-d, --depth <num>", "Maximum crawl depth", "1")
 	.option("--max-pages <num>", "Maximum number of pages to crawl (0 = unlimited)")
 	.option("-o, --output <dir>", "Output directory (default: ./.context/<site-name>/)")
@@ -42,7 +42,7 @@ const options = program.opts();
 const startUrl = program.args[0];
 
 if (!startUrl) {
-	program.help();
+	program.outputHelp();
 	process.exit(EXIT_CODES.INVALID_ARGUMENTS);
 }
 


### PR DESCRIPTION
## Summary
Fixes #837 - Resolves unreachable code issue in crawl.ts where `process.exit(EXIT_CODES.INVALID_ARGUMENTS)` was never reached after `program.help()`.

## Changes
- Changed URL argument from `<url>` (required) to `[url]` (optional) to allow manual validation
- Changed `program.help()` to `program.outputHelp()` to avoid automatic exit with code 0
- Now correctly exits with code 2 (EXIT_CODES.INVALID_ARGUMENTS) when URL is missing

## Testing
- ✅ All 779 tests pass (26 test files)
- ✅ Manual verification: URL missing now exits with code 2
- ✅ Help text displays correctly
- ✅ Normal operation unaffected

## Related
Closes #837