### PR TITLE
fix: cleanup chunks/ and full.md when options change

### DIFF
--- a/link-crawler/src/output/writer.ts
+++ b/link-crawler/src/output/writer.ts
@@ -49,6 +49,8 @@ export class OutputWriter {
 	async init(): Promise<void> {
 		const pagesDir = join(this.config.outputDir, FILENAME.PAGES_DIR);
 		const specsDir = join(this.config.outputDir, FILENAME.SPECS_DIR);
+		const chunksDir = join(this.config.outputDir, FILENAME.CHUNKS_DIR);
+		const fullMdPath = join(this.config.outputDir, FILENAME.FULL_MD);
 
 		// 非 diff モード時のみディレクトリをクリーンアップ
 		if (!this.config.diff && existsSync(pagesDir)) {
@@ -56,6 +58,12 @@ export class OutputWriter {
 		}
 		if (!this.config.diff && existsSync(specsDir)) {
 			rmSync(specsDir, { recursive: true, force: true });
+		}
+		if (!this.config.diff && existsSync(chunksDir)) {
+			rmSync(chunksDir, { recursive: true, force: true });
+		}
+		if (!this.config.diff && existsSync(fullMdPath)) {
+			rmSync(fullMdPath, { force: true });
 		}
 
 		// ディレクトリを作成

--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -917,5 +917,54 @@ describe("OutputWriter", () => {
 			// ディレクトリが削除されたため、ファイルが存在しないことを確認
 			expect(() => readFileSync(pagePath, "utf-8")).toThrow();
 		});
+
+		it("should cleanup chunks/ directory and full.md in non-diff mode", async () => {
+			// 1. 初回実行: chunks/ と full.md を作成
+			const chunksDir = join(testOutputDir, "chunks");
+			const fullMdPath = join(testOutputDir, "full.md");
+
+			mkdirSync(chunksDir, { recursive: true });
+			writeFileSync(join(chunksDir, "chunk-001.md"), "# Chunk 1");
+			writeFileSync(join(chunksDir, "chunk-002.md"), "# Chunk 2");
+			writeFileSync(fullMdPath, "# Full Content");
+
+			// ファイルが作成されたことを確認
+			expect(readFileSync(join(chunksDir, "chunk-001.md"), "utf-8")).toBe("# Chunk 1");
+			expect(readFileSync(join(chunksDir, "chunk-002.md"), "utf-8")).toBe("# Chunk 2");
+			expect(readFileSync(fullMdPath, "utf-8")).toBe("# Full Content");
+
+			// 2. 非 diff モードで再初期化
+			const writer = new OutputWriter({ ...defaultConfig, diff: false });
+			await writer.init();
+
+			// chunks/ ディレクトリと full.md が削除されたことを確認
+			expect(() => readFileSync(join(chunksDir, "chunk-001.md"), "utf-8")).toThrow();
+			expect(() => readFileSync(fullMdPath, "utf-8")).toThrow();
+		});
+
+		it("should preserve chunks/ directory and full.md in diff mode", async () => {
+			// 1. 初回実行: chunks/ と full.md を作成
+			const chunksDir = join(testOutputDir, "chunks");
+			const fullMdPath = join(testOutputDir, "full.md");
+
+			mkdirSync(chunksDir, { recursive: true });
+			writeFileSync(join(chunksDir, "chunk-001.md"), "# Chunk 1");
+			writeFileSync(join(chunksDir, "chunk-002.md"), "# Chunk 2");
+			writeFileSync(fullMdPath, "# Full Content");
+
+			// ファイルが作成されたことを確認
+			expect(readFileSync(join(chunksDir, "chunk-001.md"), "utf-8")).toBe("# Chunk 1");
+			expect(readFileSync(join(chunksDir, "chunk-002.md"), "utf-8")).toBe("# Chunk 2");
+			expect(readFileSync(fullMdPath, "utf-8")).toBe("# Full Content");
+
+			// 2. diff モードで再初期化
+			const writer = new OutputWriter({ ...defaultConfig, diff: true });
+			await writer.init();
+
+			// chunks/ ディレクトリと full.md が保持されていることを確認
+			expect(readFileSync(join(chunksDir, "chunk-001.md"), "utf-8")).toBe("# Chunk 1");
+			expect(readFileSync(join(chunksDir, "chunk-002.md"), "utf-8")).toBe("# Chunk 2");
+			expect(readFileSync(fullMdPath, "utf-8")).toBe("# Full Content");
+		});
 	});
 });


### PR DESCRIPTION
## Summary
Fixes #926 

## Changes
- Add cleanup for `chunks/` directory in non-diff mode
- Add cleanup for `full.md` file in non-diff mode
- Add unit tests to verify cleanup behavior
- Add unit tests to verify diff mode preserves files

## Issue
Previously, when changing options (e.g., from `--chunks` to `--no-chunks`), the old `chunks/` directory and `full.md` file would remain, causing confusion.

## Solution
Modified `OutputWriter.init()` to cleanup `chunks/` and `full.md` in non-diff mode, consistent with how `pages/` and `specs/` are handled.

## Testing
- ✅ All 816 tests pass
- ✅ Added 2 new test cases for cleanup behavior
- ✅ Verified diff mode preserves files correctly

Closes #926