### PR TITLE
docs: fix relative links in SKILL.md and README.md for npm publish

### DIFF
--- a/link-crawler/README.md
+++ b/link-crawler/README.md
@@ -78,7 +78,7 @@ bun run src/crawl.ts https://nextjs.org/docs \
 | `--exclude <pattern>` | 除外するURLパターン（正規表現） | - |
 | `--delay <ms>` | リクエスト間隔 | `500` |
 
-**完全なオプション一覧は [CLI仕様書](../docs/cli-spec.md) を参照してください。**
+**完全なオプション一覧は [CLI仕様書](https://github.com/takemo101/dict-skills/blob/main/docs/cli-spec.md) を参照してください。**
 
 ## 出力ファイル
 
@@ -96,8 +96,8 @@ bun run src/crawl.ts https://nextjs.org/docs \
 | ドキュメント | 対象読者 | 内容 |
 |-------------|---------|------|
 | [SKILL.md](./SKILL.md) | **piユーザー** | piスキルとしての使い方・オプション一覧 |
-| [CLI仕様書](../docs/cli-spec.md) | **CLIユーザー** | 完全なオプション一覧・詳細な使用例・出力形式 |
-| [設計書](../docs/design.md) | **開発者** | アーキテクチャ・データ構造・技術仕様 |
+| [CLI仕様書](https://github.com/takemo101/dict-skills/blob/main/docs/cli-spec.md) | **CLIユーザー** | 完全なオプション一覧・詳細な使用例・出力形式 |
+| [設計書](https://github.com/takemo101/dict-skills/blob/main/docs/design.md) | **開発者** | アーキテクチャ・データ構造・技術仕様 |
 
 ## 開発
 

--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -54,7 +54,7 @@ bun run src/crawl.ts <url> [options]
 - `--exclude <pattern>`: 除外するURLパターン（正規表現）
 - `--no-robots`: robots.txt を無視（非推奨、開発・テスト用）
 
-**完全なオプション一覧は [CLI仕様書](../docs/cli-spec.md) を参照してください。**
+**完全なオプション一覧は [CLI仕様書](https://github.com/takemo101/dict-skills/blob/main/docs/cli-spec.md) を参照してください。**
 
 ## piエージェントでの使用例
 
@@ -77,11 +77,11 @@ bun run src/crawl.ts https://nextjs.org/docs -d 2
 | `specs/*.yaml` | API仕様ファイル（検出時のみ） |
 | `index.json` | メタデータ・ハッシュ |
 
-**詳細な仕様は [CLI仕様書](../docs/cli-spec.md) を参照してください。**
+**詳細な仕様は [CLI仕様書](https://github.com/takemo101/dict-skills/blob/main/docs/cli-spec.md) を参照してください。**
 
 ## 参考リンク
 
 | ドキュメント | 内容 |
 |-------------|------|
-| [CLI仕様書](../docs/cli-spec.md) | 完全なオプション一覧・使用例・出力形式の詳細 |
-| [設計書](../docs/design.md) | アーキテクチャ・データ構造・技術仕様 |
+| [CLI仕様書](https://github.com/takemo101/dict-skills/blob/main/docs/cli-spec.md) | 完全なオプション一覧・使用例・出力形式の詳細 |
+| [設計書](https://github.com/takemo101/dict-skills/blob/main/docs/design.md) | アーキテクチャ・データ構造・技術仕様 |


### PR DESCRIPTION
## Summary

Fixes #872

相対リンク（`../docs/`）をGitHub URLに変更し、npm publish時のリンク破損を防止。

## Changes

- `link-crawler/SKILL.md`: 4箇所のリンクを変更
- `link-crawler/README.md`: 3箇所のリンクを変更

### Before
```markdown
[CLI仕様書](../docs/cli-spec.md)
[設計書](../docs/design.md)
```

### After
```markdown
[CLI仕様書](https://github.com/takemo101/dict-skills/blob/main/docs/cli-spec.md)
[設計書](https://github.com/takemo101/dict-skills/blob/main/docs/design.md)
```

## Verification

```bash
# No relative links remaining
grep -n "\.\.\/docs\/" link-crawler/SKILL.md link-crawler/README.md
# (no output)

# GitHub URLs added
grep -n "github.com/takemo101/dict-skills" link-crawler/SKILL.md link-crawler/README.md
# 7 links found
```

## Impact

- ✅ GitHub上でのリンクは正常動作
- ✅ npm publish時のリンク破損を防止
- ✅ ドキュメント内容に変更なし

Closes #872