### PR TITLE
docs: add --max-pages and --no-robots options to SKILL.md and README.md

### DIFF
--- a/link-crawler/README.md
+++ b/link-crawler/README.md
@@ -70,6 +70,7 @@ bun run src/crawl.ts https://nextjs.org/docs \
 | オプション | 説明 | デフォルト |
 |-----------|------|-----------|
 | `-d, --depth <num>` | 最大クロール深度 | `1` |
+| `--max-pages <num>` | 最大クロールページ数（0=無制限） | 無制限 |
 | `-o, --output <dir>` | 出力ディレクトリ | `./.context/<サイト名>/` |
 | `--diff` | 差分クロール（変更ページのみ） | `false` |
 | `--same-domain` | 同一ドメインのみ追跡 | `true` |

--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -45,12 +45,14 @@ bun run src/crawl.ts <url> [options]
 
 主要なオプション：
 - `-d, --depth <num>`: 最大クロール深度（デフォルト: 1、上限: 10）
+- `--max-pages <num>`: 最大クロールページ数（0 = 無制限）
 - `-o, --output <dir>`: 出力ディレクトリ
 - `--diff`: 差分クロール（変更ページのみ更新）
 - `--chunks`: チャンク分割出力を有効化
 - `--same-domain`: 同一ドメインのみクロール（デフォルト: true）
 - `--include <pattern>`: 含めるURLパターン（正規表現）
 - `--exclude <pattern>`: 除外するURLパターン（正規表現）
+- `--no-robots`: robots.txt を無視（非推奨、開発・テスト用）
 
 **完全なオプション一覧は [CLI仕様書](../docs/cli-spec.md) を参照してください。**
 


### PR DESCRIPTION
## 概要

プロジェクト全体レビューで発見されたドキュメント不整合を修正。

## 変更内容

### SKILL.md
- 主要オプション一覧に `--max-pages <num>` を追加
- 主要オプション一覧に `--no-robots` を追加（非推奨として注記）

### README.md
- 主要オプションテーブルに `--max-pages <num>` を追加

## 検証

- ✅ crawl.ts の全オプションがいずれかのドキュメント（SKILL.md、README.md、cli-spec.md）に記載されていることを確認
- ✅ 説明が cli-spec.md と一貫していることを確認
- ✅ フォーマットが既存の記載スタイルに従っていることを確認

## 影響範囲

- ドキュメントのみの変更
- コード変更なし
- テスト不要

Closes #847