### PR TITLE
docs: verify coverage/ is properly excluded from version control

### DIFF
--- a/docs/verification/issue-966-verification.md
+++ b/docs/verification/issue-966-verification.md
@@ -1,0 +1,80 @@
+# Issue #966 Verification Report
+
+**Issue**: refactor: coverage/ ディレクトリをバージョン管理から除外する  
+**Date**: 2026-02-08  
+**Status**: ✅ Already Resolved
+
+## Summary
+
+Issue #966 で指摘された問題（`link-crawler/coverage/coverage-summary.json` がリポジトリに存在している）は、
+現時点で **既に解決済み** であることを確認しました。
+
+## Verification Steps
+
+### 1. Git追跡状態の確認
+
+```bash
+$ git ls-files -- link-crawler/coverage/
+(出力なし)
+```
+
+**結果**: `coverage/` ディレクトリ内のファイルは追跡されていない ✅
+
+### 2. .gitignore の確認
+
+```bash
+$ cat link-crawler/.gitignore | grep coverage
+coverage/
+
+$ cat .gitignore | grep coverage
+**/coverage/
+```
+
+**結果**: `.gitignore` で適切に除外されている ✅
+
+### 3. 実際のカバレッジ生成テスト
+
+```bash
+$ cd link-crawler
+$ bun run test:coverage
+# テスト実行後...
+
+$ ls -la coverage/
+total 0
+drwxr-xr-x@  3 kawasakiisao  staff   96 Feb  8 21:08 .
+drwxr-xr-x@ 15 kawasakiisao  staff  480 Feb  8 21:08 ..
+drwxr-xr-x@ 28 kawasakiisao  staff  896 Feb  8 21:09 .tmp
+```
+
+**結果**: カバレッジファイルは生成される ✅
+
+### 4. 生成されたファイルの追跡状態確認
+
+```bash
+$ git ls-files -- link-crawler/coverage/
+(出力なし)
+
+$ git status --short link-crawler/coverage/
+(出力なし)
+```
+
+**結果**: 生成されたファイルは `.gitignore` により正しく除外される ✅
+
+## Conclusion
+
+- ✅ `coverage/` ディレクトリはGit追跡対象外
+- ✅ `.gitignore` が正しく機能している
+- ✅ カバレッジファイル生成時も追跡されない
+- ✅ Issue #966 の問題は既に解決済み
+
+## Timeline
+
+Issue作成時（推定）には `link-crawler/coverage/coverage-summary.json` が追跡されていた可能性がありますが、
+現在のmainブランチでは既に適切に除外されています。
+
+過去のPRまたはコミットで修正されたと考えられます。
+
+## Recommendation
+
+このPRではIssue #966が既に解決済みであることを報告し、検証結果を記録として残します。
+追加の修正は不要です。


### PR DESCRIPTION
## Summary

Issue #966 で指摘された問題（`link-crawler/coverage/coverage-summary.json` がリポジトリに存在している）は、現時点で **既に解決済み** であることを確認しました。

## Verification Results

✅ `coverage/` ディレクトリはGit追跡対象外  
✅ `.gitignore` が正しく機能している  
✅ カバレッジファイル生成時も追跡されない  

詳細な検証結果は `docs/verification/issue-966-verification.md` を参照してください。

## Changes

- 📄 Added `docs/verification/issue-966-verification.md` - Verification report

Closes #966