### PR TITLE
fix: テストコードのLintエラー修正（未使用変数・フォーマット不一致）

### DIFF
--- a/link-crawler/tests/unit/crawler-error-handling.test.ts
+++ b/link-crawler/tests/unit/crawler-error-handling.test.ts
@@ -190,7 +190,7 @@ describe("Crawler - Error Handling", () => {
 		it("エラーページはスキップされ、他のページは正常にクロールされる", async () => {
 			// 1ページ目: 成功
 			const successResult: FetchResult = {
-				html: '<html><head><title>Page 1</title></head><body><a href="https://example.com/page2">Link</a></body></html>',
+				html: "<html><head><title>Page 1</title></head><body><a href='https://example.com/page2'>Link</a></body></html>",
 				finalUrl: "https://example.com",
 				contentType: "text/html",
 			};
@@ -222,7 +222,7 @@ describe("Crawler - Error Handling", () => {
 	describe("フェッチ失敗URLのリトライ機構", () => {
 		it("一時的なエラー後、他ページからのリンクでリトライされる", async () => {
 			// ページ1: 成功（page2へのリンク）
-			const page1Result: FetchResult = {
+			const _page1Result: FetchResult = {
 				html: '<html><head><title>Page 1</title></head><body><a href="https://example.com/page2">Link to Page 2</a></body></html>',
 				finalUrl: "https://example.com",
 				contentType: "text/html",
@@ -231,21 +231,21 @@ describe("Crawler - Error Handling", () => {
 			// ページ2: 1回目は失敗、2回目は成功
 			const timeoutError = new TimeoutError("Request timeout", 5000);
 			const page2Result: FetchResult = {
-				html: '<html><head><title>Page 2</title></head><body><p>Content</p></body></html>',
+				html: "<html><head><title>Page 2</title></head><body><p>Content</p></body></html>",
 				finalUrl: "https://example.com/page2",
 				contentType: "text/html",
 			};
 
 			// ページ3: 成功（page2へのリンク）
 			const page3Result: FetchResult = {
-				html: '<html><head><title>Page 3</title></head><body><a href="https://example.com/page2">Link to Page 2</a></body></html>',
+				html: "<html><head><title>Page 3</title></head><body><a href='https://example.com/page2'>Link to Page 2</a></body></html>",
 				finalUrl: "https://example.com/page3",
 				contentType: "text/html",
 			};
 
 			// ページ1に page3 へのリンクを追加
 			const page1WithPage3: FetchResult = {
-				html: '<html><head><title>Page 1</title></head><body><a href="https://example.com/page2">Page 2</a><a href="https://example.com/page3">Page 3</a></body></html>',
+				html: "<html><head><title>Page 1</title></head><body><a href='https://example.com/page2'>Page 2</a><a href='https://example.com/page3'>Page 3</a></body></html>",
 				finalUrl: "https://example.com",
 				contentType: "text/html",
 			};
@@ -275,19 +275,19 @@ describe("Crawler - Error Handling", () => {
 			// 複数ページから page2 へリンク、3回失敗させる
 			// MAX_RETRIES = 2 の場合、初回 + リトライ2回 = 合計3回までフェッチされる
 			const page1Result: FetchResult = {
-				html: '<html><head><title>Page 1</title></head><body><a href="https://example.com/page2">Page 2</a><a href="https://example.com/page3">Page 3</a><a href="https://example.com/page4">Page 4</a></body></html>',
+				html: "<html><head><title>Page 1</title></head><body><a href='https://example.com/page2'>Page 2</a><a href='https://example.com/page3'>Page 3</a><a href='https://example.com/page4'>Page 4</a></body></html>",
 				finalUrl: "https://example.com",
 				contentType: "text/html",
 			};
 
 			const page3Result: FetchResult = {
-				html: '<html><head><title>Page 3</title></head><body><a href="https://example.com/page2">Page 2</a></body></html>',
+				html: "<html><head><title>Page 3</title></head><body><a href='https://example.com/page2'>Page 2</a></body></html>",
 				finalUrl: "https://example.com/page3",
 				contentType: "text/html",
 			};
 
 			const page4Result: FetchResult = {
-				html: '<html><head><title>Page 4</title></head><body><a href="https://example.com/page2">Page 2</a></body></html>',
+				html: "<html><head><title>Page 4</title></head><body><a href='https://example.com/page2'>Page 2</a></body></html>",
 				finalUrl: "https://example.com/page4",
 				contentType: "text/html",
 			};
@@ -322,13 +322,13 @@ describe("Crawler - Error Handling", () => {
 		it("fetch()がnullを返す場合（404等）もリトライ上限が適用される", async () => {
 			// 404エラーもリトライ対象とする
 			const page1Result: FetchResult = {
-				html: '<html><head><title>Page 1</title></head><body><a href="https://example.com/page2">Page 2</a><a href="https://example.com/page3">Page 3</a></body></html>',
+				html: "<html><head><title>Page 1</title></head><body><a href='https://example.com/page2'>Page 2</a><a href='https://example.com/page3'>Page 3</a></body></html>",
 				finalUrl: "https://example.com",
 				contentType: "text/html",
 			};
 
 			const page3Result: FetchResult = {
-				html: '<html><head><title>Page 3</title></head><body><a href="https://example.com/page2">Page 2</a></body></html>',
+				html: "<html><head><title>Page 3</title></head><body><a href='https://example.com/page2'>Page 2</a></body></html>",
 				finalUrl: "https://example.com/page3",
 				contentType: "text/html",
 			};
@@ -357,25 +357,25 @@ describe("Crawler - Error Handling", () => {
 		it("フェッチ成功後、リトライカウントがクリアされる", async () => {
 			// page2: 1回失敗 → 2回目成功 → 3回目はvisitedによりスキップ
 			const page1Result: FetchResult = {
-				html: '<html><head><title>Page 1</title></head><body><a href="https://example.com/page2">Page 2</a><a href="https://example.com/page3">Page 3</a><a href="https://example.com/page4">Page 4</a></body></html>',
+				html: "<html><head><title>Page 1</title></head><body><a href='https://example.com/page2'>Page 2</a><a href='https://example.com/page3'>Page 3</a><a href='https://example.com/page4'>Page 4</a></body></html>",
 				finalUrl: "https://example.com",
 				contentType: "text/html",
 			};
 
 			const page2Result: FetchResult = {
-				html: '<html><head><title>Page 2</title></head><body><p>Content</p></body></html>',
+				html: "<html><head><title>Page 2</title></head><body><p>Content</p></body></html>",
 				finalUrl: "https://example.com/page2",
 				contentType: "text/html",
 			};
 
 			const page3Result: FetchResult = {
-				html: '<html><head><title>Page 3</title></head><body><a href="https://example.com/page2">Page 2</a></body></html>',
+				html: "<html><head><title>Page 3</title></head><body><a href='https://example.com/page2'>Page 2</a></body></html>",
 				finalUrl: "https://example.com/page3",
 				contentType: "text/html",
 			};
 
 			const page4Result: FetchResult = {
-				html: '<html><head><title>Page 4</title></head><body><a href="https://example.com/page2">Page 2</a></body></html>',
+				html: "<html><head><title>Page 4</title></head><body><a href='https://example.com/page2'>Page 2</a></body></html>",
 				finalUrl: "https://example.com/page4",
 				contentType: "text/html",
 			};


### PR DESCRIPTION
## 概要

プロジェクトレビューで発見されたテストコードのLintエラーを修正しました。

## 変更内容

### 1. 未使用変数の修正
- `link-crawler/tests/unit/crawler-error-handling.test.ts` L225
- `page1Result` → `_page1Result` にリネーム
- このテストでは `page1WithPage3` を使用しており、`page1Result` は使用されていなかった

### 2. クォートスタイルの統一
- HTML文字列のクォートをBiome推奨形式に統一
- エスケープ不要: ダブルクォート
- エスケープ必要: シングルクォート（可読性向上）

## 検証結果

```bash
# Lintチェック
$ bun run check
Checked 54 files in 323ms. No fixes applied.

# TypeScriptチェック  
$ bun run typecheck
✓ No errors

# テスト
$ bun run test
Test Files  27 passed (27)
Tests  812 passed (812)
```

## 関連Issue

Closes #906