### PR TITLE
fix: writer テストで一時ディレクトリがリークする

### DIFF
--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { OutputWriter } from "../../src/output/writer.js";
@@ -43,6 +43,11 @@ describe("OutputWriter", () => {
 
 	afterEach(() => {
 		rmSync(testOutputDir, { recursive: true, force: true });
+		// 一時ディレクトリもクリーンアップ
+		const entries = readdirSync(".").filter(e => e.startsWith("test-output-writer"));
+		for (const entry of entries) {
+			rmSync(entry, { recursive: true, force: true });
+		}
 	});
 
 	it("should save page with hash and crawledAt", () => {


### PR DESCRIPTION
## 概要

Issue #945 の修正: writer テストの  で一時ディレクトリが正しくクリーンアップされない問題を解決しました。

## 変更内容

-  に glob パターンによるクリーンアップを追加
-  で始まる全てのディレクトリを削除
-  を追加でインポート

## 問題の詳細

`OutputWriter` は非diffモード時に `${outputDir}.tmp-${Date.now()}-${process.pid}` という一時ディレクトリを作成しますが、`afterEach` は `./test-output-writer` のみを削除していたため、`finalize()` を呼ばないテストケースで一時ディレクトリが残り続けていました。

## テスト結果

- ✅ 全 818 テストがパス
- ✅ テスト実行後に一時ディレクトリが残らないことを確認済み

Closes #945