### PR TITLE
docs: add cwd() to RuntimeAdapter interface in design.md

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -467,6 +467,7 @@ interface RuntimeAdapter {
   spawn(command: string, args: string[]): Promise<SpawnResult>;
   sleep(ms: number): Promise<void>;
   readFile(path: string): Promise<string>;
+  cwd(): string;
 }
 ```
 


### PR DESCRIPTION
## 概要

設計書 (`docs/design.md`) の `RuntimeAdapter` インターフェース定義に `cwd(): string` メソッドを追加し、実装 (`src/utils/runtime.ts`) と一致させました。

## 変更内容

- `docs/design.md` セクション 6.2 の `RuntimeAdapter` インターフェースに `cwd(): string` を追加

## 検証

```bash
# 設計書と実装のインターフェースが一致していることを確認
grep -A 5 "interface RuntimeAdapter" docs/design.md
grep -A 10 "interface RuntimeAdapter" link-crawler/src/utils/runtime.ts
```

Closes #988