### PR TITLE
docs: add signal-handler.ts to design and development docs

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -83,6 +83,7 @@ link-crawler/
 │   ├── constants.ts            # 定数定義
 │   ├── errors.ts               # エラークラス
 │   ├── error-handler.ts        # エラーハンドリング
+│   ├── signal-handler.ts       # シグナルハンドリング（SIGINT/SIGTERM）
 │   │
 │   ├── crawler/
 │   │   ├── index.ts            # Crawler
@@ -126,6 +127,7 @@ link-crawler/
 | `Constants` | 定数定義（デフォルト値、ファイル名、パターン、終了コード） | - | 定数オブジェクト |
 | `Errors` | エラークラス定義（CrawlError, FetchError, ConfigError等） | Error情報 | Typed Error |
 | `ErrorHandler` | エラー種別判定、メッセージ生成、終了コード決定 | Error | ErrorHandlerResult |
+| `SignalHandler` | SIGINT/SIGTERMシグナルの捕捉、グレースフルシャットダウン制御 | Signal, onShutdown callback | Cleanup → process.exit |
 | `Crawler` | クロール制御、再帰管理 | URL, Config | CrawledPages |
 | `PlaywrightFetcher` | ページ取得 | URL | HTML |
 | `RobotsChecker` | robots.txt のパースとURL許可判定 | robots.txt, URL | boolean |

--- a/docs/development.md
+++ b/docs/development.md
@@ -35,6 +35,7 @@ link-crawler/
 │   ├── constants.ts            # 定数定義
 │   ├── errors.ts               # エラークラス
 │   ├── error-handler.ts        # エラーハンドリング
+│   ├── signal-handler.ts       # シグナルハンドリング（SIGINT/SIGTERM）
 │   │
 │   ├── crawler/
 │   │   ├── index.ts            # CrawlerEngine


### PR DESCRIPTION
## 概要

signal-handler.ts モジュールがドキュメントから欠落していた問題を修正しました。

## 変更内容

- docs/design.md section 3.2: ディレクトリ構成に signal-handler.ts を追加
- docs/design.md section 3.3: モジュール責務テーブルに SignalHandler を追加
- docs/development.md section 2: プロジェクト構成に signal-handler.ts を追加

## 検証

```bash
grep -n "signal-handler\|SignalHandler" docs/design.md docs/development.md
```

結果:
- docs/design.md:86 (section 3.2)
- docs/design.md:130 (section 3.3)
- docs/development.md:38 (section 2)

## テスト

全テストがパスしました（804 tests passed）

Closes #868