### PR TITLE
refactor: PostProcessor の不要なインスタンス生成を削除

### DIFF
--- a/link-crawler/src/crawler/post-processor.ts
+++ b/link-crawler/src/crawler/post-processor.ts
@@ -11,16 +11,12 @@ import { CrawlLogger } from "./logger.js";
  */
 export class PostProcessor {
 	private logger: CrawlLogger;
-	private merger: Merger;
-	private chunker: Chunker;
 
 	constructor(
 		private config: CrawlConfig,
 		logger?: CrawlLogger,
 	) {
 		this.logger = logger ?? new CrawlLogger(config);
-		this.merger = new Merger(this.logger);
-		this.chunker = new Chunker(config.outputDir);
 	}
 
 	/**
@@ -45,7 +41,13 @@ export class PostProcessor {
 		// - merge: full.md出力のため
 		// - chunks: チャンク分割のため
 		const needsFullContent = this.config.merge || this.config.chunks;
-		const fullMdContent = needsFullContent ? this.merger.buildFullContent(pages, contents) : "";
+		let fullMdContent = "";
+
+		if (needsFullContent) {
+			// Merger を必要時のみ生成
+			const merger = new Merger(this.logger);
+			fullMdContent = merger.buildFullContent(pages, contents);
+		}
 
 		// Merger出力 (full.md書き込み)
 		if (this.config.merge && fullMdContent) {
@@ -58,7 +60,9 @@ export class PostProcessor {
 		// Chunker出力
 		if (this.config.chunks && fullMdContent) {
 			this.logger.logChunkerStart();
-			const chunkFiles = this.chunker.chunkAndWrite(fullMdContent);
+			// Chunker を必要時のみ生成
+			const chunker = new Chunker(this.config.outputDir);
+			const chunkFiles = chunker.chunkAndWrite(fullMdContent);
 			this.logger.logChunkerComplete(chunkFiles.length);
 		}
 	}


### PR DESCRIPTION
## 概要

`PostProcessor` クラスのコンストラクタが `config.merge` や `config.chunks` の値に関わらず、常に `Merger` と `Chunker` のインスタンスを生成している問題を修正。

## 変更内容

### Before
- コンストラクタで常に `Merger` と `Chunker` のインスタンスを生成
- `--no-merge --no-pages` でも不要なインスタンスが生成される

### After
- 遅延初期化パターンを採用
- `Merger` は `config.merge || config.chunks` の場合のみ生成
- `Chunker` は `config.chunks` の場合のみ生成

## 影響

- パフォーマンス: 微小な改善（不要なオブジェクト生成を回避）
- コードの意図: より明確に
- 動作: 変更なし（全テストパス）

## テスト

- ✅ 全単体テスト（815/815）がパス
- ✅ 型チェックがパス
- ✅ 既存のテストカバレッジを維持

## 関連

Closes #939