### PR TITLE
refactor: implement atomic output with temp directories

### DIFF
--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -121,6 +121,9 @@ export class Crawler {
 		// 後処理: MergerとChunkerの実行
 		await this.postProcessor.process(result.pages, this.pageContents);
 
+		// クロール成功時: 一時ディレクトリを確定
+		this.writer.finalize();
+
 		// 完了ログ
 		this.logger.logComplete(result.totalPages, result.specs.length, indexPath);
 	}
@@ -144,7 +147,10 @@ export class Crawler {
 			const indexPath = this.writer.saveIndex();
 			this.logger.logDebug("Saved partial index", { path: indexPath });
 
-			// 2. Fetcher をクローズ（初期化中の場合も待機）
+			// 2. 失敗時: 一時ディレクトリを削除（既存出力は保持）
+			this.writer.cleanup();
+
+			// 3. Fetcher をクローズ（初期化中の場合も待機）
 			if (this.fetcherPromise) {
 				try {
 					const fetcher = await this.fetcherPromise;

--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -46,7 +46,7 @@ describe("OutputWriter", () => {
 	});
 
 	it("should save page with hash and crawledAt", () => {
-		const writer = new OutputWriter(defaultConfig);
+		const writer = new OutputWriter({ ...defaultConfig });
 		const markdown = "# Test Content\n\nThis is test content.";
 
 		const pageFile = writer.savePage(
@@ -69,8 +69,8 @@ describe("OutputWriter", () => {
 	});
 
 	it("should compute consistent hash for same content", () => {
-		const writer1 = new OutputWriter(defaultConfig);
-		const writer2 = new OutputWriter(defaultConfig);
+		const writer1 = new OutputWriter({ ...defaultConfig });
+		const writer2 = new OutputWriter({ ...defaultConfig });
 		const markdown = "# Same Content";
 
 		writer1.savePage("https://example.com/p1", markdown, 1, [], defaultMetadata, null);
@@ -109,8 +109,8 @@ describe("OutputWriter", () => {
 
 		writeFileSync(join(testOutputDir, "index.json"), JSON.stringify(existingResult, null, 2));
 
-		// Create new writer that should read existing index
-		const writer = new OutputWriter(defaultConfig);
+		// Create new writer in diff mode that should read existing index
+		const writer = new OutputWriter({ ...defaultConfig, diff: true });
 
 		const existingHash = writer.getExistingHash("https://example.com/existing");
 		expect(existingHash).toBe("abc123");
@@ -120,9 +120,10 @@ describe("OutputWriter", () => {
 	});
 
 	it("should save index.json with hash and crawledAt fields", () => {
-		const writer = new OutputWriter(defaultConfig);
+		const writer = new OutputWriter({ ...defaultConfig });
 		writer.savePage("https://example.com", "# Content", 0, [], defaultMetadata, "Title");
 		writer.saveIndex();
+		writer.finalize();
 
 		const indexContent = readFileSync(join(testOutputDir, "index.json"), "utf-8");
 		const result = JSON.parse(indexContent) as CrawlResult;
@@ -132,10 +133,11 @@ describe("OutputWriter", () => {
 	});
 
 	it("should add blank line after frontmatter closing ---", () => {
-		const writer = new OutputWriter(defaultConfig);
+		const writer = new OutputWriter({ ...defaultConfig });
 		const markdown = "## Introduction\n\nThis is content.";
 
 		writer.savePage("https://example.com/page1", markdown, 1, [], defaultMetadata, "Test Page");
+		writer.finalize();
 
 		const pagePath = join(testOutputDir, "pages/page-001-test-page.md");
 		const content = readFileSync(pagePath, "utf-8");
@@ -146,7 +148,7 @@ describe("OutputWriter", () => {
 	});
 
 	it("should include hash in frontmatter", () => {
-		const writer = new OutputWriter(defaultConfig);
+		const writer = new OutputWriter({ ...defaultConfig });
 		const markdown = "# Test Content\n\nThis is test content.";
 
 		const pageFile = writer.savePage(
@@ -157,6 +159,7 @@ describe("OutputWriter", () => {
 			defaultMetadata,
 			"Test Page",
 		);
+		writer.finalize();
 
 		const pagePath = join(testOutputDir, pageFile);
 		const content = readFileSync(pagePath, "utf-8");
@@ -174,7 +177,7 @@ describe("OutputWriter", () => {
 
 	describe("filename with title", () => {
 		it("should include slugified title in filename", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -187,7 +190,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should use sequential numbers only when title is null", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -200,7 +203,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should use sequential numbers only when title is empty", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -213,7 +216,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should use sequential numbers only when title is whitespace only", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -226,7 +229,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should fallback to title parameter when metadata.title is null", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -239,7 +242,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should convert title to lowercase", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -252,7 +255,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should remove special characters from title", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -265,7 +268,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should replace underscores with hyphens", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -278,7 +281,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should collapse multiple hyphens into one", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -291,7 +294,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should trim leading and trailing hyphens", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -304,7 +307,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should truncate long titles to 50 characters", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const longTitle = "This is a very long title that exceeds the fifty character limit";
 			const pageFile = writer.savePage(
 				"https://example.com",
@@ -320,7 +323,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should handle titles with multiple spaces", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -333,7 +336,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should handle Japanese titles", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -347,7 +350,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should handle mixed alphanumeric and Japanese", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -361,7 +364,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should handle Chinese titles (simplified)", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -375,7 +378,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should handle Chinese titles (traditional)", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -389,7 +392,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should handle Korean titles", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -403,7 +406,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should remove emoji from titles", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -417,7 +420,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should truncate long non-ASCII titles without breaking characters", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			// 60 characters: each Japanese character is one character
 			const longTitle =
 				"これは非常に長いタイトルで最大文字数の制限を超えていますので切り詰められる必要があります";
@@ -434,7 +437,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should handle Arabic titles", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -448,7 +451,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should handle Cyrillic titles", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -462,7 +465,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should remove all non-ASCII characters from mixed title", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -476,7 +479,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should fallback to sequential number when title becomes empty after slugify", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const pageFile = writer.savePage(
 				"https://example.com",
 				"# Content",
@@ -492,7 +495,7 @@ describe("OutputWriter", () => {
 
 	describe("YAML frontmatter escaping", () => {
 		it("should escape double quotes in keywords field", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const metadataWithQuotes: PageMetadata = {
 				...defaultMetadata,
 				keywords: 'test, "quoted keyword", another',
@@ -506,6 +509,7 @@ describe("OutputWriter", () => {
 				metadataWithQuotes,
 				"Test",
 			);
+			writer.finalize();
 
 			const pagePath = join(testOutputDir, pageFile);
 			const content = readFileSync(pagePath, "utf-8");
@@ -515,7 +519,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should escape double quotes in title field", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const metadataWithQuotes: PageMetadata = {
 				...defaultMetadata,
 				title: 'Test "quoted" title',
@@ -529,6 +533,7 @@ describe("OutputWriter", () => {
 				metadataWithQuotes,
 				null,
 			);
+			writer.finalize();
 
 			const pagePath = join(testOutputDir, pageFile);
 			const content = readFileSync(pagePath, "utf-8");
@@ -537,7 +542,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should escape double quotes in description field", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const metadataWithQuotes: PageMetadata = {
 				...defaultMetadata,
 				description: 'Description with "quotes"',
@@ -551,6 +556,7 @@ describe("OutputWriter", () => {
 				metadataWithQuotes,
 				"Test",
 			);
+			writer.finalize();
 
 			const pagePath = join(testOutputDir, pageFile);
 			const content = readFileSync(pagePath, "utf-8");
@@ -559,7 +565,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should handle keywords without quotes", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const metadataWithoutQuotes: PageMetadata = {
 				...defaultMetadata,
 				keywords: "test, keyword, another",
@@ -573,6 +579,7 @@ describe("OutputWriter", () => {
 				metadataWithoutQuotes,
 				"Test",
 			);
+			writer.finalize();
 
 			const pagePath = join(testOutputDir, pageFile);
 			const content = readFileSync(pagePath, "utf-8");
@@ -582,7 +589,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should escape newline characters in title", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const metadataWithNewline: PageMetadata = {
 				...defaultMetadata,
 				title: "Title with\nnewline",
@@ -596,7 +603,7 @@ describe("OutputWriter", () => {
 				metadataWithNewline,
 				null,
 			);
-
+			writer.finalize();
 			const pagePath = join(testOutputDir, pageFile);
 			const content = readFileSync(pagePath, "utf-8");
 
@@ -605,7 +612,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should escape carriage return and newline in description", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const metadataWithCRLF: PageMetadata = {
 				...defaultMetadata,
 				description: "Description with\r\nCRLF line ending",
@@ -619,7 +626,7 @@ describe("OutputWriter", () => {
 				metadataWithCRLF,
 				"Test",
 			);
-
+			writer.finalize();
 			const pagePath = join(testOutputDir, pageFile);
 			const content = readFileSync(pagePath, "utf-8");
 
@@ -628,7 +635,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should escape backslash in keywords", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const metadataWithBackslash: PageMetadata = {
 				...defaultMetadata,
 				keywords: "path\\to\\file, test",
@@ -642,7 +649,7 @@ describe("OutputWriter", () => {
 				metadataWithBackslash,
 				"Test",
 			);
-
+			writer.finalize();
 			const pagePath = join(testOutputDir, pageFile);
 			const content = readFileSync(pagePath, "utf-8");
 
@@ -651,7 +658,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should escape tab character in description", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const metadataWithTab: PageMetadata = {
 				...defaultMetadata,
 				description: "Description with\ttab character",
@@ -665,7 +672,7 @@ describe("OutputWriter", () => {
 				metadataWithTab,
 				"Test",
 			);
-
+			writer.finalize();
 			const pagePath = join(testOutputDir, pageFile);
 			const content = readFileSync(pagePath, "utf-8");
 
@@ -674,7 +681,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should escape multiple special characters in title", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const metadataWithMultiple: PageMetadata = {
 				...defaultMetadata,
 				title: 'Title with "quotes"\nand newline',
@@ -688,7 +695,7 @@ describe("OutputWriter", () => {
 				metadataWithMultiple,
 				null,
 			);
-
+			writer.finalize();
 			const pagePath = join(testOutputDir, pageFile);
 			const content = readFileSync(pagePath, "utf-8");
 
@@ -697,7 +704,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should escape backslash and quotes in description", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const metadataWithBackslashAndQuotes: PageMetadata = {
 				...defaultMetadata,
 				description: 'Path is "C:\\Program Files\\App"',
@@ -711,7 +718,7 @@ describe("OutputWriter", () => {
 				metadataWithBackslashAndQuotes,
 				"Test",
 			);
-
+			writer.finalize();
 			const pagePath = join(testOutputDir, pageFile);
 			const content = readFileSync(pagePath, "utf-8");
 
@@ -720,7 +727,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should handle empty strings without errors", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const metadataEmpty: PageMetadata = {
 				...defaultMetadata,
 				title: "",
@@ -736,7 +743,7 @@ describe("OutputWriter", () => {
 				metadataEmpty,
 				null,
 			);
-
+			writer.finalize();
 			const pagePath = join(testOutputDir, pageFile);
 			const content = readFileSync(pagePath, "utf-8");
 
@@ -749,7 +756,7 @@ describe("OutputWriter", () => {
 		});
 
 		it("should handle strings with only special characters", () => {
-			const writer = new OutputWriter(defaultConfig);
+			const writer = new OutputWriter({ ...defaultConfig });
 			const metadataOnlySpecial: PageMetadata = {
 				...defaultMetadata,
 				title: "\n\r\t",
@@ -764,7 +771,7 @@ describe("OutputWriter", () => {
 				metadataOnlySpecial,
 				null,
 			);
-
+			writer.finalize();
 			const pagePath = join(testOutputDir, pageFile);
 			const content = readFileSync(pagePath, "utf-8");
 
@@ -787,6 +794,7 @@ describe("OutputWriter", () => {
 				null,
 			);
 			writer1.saveIndex();
+			writer1.finalize();
 
 			const pagePath1 = join(testOutputDir, pageFile1);
 
@@ -827,6 +835,7 @@ describe("OutputWriter", () => {
 			const spec1Content = '{"openapi": "3.0.0"}';
 			writer1.handleSpec("https://api.example.com/openapi.json", spec1Content);
 			writer1.saveIndex();
+			writer1.finalize();
 
 			const specPath = join(testOutputDir, "specs/openapi.json");
 			expect(readFileSync(specPath, "utf-8")).toBe(spec1Content);
@@ -847,7 +856,7 @@ describe("OutputWriter", () => {
 			expect(readFileSync(join(testOutputDir, "specs/swagger.json"), "utf-8")).toBe(spec2Content);
 		});
 
-		it("should delete and recreate directories in non-diff mode", () => {
+		it("should replace output on successful finalize in non-diff mode", () => {
 			// 1. 初回クロール
 			const writer1 = new OutputWriter({ ...defaultConfig, diff: false });
 			writer1.savePage(
@@ -859,15 +868,73 @@ describe("OutputWriter", () => {
 				null,
 			);
 			writer1.saveIndex();
+			writer1.finalize();
 
 			const pagePath = join(testOutputDir, "pages/page-001-page-1.md");
 			expect(readFileSync(pagePath, "utf-8")).toContain("# Old Content");
 
 			// 2. 2回目のクロール（非 diff モード）
-			new OutputWriter({ ...defaultConfig, diff: false });
+			const writer2 = new OutputWriter({ ...defaultConfig, diff: false });
 
-			// ディレクトリが削除されたため、ファイルが存在しないことを確認
+			// 古いファイルはまだ存在する（finalizeされていないため）
+			expect(readFileSync(pagePath, "utf-8")).toContain("# Old Content");
+
+			// 新しい内容でページを保存
+			writer2.savePage(
+				"https://example.com/page2",
+				"# New Content",
+				0,
+				[],
+				{ ...defaultMetadata, title: "Page 2" },
+				null,
+			);
+			writer2.saveIndex();
+			writer2.finalize();
+
+			// finalizeされた後、新しいファイルのみが存在する
+			const newPagePath = join(testOutputDir, "pages/page-001-page-2.md");
+			expect(readFileSync(newPagePath, "utf-8")).toContain("# New Content");
+
+			// 古いファイルは削除されている
 			expect(() => readFileSync(pagePath, "utf-8")).toThrow();
+		});
+
+		it("should preserve existing output when crawl fails (cleanup called)", () => {
+			// 1. 初回クロール（成功）
+			const writer1 = new OutputWriter({ ...defaultConfig, diff: false });
+			writer1.savePage(
+				"https://example.com/page1",
+				"# Original Content",
+				0,
+				[],
+				{ ...defaultMetadata, title: "Page 1" },
+				null,
+			);
+			writer1.saveIndex();
+			writer1.finalize();
+
+			const pagePath = join(testOutputDir, "pages/page-001-page-1.md");
+			expect(readFileSync(pagePath, "utf-8")).toContain("# Original Content");
+
+			// 2. 2回目のクロール（失敗をシミュレート）
+			const writer2 = new OutputWriter({ ...defaultConfig, diff: false });
+			writer2.savePage(
+				"https://example.com/page2",
+				"# Failed Content",
+				0,
+				[],
+				{ ...defaultMetadata, title: "Page 2" },
+				null,
+			);
+			writer2.saveIndex();
+			writer2.cleanup(); // 失敗時のクリーンアップ
+
+			// 既存ファイルが保持されていることを確認
+			expect(readFileSync(pagePath, "utf-8")).toContain("# Original Content");
+
+			// 新しいファイルは最終ディレクトリに存在しない
+			const newPagePath = join(testOutputDir, "pages/page-001-page-2.md");
+			expect(() => readFileSync(newPagePath, "utf-8")).toThrow();
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Implements atomic output writes using temporary directories to prevent data loss on crawl failures.

## Changes

### OutputWriter
- Writes to temporary directory () in non-diff mode
- Successful crawls call  to atomically rename temp→final
- Failed crawls call  to remove temp and preserve existing output
- Added backup mechanism during finalization

### Crawler
- Calls  after successful post-processing
- Calls  in error handler
- Ensures existing output is preserved on failure

### Tests
- Added rollback test to verify existing output preservation
- Fixed config mutation issues in existing tests
- All 805 tests passing

## Benefits

✅ **Atomic writes**: Output is only replaced on successful completion  
✅ **Rollback safety**: Failed crawls preserve previous output  
✅ **No data loss**: Interruptions (Ctrl+C, crashes) keep old data intact  
✅ **Backward compatible**: Same output structure, only affects non-diff mode

## Testing

```bash
cd link-crawler && bun run test
# All 805 tests pass
```

Closes #871