### PR TITLE
fix: remove unused check() function from verify-gitignore.sh

### DIFF
--- a/scripts/verify-gitignore.sh
+++ b/scripts/verify-gitignore.sh
@@ -17,29 +17,6 @@ NC='\033[0m' # No Color
 PASSED=0
 FAILED=0
 
-# Function to check and report
-check() {
-    local description="$1"
-    local command="$2"
-    local expected="$3"
-    
-    echo "Checking: $description"
-    
-    if eval "$command" > /dev/null 2>&1; then
-        if [ "$expected" = "empty" ]; then
-            echo -e "${GREEN}✓ PASS${NC}: No tracked files found"
-            ((PASSED++))
-        else
-            echo -e "${GREEN}✓ PASS${NC}: Files are properly ignored"
-            ((PASSED++))
-        fi
-    else
-        echo -e "${RED}✗ FAIL${NC}: $description"
-        ((FAILED++))
-    fi
-    echo ""
-}
-
 # Check 1: .improve-logs/ not tracked
 echo "1. Checking .improve-logs/ tracking status..."
 RESULT=$(git ls-files .improve-logs/ 2>/dev/null || true)


### PR DESCRIPTION
## Summary

Removes the unused `check()` function from `scripts/verify-gitignore.sh` that was flagged by ShellCheck SC2329.

## Changes

- Removed never-invoked `check()` function (lines 21-40)
- Fixes ShellCheck SC2329 warning
- No functional changes (function was not used)

## Verification

✅ ShellCheck: No warnings
✅ Script execution: All checks pass
✅ No regressions

## Testing

```bash
# ShellCheck verification
shellcheck scripts/verify-gitignore.sh
# ✅ No warnings

# Functional verification
bash scripts/verify-gitignore.sh
# ✅ All 5 checks pass
```

Closes #938