### PR TITLE
refactor: generateMarkerId のタイムスタンプ依存による非決定性を修正

### DIFF
--- a/link-crawler/src/parser/extractor.ts
+++ b/link-crawler/src/parser/extractor.ts
@@ -26,7 +26,7 @@ const CODE_BLOCK_PRIORITY_SELECTORS = [
 
 /** 一意なマーカーIDを生成 */
 function generateMarkerId(index: number): string {
-	return `CODEBLOCK_${index}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+	return `CODEBLOCK_${index}`;
 }
 
 /** コードブロックを保護（マーカーに置き換え） */


### PR DESCRIPTION
## Summary
Closes #848

## Changes
- `generateMarkerId` 関数を `Date.now()` と `Math.random()` に依存した非決定的なID生成から、インデックスベースの決定的なIDに変更
- マーカーIDの形式を `CODEBLOCK_${index}_${timestamp}_${random}` から `CODEBLOCK_${index}` にシンプル化

## Benefits
- **デバッグ性の向上**: マーカーIDが予測可能になり、デバッグ時の追跡が容易に
- **再現性の向上**: 同じ入力から同じIDが生成される
- **設計整合性**: プロジェクトの再現性設計思想（`computeHash`）との整合性を確保

## Testing
- ✅ All 779 tests in 26 test files passed
- ✅ Code block protection and restoration working correctly
- ✅ No regressions in existing functionality