### PR TITLE
refactor: crawl.ts の二重エラーハンドリングを整理

### DIFF
--- a/link-crawler/src/crawl.ts
+++ b/link-crawler/src/crawl.ts
@@ -62,16 +62,9 @@ async function main(): Promise<void> {
 
 	signalHandler.install();
 
-	try {
-		const config = parseConfig(options, startUrl, packageJson.version);
-		crawler = new Crawler(config);
-		await crawler.run();
-		process.exit(EXIT_CODES.SUCCESS);
-	} catch (error) {
-		const { message, exitCode } = handleError(error);
-		console.error(message);
-		process.exit(exitCode);
-	}
+	const config = parseConfig(options, startUrl, packageJson.version);
+	crawler = new Crawler(config);
+	await crawler.run();
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## 概要
crawl.ts の二重エラーハンドリングを整理し、コードの意図を明確にしました。

## 変更内容
- main() 関数内の try/catch ブロックを削除
- 成功時の `process.exit(EXIT_CODES.SUCCESS)` を削除
- エラーハンドリングを外側の `.catch()` ブロックに統一

## 修正前の問題
- main() 内の try/catch と外側の .catch() が二重にエラーハンドリングを実施
- main() 内で全パスが process.exit() で終了するため、外側の .catch() はデッドコード
- Node.js の慣習に反する（正常終了時は process.exit を呼ばない）

## 修正後
- エラーハンドリングを1箇所に統一（外側の .catch()）
- 正常終了時は自然にプロセスが終了（exit code 0）
- コードの意図が明確になり、メンテナンス性が向上

## テスト結果
- ✅ 全テスト804件パス（27ファイル）
- ✅ 手動テスト確認済み（正常系・エラー系）
- ✅ TypeScript型チェック済み

Closes #883