### PR TITLE
docs: fix class and method name inconsistencies in design.md

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -85,7 +85,7 @@ link-crawler/
 │   ├── error-handler.ts        # エラーハンドリング
 │   │
 │   ├── crawler/
-│   │   ├── index.ts            # CrawlerEngine
+│   │   ├── index.ts            # Crawler
 │   │   ├── fetcher.ts          # PlaywrightFetcher
 │   │   ├── logger.ts           # ログ出力
 │   │   ├── robots.ts           # robots.txt パーサー
@@ -126,7 +126,7 @@ link-crawler/
 | `Constants` | 定数定義（デフォルト値、ファイル名、パターン、終了コード） | - | 定数オブジェクト |
 | `Errors` | エラークラス定義（CrawlError, FetchError, ConfigError等） | Error情報 | Typed Error |
 | `ErrorHandler` | エラー種別判定、メッセージ生成、終了コード決定 | Error | ErrorHandlerResult |
-| `CrawlerEngine` | クロール制御、再帰管理 | URL, Config | CrawledPages |
+| `Crawler` | クロール制御、再帰管理 | URL, Config | CrawledPages |
 | `PlaywrightFetcher` | ページ取得 | URL | HTML |
 | `RobotsChecker` | robots.txt のパースとURL許可判定 | robots.txt, URL | boolean |
 | `CrawlLogger` | クロールログ出力（開始、進捗、完了、エラー等） | Config, Events | コンソール出力 |
@@ -584,7 +584,7 @@ configパラメータの役割：
 
 ```typescript
 // IndexManagerから既存ハッシュを読み込み
-const existingHashes = indexManager.getHashMap();
+const existingHashes = indexManager.getExistingHashes();
 const hasher = new Hasher(existingHashes);
 
 // クロール中


### PR DESCRIPTION
## 概要

設計書(`docs/design.md`)と実装コードの間のクラス名・メソッド名の不整合を修正しました。

## 変更内容

### 修正箇所（3箇所）

| 行 | Before | After |
|----|--------|-------|
| L88 | `CrawlerEngine` | `Crawler` |
| L129 | `CrawlerEngine` | `Crawler` |
| L587 | `getHashMap()` | `getExistingHashes()` |

### 検証

```bash
# 古い名前が残っていないことを確認
grep -n "CrawlerEngine\|getHashMap" docs/design.md
# → 0件（ヒットなし）
```

## 実装コードとの対応関係

- `Crawler` ← `link-crawler/src/crawler/index.ts` L14
- `getExistingHashes()` ← `link-crawler/src/output/index-manager.ts` L91

## テスト

- [x] `grep`コマンドでの検証完了
- [x] 関連ドキュメント(`cli-spec.md`, `SKILL.md`)も確認済み

## 影響範囲

- ドキュメントのみの修正
- 実装コードの変更なし
- 動作への影響なし

Closes #853