### PR TITLE
fix: prioritize PATH-based fallback for Node.js and playwright-cli

### DIFF
--- a/link-crawler/src/constants.ts
+++ b/link-crawler/src/constants.ts
@@ -56,13 +56,18 @@ export const SPEC_PATTERNS: Record<string, RegExp> = {
 /** パス候補 */
 export const PATHS = {
 	/** Node.js実行ファイルの候補 */
-	NODE_PATHS: ["/opt/homebrew/bin/node", "/usr/local/bin/node", "/usr/bin/node", "node"],
+	NODE_PATHS: [
+		"node", // PATH上にあれば最速
+		"/opt/homebrew/bin/node",
+		"/usr/local/bin/node",
+		"/usr/bin/node",
+	],
 	/** Playwright CLIの候補 */
 	PLAYWRIGHT_PATHS: [
+		"playwright-cli", // PATH上にあれば最速
 		"/opt/homebrew/bin/playwright-cli",
 		"/usr/local/bin/playwright-cli",
 		...(process.env.HOME ? [`${process.env.HOME}/.npm-global/bin/playwright-cli`] : []),
-		"playwright-cli",
 	],
 } as const;
 

--- a/link-crawler/tests/unit/constants.test.ts
+++ b/link-crawler/tests/unit/constants.test.ts
@@ -16,7 +16,7 @@ describe("PATHS constants", () => {
 			expect(PATHS.NODE_PATHS).toContain("node");
 		});
 
-		it("should have correct order: specific paths before fallback", () => {
+		it("should have correct order: fallback before specific paths", () => {
 			const paths = PATHS.NODE_PATHS;
 			const fallbackIndex = paths.indexOf("node");
 			const macOSIndices = [
@@ -25,9 +25,9 @@ describe("PATHS constants", () => {
 			];
 			const linuxIndex = paths.indexOf("/usr/bin/node");
 
-			// All specific paths should come before the fallback
+			// PATH fallback should come first, before specific paths
 			for (const index of [...macOSIndices, linuxIndex]) {
-				expect(index).toBeLessThan(fallbackIndex);
+				expect(index).toBeGreaterThan(fallbackIndex);
 			}
 		});
 	});
@@ -42,7 +42,7 @@ describe("PATHS constants", () => {
 			expect(PATHS.PLAYWRIGHT_PATHS).toContain("playwright-cli");
 		});
 
-		it("should have correct order: specific paths before fallback", () => {
+		it("should have correct order: fallback before specific paths", () => {
 			const paths = PATHS.PLAYWRIGHT_PATHS;
 			const fallbackIndex = paths.indexOf("playwright-cli");
 			const macOSIndices = [
@@ -50,9 +50,9 @@ describe("PATHS constants", () => {
 				paths.indexOf("/usr/local/bin/playwright-cli"),
 			];
 
-			// All specific paths should come before the fallback
+			// PATH fallback should come first, before specific paths
 			for (const index of macOSIndices) {
-				expect(index).toBeLessThan(fallbackIndex);
+				expect(index).toBeGreaterThan(fallbackIndex);
 			}
 		});
 
@@ -63,9 +63,9 @@ describe("PATHS constants", () => {
 			}
 		});
 
-		it("should have fallback as last element", () => {
+		it("should have fallback as first element", () => {
 			const paths = PATHS.PLAYWRIGHT_PATHS;
-			expect(paths[paths.length - 1]).toBe("playwright-cli");
+			expect(paths[0]).toBe("playwright-cli");
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Optimizes Node.js and playwright-cli path search by checking PATH environment variable first. This improves efficiency in CI environments and Docker containers.

## Changes

- Move `node` and `playwright-cli` to the beginning of path arrays
- Platform-specific paths (`/opt/homebrew/bin/`, etc.) remain as fallbacks
- Update tests to reflect new priority order

## Testing

- ✅ All 808 tests pass across 27 test files
- ✅ Type checking passes
- ✅ No regressions

## Closes

Closes #889