### PR TITLE
refactor: remove redundant singleFork option from vitest config

### DIFF
--- a/link-crawler/vitest.config.ts
+++ b/link-crawler/vitest.config.ts
@@ -12,8 +12,6 @@ export default defineConfig({
 		// forksプールを使用して各テストファイルを完全に分離
 		// (threadsではなくforksを使用することで、module mocksが他のファイルに影響しない)
 		pool: "forks",
-		// Vitest 4: poolOptions moved to top-level
-		singleFork: false,
 		// テスト間でモックをクリアして分離を確保
 		clearMocks: true,
 		mockReset: true,


### PR DESCRIPTION
## Summary
Removes the incorrectly placed `singleFork` option from vitest.config.ts.

## Changes
- Removed `singleFork: false` (was at wrong level, default value anyway)
- Removed misleading comment about Vitest 4

## Testing
✅ All 804 tests pass (32.21s)

## References
Closes #880