### PR TITLE
refactor: PostProcessor.process() の不要な async 宣言を整理

### DIFF
--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -119,7 +119,7 @@ export class Crawler {
 		const result = this.writer.getResult();
 
 		// 後処理: MergerとChunkerの実行
-		await this.postProcessor.process(result.pages, this.pageContents);
+		this.postProcessor.process(result.pages, this.pageContents);
 
 		// 完了ログ
 		this.logger.logComplete(result.totalPages, result.specs.length, indexPath);

--- a/link-crawler/src/crawler/post-processor.ts
+++ b/link-crawler/src/crawler/post-processor.ts
@@ -28,7 +28,7 @@ export class PostProcessor {
 	 * @param pages クロール済みページ一覧
 	 * @param pageContents ページ内容のMap (--no-pages時に使用)
 	 */
-	async process(pages: CrawledPage[], pageContents?: Map<string, string>): Promise<void> {
+	process(pages: CrawledPage[], pageContents?: Map<string, string>): void {
 		if (pages.length === 0) {
 			this.logger.logPostProcessingSkipped();
 			return;


### PR DESCRIPTION
## 概要
PostProcessor.process() メソッドの不要な async 宣言を削除し、同期メソッドとして整理しました。

## 変更内容
- `PostProcessor.process()` から `async` キーワードを削除
- 戻り値の型を `Promise<void>` から `void` に変更
- 呼び出し側 (`crawler/index.ts`) の `await` を削除

## 理由
- メソッド内部で `await` を一切使用していない
- 全ての処理が同期（`readFileSync`, `writeFileSync`, 同期メソッド呼び出し）
- 不要な Promise ラッピングによるオーバーヘッドを削減
- コードの可読性向上

## テスト結果
- ✅ 型チェック: パス
- ✅ Lint: パス  
- ✅ 全テスト (804件): パス

## 影響範囲
- 変更ファイル: 2ファイル
- メソッドの振る舞いは変わらない（同期処理として明示化）

Closes #882