### PR TITLE
docs: document that issue #965 is duplicate of #961

### DIFF
--- a/docs/decisions/004-issue-965-duplicate.md
+++ b/docs/decisions/004-issue-965-duplicate.md
@@ -1,0 +1,58 @@
+# 004: Issue #965 は Issue #961 と重複 (2026-02-08)
+
+## 問題
+
+Issue #965 で「`docs/decisions/` ディレクトリ内でファイル番号が重複している」という問題が報告された。
+
+具体的には：
+```
+001-playwright-cli-session.md
+002-issue-854-duplicate.md
+002-issue-946-duplicate.md   ← 番号が 002 で重複
+```
+
+## 調査結果
+
+Issue #965 の worktree (`issue-965-fix-docs-decisions`) を調査した結果、**この問題は既に PR #961 で解決済み**であることが判明した。
+
+### PR #961 の内容
+
+コミット `5039c5b` (PR #961) で以下の修正が実施された：
+
+1. **ファイルリネーム**
+   - `docs/decisions/002-issue-946-duplicate.md` → `docs/decisions/003-issue-946-duplicate.md`
+
+2. **見出し修正**
+   - `002-issue-854-duplicate.md`: `# 854:` → `# 002:`
+   - `003-issue-946-duplicate.md`: `# 002:` → `# 003:`
+
+3. **README.md 更新**
+   - 002, 003 のエントリを追加
+
+### 現在の状態
+
+```bash
+docs/decisions/
+├── 001-playwright-cli-session.md
+├── 002-issue-854-duplicate.md
+├── 003-issue-946-duplicate.md  ← 既に修正済み
+└── README.md
+```
+
+## 結論
+
+- Issue #965 は Issue #961 の**重複Issue**である
+- 実装作業は不要（既に完了済み）
+- この ADR（004）で重複の記録を残し、Issue #965 をクローズする
+
+## 教訓
+
+- Issue 作成前に既存の PR/Issue を検索することが重要
+- 同じ問題が並行して報告される可能性があるため、作業開始前の最新状態確認が必須
+- worktree ベースの並行開発では、ベースコミットが最新でない場合がある
+
+## 参考
+
+- Issue #965: fix: docs/decisions/ のファイル番号の重複を解消する
+- Issue #961 / PR #961: docs: ADR番号重複を解消 (002→002,003)
+- Commit: 5039c5b

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -15,6 +15,7 @@ NNN-問題名.md
 | [001](001-playwright-cli-session.md) | playwright-cli セッション問題 | 有効 |
 | [002](002-issue-854-duplicate.md) | Issue #854 is Duplicate of #848 | 解決済み |
 | [003](003-issue-946-duplicate.md) | Issue #946 は PR #944 で解決済み | 解決済み |
+| [004](004-issue-965-duplicate.md) | Issue #965 は Issue #961 と重複 | 解決済み |
 
 ## 記録すべき内容
 


### PR DESCRIPTION
## 概要

Issue #965 が Issue #961 と重複していることを記録する ADR（004）を追加。

## 背景

Issue #965 で「`docs/decisions/` ディレクトリ内でファイル番号が重複している」という問題が報告されたが、調査の結果、この問題は既に PR #961 で解決済みであることが判明した。

## 変更内容

- **新規**: `docs/decisions/004-issue-965-duplicate.md` - 重複Issue の記録
- **更新**: `docs/decisions/README.md` - ADR 004 のエントリ追加

## PR #961 の内容（既に解決済み）

```
002-issue-946-duplicate.md → 003-issue-946-duplicate.md にリネーム
見出し番号の修正（002, 003）
README.md の更新
```

## 検証方法

```bash
ls docs/decisions/
# 期待: 001, 002, 003, 004 が連番で並ぶ
```

## 関連Issue

Closes #965

## 備考

- Issue #965 は実装作業不要（既に完了済み）
- この PR は重複の記録のみを目的とする