### PR TITLE
fix: CI lint ジョブが main ブランチで失敗する状態の解消

### DIFF
--- a/link-crawler/tests/unit/crawler-error-handling.test.ts
+++ b/link-crawler/tests/unit/crawler-error-handling.test.ts
@@ -222,7 +222,7 @@ describe("Crawler - Error Handling", () => {
 	describe("フェッチ失敗URLのリトライ機構", () => {
 		it("一時的なエラー後、他ページからのリンクでリトライされる", async () => {
 			// ページ1: 成功（page2へのリンク）
-			const page1Result: FetchResult = {
+			const _page1Result: FetchResult = {
 				html: '<html><head><title>Page 1</title></head><body><a href="https://example.com/page2">Link to Page 2</a></body></html>',
 				finalUrl: "https://example.com",
 				contentType: "text/html",
@@ -231,7 +231,7 @@ describe("Crawler - Error Handling", () => {
 			// ページ2: 1回目は失敗、2回目は成功
 			const timeoutError = new TimeoutError("Request timeout", 5000);
 			const page2Result: FetchResult = {
-				html: '<html><head><title>Page 2</title></head><body><p>Content</p></body></html>',
+				html: "<html><head><title>Page 2</title></head><body><p>Content</p></body></html>",
 				finalUrl: "https://example.com/page2",
 				contentType: "text/html",
 			};
@@ -363,7 +363,7 @@ describe("Crawler - Error Handling", () => {
 			};
 
 			const page2Result: FetchResult = {
-				html: '<html><head><title>Page 2</title></head><body><p>Content</p></body></html>',
+				html: "<html><head><title>Page 2</title></head><body><p>Content</p></body></html>",
 				finalUrl: "https://example.com/page2",
 				contentType: "text/html",
 			};


### PR DESCRIPTION
## 概要

CI の lint ジョブ (`bun run check`) で発生していた2件のエラーを修正しました。

## 修正内容

### 1. 未使用変数の修正
- **ファイル**: `link-crawler/tests/unit/crawler-error-handling.test.ts:225`
- **変更**: `page1Result` → `_page1Result`
- **理由**: 変数は宣言されているが使用されていなかったため、Biome の推奨に従いアンダースコアをプレフィックス

### 2. クォートスタイルの統一
- **ファイル**: `link-crawler/tests/unit/crawler-error-handling.test.ts:234, 366`
- **変更**: シングルクォート → ダブルクォート
- **理由**: プロジェクトの標準に合わせて統一

## 検証

```bash
cd link-crawler
bun run check      # ✅ エラー0件
bun run typecheck  # ✅ パス
bun run test       # ✅ 812テスト全てパス
```

## 影響範囲

- テストファイルのみの変更
- テスト動作に影響なし
- 実装コードへの影響なし

Closes #918