### PR TITLE
fix: Biome lint/format errors in crawl-cli.test.ts

### DIFF
--- a/link-crawler/tests/integration/crawl-cli.test.ts
+++ b/link-crawler/tests/integration/crawl-cli.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -161,15 +161,12 @@ describe("crawl CLI integration", () => {
 			const outputDir = `${TEST_OUTPUT_DIR}/output-no-pages`;
 
 			try {
-				execSync(
-					`bun run src/crawl.ts "https://example.com" -d 0 -o "${outputDir}" --no-pages`,
-					{
-						encoding: "utf-8",
-						cwd: process.cwd(),
-						stdio: "pipe",
-						timeout: 30000,
-					},
-				);
+				execSync(`bun run src/crawl.ts "https://example.com" -d 0 -o "${outputDir}" --no-pages`, {
+					encoding: "utf-8",
+					cwd: process.cwd(),
+					stdio: "pipe",
+					timeout: 30000,
+				});
 
 				// index.json and full.md should be generated
 				expect(existsSync(join(outputDir, "index.json"))).toBe(true);
@@ -192,15 +189,12 @@ describe("crawl CLI integration", () => {
 			const outputDir = `${TEST_OUTPUT_DIR}/output-no-merge`;
 
 			try {
-				execSync(
-					`bun run src/crawl.ts "https://example.com" -d 0 -o "${outputDir}" --no-merge`,
-					{
-						encoding: "utf-8",
-						cwd: process.cwd(),
-						stdio: "pipe",
-						timeout: 30000,
-					},
-				);
+				execSync(`bun run src/crawl.ts "https://example.com" -d 0 -o "${outputDir}" --no-merge`, {
+					encoding: "utf-8",
+					cwd: process.cwd(),
+					stdio: "pipe",
+					timeout: 30000,
+				});
 
 				// index.json and pages/ should be generated
 				expect(existsSync(join(outputDir, "index.json"))).toBe(true);


### PR DESCRIPTION
## 概要

Biome の lint/format エラー2件を修正しました。

## 変更内容

### 1. Import order 修正
- `readFileSync` と `readdirSync` の順序をアルファベット順に修正

### 2. Formatting 修正  
- `execSync()` 呼び出しのフォーマットを修正（2箇所）
- 第1引数を関数呼び出しと同じ行に配置

## 検証結果

- ✅ `bun run check`: エラー0件
- ✅ `bun run typecheck`: エラー0件
- ✅ `bun run test`: 822/822 パス

## 影響範囲

- テストファイルのみ（実装コードへの影響なし）
- フォーマット修正のみ（ロジック変更なし）

Closes #964