### PR TITLE
docs: remove obsolete sessionId短縮形式 constraint from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,6 @@
 |------|------|------|
 | デフォルトセッション使用 | playwright-cli 0.0.63+ の仕様変更 | [001](docs/decisions/001-playwright-cli-session.md) |
 | 並列クロール不可 | 上記の制約による | [001](docs/decisions/001-playwright-cli-session.md) |
-| sessionId短縮形式 | Unixソケットパス長制限 | [001](docs/decisions/001-playwright-cli-session.md) |
 
 <!-- エージェントが重要な知見を発見した際、上の表に1行追加し、docs/decisions/ に詳細を記録する -->
 


### PR DESCRIPTION
## Summary

Remove the obsolete "sessionId短縮形式" constraint from AGENTS.md constraint table.

## Background

The current implementation () uses default session (omits  option) and no longer generates sessionId. The sessionId shortening constraint was a transitional solution before switching to default session in playwright-cli 0.0.63+.

## Changes

- Remove 1 line from AGENTS.md constraint table: `| sessionId短縮形式 | Unixソケットパス長制限 | [001](docs/decisions/001-playwright-cli-session.md) |`
- Retain the other 2 constraints (デフォルトセッション使用, 並列クロール不可)
- Keep docs/decisions/001-playwright-cli-session.md as historical record

## Verification

All tests passed:
```bash
# sessionId短縮 removed
grep -c "sessionId短縮" AGENTS.md  # → 0

# Other constraints retained
grep -c "デフォルトセッション使用" AGENTS.md  # → 1
grep -c "並列クロール不可" AGENTS.md  # → 1
grep -c "docs/decisions/001" AGENTS.md  # → 3
```

Closes #959