### PR TITLE
refactor: make CrawlError cause parameter type-safe

### DIFF
--- a/link-crawler/src/crawler/fetcher.ts
+++ b/link-crawler/src/crawler/fetcher.ts
@@ -262,7 +262,7 @@ export class PlaywrightFetcher implements Fetcher {
 				throw error;
 			}
 			const message = error instanceof Error ? error.message : String(error);
-			throw new FetchError(message, url, error instanceof Error ? error : undefined);
+			throw new FetchError(message, url, error);
 		}
 	}
 

--- a/link-crawler/src/errors.ts
+++ b/link-crawler/src/errors.ts
@@ -3,9 +3,9 @@ export class CrawlError extends Error {
 	constructor(
 		message: string,
 		public readonly code: string,
-		cause?: Error,
+		cause?: unknown,
 	) {
-		super(message, cause ? { cause } : undefined);
+		super(message, cause !== undefined ? { cause } : undefined);
 		this.name = "CrawlError";
 	}
 
@@ -22,7 +22,7 @@ export class FetchError extends CrawlError {
 	constructor(
 		message: string,
 		public readonly url: string,
-		cause?: Error,
+		cause?: unknown,
 	) {
 		super(message, "FETCH_ERROR", cause);
 		this.name = "FetchError";


### PR DESCRIPTION
## Summary
Closes #890

## Changes
- Changed `cause` parameter type from `Error` to `unknown` in `CrawlError` and `FetchError` classes
- Removed redundant `instanceof Error` check in `fetcher.ts`
- Aligned with ES2022 Error.cause specification
- Fixed Biome lint issues

## Impact
- Non-Error type exceptions (strings, objects) can now be properly preserved as error causes
- Simplified error handling code by removing unnecessary type guards

## Testing
- ✅ All 808 tests pass
- ✅ Type checking passes (`bun run typecheck`)
- ✅ Lint check passes (`bun run check`)
- ✅ Existing tests verify backward compatibility with Error instances