### PR TITLE
docs: add missing error-handler.ts to design.md module documentation

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -82,6 +82,7 @@ link-crawler/
 │   ├── types.ts                # 型定義
 │   ├── constants.ts            # 定数定義
 │   ├── errors.ts               # エラークラス
+│   ├── error-handler.ts        # エラーハンドリング
 │   │
 │   ├── crawler/
 │   │   ├── index.ts            # CrawlerEngine
@@ -124,6 +125,7 @@ link-crawler/
 |-----------|------|------|------|
 | `Constants` | 定数定義（デフォルト値、ファイル名、パターン、終了コード） | - | 定数オブジェクト |
 | `Errors` | エラークラス定義（CrawlError, FetchError, ConfigError等） | Error情報 | Typed Error |
+| `ErrorHandler` | エラー種別判定、メッセージ生成、終了コード決定 | Error | ErrorHandlerResult |
 | `CrawlerEngine` | クロール制御、再帰管理 | URL, Config | CrawledPages |
 | `PlaywrightFetcher` | ページ取得 | URL | HTML |
 | `RobotsChecker` | robots.txt のパースとURL許可判定 | robots.txt, URL | boolean |


### PR DESCRIPTION
## Overview

Fixes #834

## Changes

Added missing `error-handler.ts` documentation to `docs/design.md`:

1. **Section 3.2 (File Tree)**: Added `error-handler.ts` after `errors.ts`
2. **Section 3.3 (Module Responsibilities)**: Added `ErrorHandler` row with its responsibilities

## Background

The `error-handler.ts` module exists in the codebase and is used by `crawl.ts`, but was missing from the design documentation.

## Verification

```bash
# Confirmed both additions
grep 'error-handler' docs/design.md
grep 'ErrorHandler' docs/design.md

# All tests pass
cd link-crawler && bun run test  # 779 tests passed
```

## Impact

- Documentation only, no code changes
- All existing tests pass

Closes #834