### PR TITLE
docs: add missing type definitions to design.md

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -267,6 +267,26 @@ interface CrawlConfig {
   version: string;
 }
 
+/** フェッチ結果 */
+interface FetchResult {
+  html: string;
+  finalUrl: string;
+  contentType: string;
+}
+
+/** Fetcher インターフェース */
+interface Fetcher {
+  fetch(url: string): Promise<FetchResult | null>;
+  close?(): Promise<void>;
+}
+
+/** ロガーインターフェース（output モジュールが依存） */
+interface Logger {
+  logIndexFormatError(path: string): void;
+  logIndexLoadError(error: string): void;
+  logDebug(message: string, data?: unknown): void;
+}
+
 /** ページメタデータ */
 interface PageMetadata {
   title: string | null;


### PR DESCRIPTION
## Summary

Add missing type definitions (FetchResult, Fetcher, Logger) to section 5.1 of design.md.

## Changes

- Added `FetchResult` interface (fetch result structure)
- Added `Fetcher` interface (page fetching abstraction)
- Added `Logger` interface (logging methods for output module)

## Motivation

These interfaces exist in `link-crawler/src/types.ts` and are referenced in section 3.3 (モジュール責務) but were missing from the type definitions section.

## Verification

✅ All 8 interfaces from types.ts are now documented in design.md  
✅ Type definitions match exactly with implementation  
✅ Logical placement: after CrawlConfig, before PageMetadata  

Closes #976