### PR TITLE
docs: fix coverage exclusion settings in development.md

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -258,7 +258,7 @@ try {
 **カバレッジ設定**:
 - Provider: `v8`
 - Reporter: `text`, `html`, `json-summary`
-- 除外: `src/crawl.ts`, `src/types.ts`, `src/types/**`
+- 除外: `src/types.ts`, `src/types/**`
 
 ### 5.3 ユニットテスト例
 


### PR DESCRIPTION
## Summary

Fix documentation inconsistency between `docs/development.md` and `link-crawler/vitest.config.ts`.

## Changes

- Remove `src/crawl.ts` from coverage exclusion list in documentation
- Align `docs/development.md` section 5.2 with actual `vitest.config.ts` settings

## Details

**Before:**
```markdown
- 除外: `src/crawl.ts`, `src/types.ts`, `src/types/**`
```

**After:**
```markdown
- 除外: `src/types.ts`, `src/types/**`
```

**Actual vitest.config.ts:**
```typescript
exclude: ["src/types.ts", "src/types/**"],
```

Closes #869