### PR TITLE
fix: install.sh のシバン行を #!/usr/bin/env bash に統一

### DIFF
--- a/link-crawler/install.sh
+++ b/link-crawler/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 echo "🔧 link-crawler インストールスクリプト"


### PR DESCRIPTION
## 概要
`link-crawler/install.sh` のシバン行を `#!/bin/bash` から `#!/usr/bin/env bash` に変更し、ポータビリティを向上させました。

## 変更内容
- `link-crawler/install.sh` のシバン行を `#!/usr/bin/env bash` に変更

## 理由
NixOSや一部のLinuxディストリビューション、Dockerコンテナでは `/bin/bash` が存在しない場合があります。`/usr/bin/env bash` を使用することで、PATH環境変数からbashを検索し、より多くの環境で実行可能になります。

## 検証
- ✅ シバン行が正しく変更されたことを確認
- ✅ 実行権限が維持されていることを確認
- ✅ スクリプトの構文チェック完了
- ✅ プロジェクト内の全シェルスクリプトが統一されたことを確認

Closes #929