### PR TITLE
docs: SKILL.mdとREADME.mdのドキュメントリンクの一貫性改善

### DIFF
--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -54,7 +54,7 @@ bun run src/crawl.ts <url> [options]
 - `--exclude <pattern>`: 除外するURLパターン（正規表現）
 - `--no-robots`: robots.txt を無視（非推奨、開発・テスト用）
 
-**完全なオプション一覧は [CLI仕様書](../docs/cli-spec.md) を参照してください。**
+**完全なオプション一覧は [CLI仕様書](https://github.com/takemo101/dict-skills/blob/main/docs/cli-spec.md) を参照してください。**
 
 ## piエージェントでの使用例
 
@@ -77,11 +77,11 @@ bun run src/crawl.ts https://nextjs.org/docs -d 2
 | `specs/*.yaml` | API仕様ファイル（検出時のみ） |
 | `index.json` | メタデータ・ハッシュ |
 
-**詳細な仕様は [CLI仕様書](../docs/cli-spec.md) を参照してください。**
+**詳細な仕様は [CLI仕様書](https://github.com/takemo101/dict-skills/blob/main/docs/cli-spec.md) を参照してください。**
 
 ## 参考リンク
 
 | ドキュメント | 内容 |
 |-------------|------|
-| [CLI仕様書](../docs/cli-spec.md) | 完全なオプション一覧・使用例・出力形式の詳細 |
-| [設計書](../docs/design.md) | アーキテクチャ・データ構造・技術仕様 |
+| [CLI仕様書](https://github.com/takemo101/dict-skills/blob/main/docs/cli-spec.md) | 完全なオプション一覧・使用例・出力形式の詳細 |
+| [設計書](https://github.com/takemo101/dict-skills/blob/main/docs/design.md) | アーキテクチャ・データ構造・技術仕様 |


### PR DESCRIPTION
## 概要

link-crawler/SKILL.md のドキュメントリンクをGitHub URLに統一し、npm publish時のリンク破損を予防します。

## 変更内容

- ✅ link-crawler/SKILL.md の4箇所の相対パスリンクをGitHub URLに変更
- ✅ link-crawler/README.md の形式に統一
- ✅ npm publish時の問題を予防

## 変更箇所

```diff
- [CLI仕様書](../docs/cli-spec.md)
+ [CLI仕様書](https://github.com/takemo101/dict-skills/blob/main/docs/cli-spec.md)

- [設計書](../docs/design.md)
+ [設計書](https://github.com/takemo101/dict-skills/blob/main/docs/design.md)
```

## 検証

- ✅ 4箇所のリンクがすべてGitHub URLに変換
- ✅ 相対リンクが残っていないことを確認
- ✅ リンク先ファイル (docs/cli-spec.md, docs/design.md) の存在を確認

## 参考

- docs/development.md セクション10.2: npm publish時の注意事項

Closes #908