### PR TITLE
docs: verify coverage/ directory is not tracked (#917)

### DIFF
--- a/docs/verification/issue-917-coverage-verification.md
+++ b/docs/verification/issue-917-coverage-verification.md
@@ -1,0 +1,88 @@
+# Issue #917 Verification: coverage/ Directory Not Tracked
+
+## Issue Summary
+Issue #917 reported that `link-crawler/coverage/` directory (HTML coverage reports) is tracked in the Git repository, despite `.gitignore` configuration.
+
+## Investigation Results
+
+### 1. .gitignore Configuration
+```bash
+$ cat .gitignore | grep coverage
+**/coverage/
+
+$ cat link-crawler/.gitignore | grep coverage
+coverage/
+```
+✅ Both root and link-crawler `.gitignore` have coverage exclusion patterns
+
+### 2. Git Tracking Status (Before Any Changes)
+```bash
+$ git ls-files link-crawler/coverage/
+(no output)
+```
+✅ No files in `link-crawler/coverage/` are currently tracked
+
+### 3. Attempted Removal (from Issue Instructions)
+```bash
+$ cd link-crawler && git rm -r --cached coverage/
+fatal: pathspec 'coverage/' did not match any files
+```
+✅ Confirms no tracked files exist (nothing to remove)
+
+### 4. Coverage Generation Test
+```bash
+$ cd link-crawler && bun run test:coverage
+```
+**Results**:
+- All tests passed: 814 tests in 27 test files
+- Coverage generated successfully:
+  - Overall: 97.85% statements, 92% branches, 99.38% functions
+  - Coverage files created in `link-crawler/coverage/`
+- Git status after generation: "nothing to commit, working tree clean"
+- Coverage files remain untracked ✅
+
+### 5. Post-Generation Tracking Verification
+```bash
+$ ls -la link-crawler/coverage/ | head -10
+total 136
+drwxr-xr-x@ 12 kawasakiisao  staff    384 Feb  8 17:25 .
+drwxr-xr-x@ 15 kawasakiisao  staff    480 Feb  8 17:24 ..
+-rw-r--r--@  1 kawasakiisao  staff   5394 Feb  8 17:25 base.css
+-rw-r--r--@  1 kawasakiisao  staff   2655 Feb  8 17:25 block-navigation.js
+-rw-r--r--@  1 kawasakiisao  staff   7836 Feb  8 17:25 coverage-summary.json
+...
+
+$ git ls-files link-crawler/coverage/
+(no output)
+```
+✅ Coverage files exist but are not tracked
+
+## Completion Conditions (from Issue #917)
+
+- [x] `git ls-files link-crawler/coverage/` の出力が空
+- [x] `bun run test:coverage` が正常に動作
+
+## Conclusion
+
+The issue's requirements are **already satisfied**. No code changes are needed because:
+
+1. Coverage files are not tracked in the Git repository
+2. `.gitignore` is properly configured
+3. Coverage generation works correctly
+4. Generated coverage files remain untracked
+
+This issue appears to be either:
+- Already resolved in a previous commit
+- Based on outdated information
+- A duplicate of Issue #826 (which already verified this)
+
+## Related Issues
+
+- Issue #826: Previously verified coverage `.gitignore` configuration
+- See: `docs/verification/issue-826-coverage-gitignore-verification.md`
+
+## Verification Date
+2026-02-08
+
+## Verified By
+Automated testing and Git status verification in worktree: issue-917-refactor-coverage


### PR DESCRIPTION
## Summary

This PR verifies that Issue #917's requirements are already satisfied.

## Investigation

- **Finding**:  directory is NOT tracked in Git
- **Status**: Both completion conditions from the issue are already met
- **Action**: Created verification document instead of code changes

## Verification Results

✅  returns empty (no tracked files)
✅  works correctly (814 tests, 97.85% coverage)
✅  properly configured
✅ Coverage files remain untracked after generation

## Related Issues

- Related to #826 which previously verified the same configuration
- See: `docs/verification/issue-826-coverage-gitignore-verification.md`

## Conclusion

The issue appears to be based on outdated information or already resolved. No code changes are needed - the verification confirms the system is working as expected.

## Changes

- Added: `docs/verification/issue-917-coverage-verification.md`

Closes #917