### PR TITLE
refactor: robots.txt チェック時の User-Agent をクローラー名に統一

### DIFF
--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -77,7 +77,7 @@ export class Crawler {
 
 			const result = await this.fetcher.fetch(robotsUrl);
 			if (result?.contentType.includes("text/plain")) {
-				this.robotsChecker = new RobotsChecker(result.html);
+				this.robotsChecker = new RobotsChecker(result.html, "link-crawler");
 				this.logger.logDebug("robots.txt loaded and parsed", { url: robotsUrl });
 			} else {
 				this.logger.logDebug("robots.txt not available (allowing all)");

--- a/link-crawler/src/crawler/robots.ts
+++ b/link-crawler/src/crawler/robots.ts
@@ -10,7 +10,7 @@ export class RobotsChecker {
 	private rules: RobotsRule[] = [];
 	private userAgent: string;
 
-	constructor(robotsTxt: string, userAgent = "*") {
+	constructor(robotsTxt: string, userAgent = "link-crawler") {
 		this.userAgent = userAgent;
 		// HTMLタグを除去してからパース（playwright-cli互換性のため）
 		const plainText = this.stripHtml(robotsTxt);


### PR DESCRIPTION
## Summary
Closes #937

robots.txt チェック時の User-Agent をワイルドカード (`*`) からクローラー名 (`link-crawler`) に統一しました。

## Changes

### Modified Files
- `link-crawler/src/crawler/robots.ts`
  - デフォルトパラメータを `userAgent = "*"` から `userAgent = "link-crawler"` に変更
- `link-crawler/src/crawler/index.ts`
  - RobotsChecker の初期化時に明示的に `"link-crawler"` を指定

### Behavior
- **Before**: `User-agent: *` のルールのみをチェック
- **After**: `User-agent: link-crawler` → `User-agent: *` の順でチェック（フォールバック機構）

## Testing

- 全テスト (815件) がパス
- 既存のフォールバック機構は維持されており、`link-crawler` 専用ルールがない場合は `*` ルールが適用される

## Benefits

1. **自己識別**: クローラーが自身を識別可能な User-Agent を使用
2. **robots.txt 準拠**: サイト管理者がクローラーごとに異なるルールを設定可能に
3. **下位互換性**: フォールバック機構により既存の動作は維持