### PR TITLE
fix: exclude barrel file src/diff/index.ts from coverage

### DIFF
--- a/link-crawler/vitest.config.ts
+++ b/link-crawler/vitest.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
 			provider: "v8",
 			reporter: ["text", "html", "json-summary"],
 			include: ["src/**/*.ts"],
-			exclude: ["src/crawl.ts", "src/types.ts", "src/types/**"],
+			exclude: ["src/crawl.ts", "src/types.ts", "src/types/**", "src/diff/index.ts"],
 		},
 	},
 });


### PR DESCRIPTION
## 概要
カバレッジ設定でバレルファイル `src/diff/index.ts` を除外し、カバレッジレポートのノイズを削減。

## 変更内容
- `vitest.config.ts` の `coverage.exclude` に `src/diff/index.ts` を追加
- 既存パターン（`src/types.ts`）に準拠

## 効果
**Before:**
```
src/diff          |     100 |      100 |     100 |     100 |
 hasher.ts        |     100 |      100 |     100 |     100 |
 index.ts         |       0 |        0 |       0 |       0 |  ← ノイズ
```

**After:**
```
src/diff          |     100 |      100 |     100 |     100 |
 hasher.ts        |     100 |      100 |     100 |     100 |
```

## テスト
- ✅ 全テスト (814 tests) パス
- ✅ カバレッジレポートでバレルファイルが非表示になることを確認

Closes #928