### PR TITLE
docs: replace vitest.config.ts full copy with file reference

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -244,41 +244,21 @@ try {
 
 ### 5.2 Vitest設定
 
-<!-- Verified 2026-02-08: Configuration matches link-crawler/vitest.config.ts (Issue #809) -->
+設定の詳細は [`link-crawler/vitest.config.ts`](../link-crawler/vitest.config.ts) を参照してください。
 
-```typescript
-// vitest.config.ts
-import { defineConfig } from "vitest/config";
+**主要な設定ポイント**:
 
-export default defineConfig({
-	test: {
-		globals: true,
-		include: ["tests/**/*.test.ts"],
-		globalSetup: "./tests/global-setup.ts",
-		globalTeardown: "./tests/global-teardown.ts",
-		// Enable file-level parallelism for faster test execution
-		// forks pool provides complete isolation between test files
-		fileParallelism: true,
-		// forksプールを使用して各テストファイルを完全に分離
-		// (threadsではなくforksを使用することで、module mocksが他のファイルに影響しない)
-		pool: "forks",
-		// Vitest 4: poolOptions moved to top-level
-		singleFork: false,
-		// テスト間でモックをクリアして分離を確保
-		clearMocks: true,
-		mockReset: true,
-		restoreMocks: true,
-		// 各テストファイルを完全に分離
-		isolate: true,
-		coverage: {
-			provider: "v8",
-			reporter: ["text", "html", "json-summary"],
-			include: ["src/**/*.ts"],
-			exclude: ["src/crawl.ts", "src/types.ts", "src/types/**"],
-		},
-	},
-});
-```
+| 設定項目 | 値 | 目的 |
+|---------|-----|------|
+| `pool` | `"forks"` | テストファイル間の完全分離（module mocks が他ファイルに影響しない） |
+| `fileParallelism` | `true` | 並列実行による高速化 |
+| `clearMocks/mockReset/restoreMocks` | `true` | テスト間でモックを自動クリア |
+| `isolate` | `true` | 各テストファイルの完全分離 |
+
+**カバレッジ設定**:
+- Provider: `v8`
+- Reporter: `text`, `html`, `json-summary`
+- 除外: `src/crawl.ts`, `src/types.ts`, `src/types/**`
 
 ### 5.3 ユニットテスト例
 


### PR DESCRIPTION
## Summary

Replaces the full ~30-line `vitest.config.ts` copy in `docs/development.md` section 5.2 with a file reference link and key points summary table.

## Changes

- **Removed**: Full `vitest.config.ts` code block (~30 lines)
- **Added**: Link to `link-crawler/vitest.config.ts` as the single source of truth
- **Added**: Summary table of key settings:
  - `pool: forks` - Complete test file isolation
  - `fileParallelism: true` - Parallel execution
  - `clearMocks/mockReset/restoreMocks: true` - Auto-clear mocks
  - `isolate: true` - Complete test file isolation
- **Added**: Coverage configuration bullet points

## Benefits

- **DRY Principle**: Eliminates duplication between config file and documentation
- **Single Source of Truth**: `link-crawler/vitest.config.ts` is the master
- **Reduced Maintenance**: No need to manually sync documentation when config changes
- **Prevents Documentation Drift**: Eliminates risk of outdated information in docs

## Testing

- ✅ Markdown syntax verified
- ✅ Relative link path verified
- ✅ Information completeness maintained

Closes #856