### PR TITLE
fix: skip postProcessor in cleanup() for non-diff mode

### DIFF
--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -158,19 +158,20 @@ export class Crawler {
 				this.writer.setVisitedUrls(this.visited);
 				const indexPath = this.writer.saveIndex();
 				this.logger.logDebug("Saved partial index", { path: indexPath });
-			}
 
-			// 2. 途中結果からfull.md/chunksを生成（ベストエフォート）
-			try {
-				const result = this.writer.getResult();
-				if (result.pages.length > 0) {
-					this.postProcessor.process(result.pages, this.pageContents);
-					this.logger.logDebug("Generated partial outputs during cleanup");
+				// 2. 途中結果からfull.md/chunksを生成（ベストエフォート、diffモード時のみ）
+				// 非diffモードでは一時ディレクトリごと削除されるため不要
+				try {
+					const result = this.writer.getResult();
+					if (result.pages.length > 0) {
+						this.postProcessor.process(result.pages, this.pageContents);
+						this.logger.logDebug("Generated partial outputs during cleanup");
+					}
+				} catch (error) {
+					this.logger.logDebug("Failed to generate partial outputs (non-fatal)", {
+						error: String(error),
+					});
 				}
-			} catch (error) {
-				this.logger.logDebug("Failed to generate partial outputs (non-fatal)", {
-					error: String(error),
-				});
 			}
 
 			// 3. メモリ解放


### PR DESCRIPTION
## Summary

Fixes unnecessary postProcessor execution in cleanup() method for non-diff mode.

## Problem

In non-diff mode, cleanup() was executing postProcessor.process() to generate full.md/chunks, but these files are immediately deleted by writer.cleanup() because non-diff mode uses temporary directories.

This resulted in wasteful I/O operations.

## Solution

Moved the postProcessor.process() call inside the existing diff mode conditional block. Now:

- **Diff mode**: postProcessor runs (needed to save partial results to persistent output)
- **Non-diff mode**: postProcessor is skipped (output would be deleted anyway)

## Changes

- `link-crawler/src/crawler/index.ts`: Wrapped postProcessor call in diff mode check
- Added explanatory comments

## Testing

- All existing tests pass
- Cleanup-related tests verify correct behavior

Closes #975