### PR TITLE
docs: verify dist/ directory is properly ignored

### DIFF
--- a/.gitignore-verification
+++ b/.gitignore-verification
@@ -1,0 +1,31 @@
+# Verification: dist/ is properly ignored
+
+This file documents the verification performed for Issue #919.
+
+## Verification Steps
+
+1. Checked tracked files:
+   ```bash
+   git ls-files link-crawler/dist/
+   # Result: No output (no files tracked)
+   ```
+
+2. Built the project:
+   ```bash
+   cd link-crawler && bun run build
+   # Result: dist/crawl.js generated successfully
+   ```
+
+3. Verified git status:
+   ```bash
+   git status
+   # Result: dist/ directory not shown (properly ignored)
+   ```
+
+## Conclusion
+The .gitignore configuration is working correctly.
+- link-crawler/.gitignore contains: `dist/`
+- Root .gitignore contains: `dist/`
+- Build artifacts in dist/ are properly ignored by git
+
+Issue #919 requirements are satisfied.


### PR DESCRIPTION
## Summary
Closes #919

## Changes
- Added verification documentation () confirming that the `dist/` directory is properly excluded from git tracking
- Verified that no files in `link-crawler/dist/` are currently tracked
- Confirmed that build artifacts are correctly ignored by the existing `.gitignore` configuration

## Verification Results

### Tracked Files Check
```bash
git ls-files link-crawler/dist/
# Result: No output (no files tracked) ✓
```

### Build Test
```bash
cd link-crawler && bun run build
# Result: dist/crawl.js generated successfully ✓
```

### Git Status Verification
```bash
git status
# Result: dist/ directory not shown (properly ignored) ✓
```

## Conclusion
The issue requirements are already satisfied:
- ✓ `git ls-files link-crawler/dist/` outputs nothing
- ✓ `bun run build` works correctly
- ✓ Generated files are not tracked

The `.gitignore` configuration is working as intended. No code changes were necessary.