### PR TITLE
refactor: use barrel export for diff module

### DIFF
--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -1,5 +1,5 @@
 import { JSDOM } from "jsdom";
-import { computeHash, Hasher } from "../diff/hasher.js";
+import { computeHash, Hasher } from "../diff/index.js";
 import { OutputWriter } from "../output/writer.js";
 import { htmlToMarkdown } from "../parser/converter.js";
 import { extractContent, extractMetadata } from "../parser/extractor.js";

--- a/link-crawler/src/output/writer.ts
+++ b/link-crawler/src/output/writer.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { FILENAME, SPEC_PATTERNS } from "../constants.js";
-import { computeHash } from "../diff/hasher.js";
+import { computeHash } from "../diff/index.js";
 import type { CrawlConfig, CrawledPage, Logger, PageMetadata } from "../types.js";
 import { IndexManager } from "./index-manager.js";
 


### PR DESCRIPTION
## Summary
Refactored import statements to use the barrel export (`diff/index.ts`) instead of direct imports from `diff/hasher.ts`.

## Changes
- `src/crawler/index.ts`: Changed import from `../diff/hasher.js` to `../diff/index.js`
- `src/output/writer.ts`: Changed import from `../diff/hasher.js` to `../diff/index.js`

## Testing
- ✅ All 783 tests passed
- ✅ TypeScript type checking passed
- ✅ No functional changes

## Benefits
- Aligns implementation with module design intent
- Improves encapsulation (hides internal module structure)
- Facilitates future refactoring of diff module internals

Closes #864