### PR TITLE
fix: Biome format errors in robots.test.ts

### DIFF
--- a/link-crawler/tests/unit/robots.test.ts
+++ b/link-crawler/tests/unit/robots.test.ts
@@ -428,18 +428,33 @@ Disallow: /path(test)*
 		it("should handle ReDoS-prone patterns efficiently", () => {
 			// 従来の正規表現実装では ReDoS になりやすいパターン
 			const checker = new RobotsChecker("User-agent: *\nDisallow: /a*b*c*d*e*f*g*h*i*j*");
-			
+
 			// ほぼマッチする長い文字列でも高速に処理される
-			const longPath = "/a" + "x".repeat(1000) + "b" + "x".repeat(1000) + "c" + 
-			                "x".repeat(1000) + "d" + "x".repeat(1000) + "e" +
-			                "x".repeat(1000) + "f" + "x".repeat(1000) + "g" +
-			                "x".repeat(1000) + "h" + "x".repeat(1000) + "i" +
-			                "x".repeat(1000) + "Z"; // 最後が j ではないのでマッチしない
-			
+			const longPath =
+				"/a" +
+				"x".repeat(1000) +
+				"b" +
+				"x".repeat(1000) +
+				"c" +
+				"x".repeat(1000) +
+				"d" +
+				"x".repeat(1000) +
+				"e" +
+				"x".repeat(1000) +
+				"f" +
+				"x".repeat(1000) +
+				"g" +
+				"x".repeat(1000) +
+				"h" +
+				"x".repeat(1000) +
+				"i" +
+				"x".repeat(1000) +
+				"Z"; // 最後が j ではないのでマッチしない
+
 			const start = Date.now();
 			const result = checker.isAllowed(`https://example.com${longPath}`);
 			const elapsed = Date.now() - start;
-			
+
 			// 手動マッチングなので高速（100ms以内）
 			expect(elapsed).toBeLessThan(100);
 			expect(result).toBe(true); // j がないのでマッチせず、許可される


### PR DESCRIPTION
Fixes #863

## Summary
Fixed Biome formatting errors in `link-crawler/tests/unit/robots.test.ts` around lines 429-438.

## Changes
- Reformatted long string concatenation to comply with Biome's `lineWidth: 100` rule
- Each `+` operator now on a new line for better readability
- Removed trailing whitespace

## Verification
- ✅ `bun run check` passes with 0 errors
- ✅ All 783 tests pass
- ✅ No logic changes, formatting only

Closes #863