### PR TITLE
docs: SKILL.md の参照リンクを相対パスに統一

### DIFF
--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -54,7 +54,7 @@ bun run src/crawl.ts <url> [options]
 - `--exclude <pattern>`: 除外するURLパターン（正規表現）
 - `--no-robots`: robots.txt を無視（非推奨、開発・テスト用）
 
-**完全なオプション一覧は [CLI仕様書](https://github.com/takemo101/dict-skills/blob/main/docs/cli-spec.md) を参照してください。**
+**完全なオプション一覧は [CLI仕様書](../docs/cli-spec.md) を参照してください。**
 
 ## piエージェントでの使用例
 
@@ -77,11 +77,11 @@ bun run src/crawl.ts https://nextjs.org/docs -d 2
 | `specs/*.yaml` | API仕様ファイル（検出時のみ） |
 | `index.json` | メタデータ・ハッシュ |
 
-**詳細な仕様は [CLI仕様書](https://github.com/takemo101/dict-skills/blob/main/docs/cli-spec.md) を参照してください。**
+**詳細な仕様は [CLI仕様書](../docs/cli-spec.md) を参照してください。**
 
 ## 参考リンク
 
 | ドキュメント | 内容 |
 |-------------|------|
-| [CLI仕様書](https://github.com/takemo101/dict-skills/blob/main/docs/cli-spec.md) | 完全なオプション一覧・使用例・出力形式の詳細 |
-| [設計書](https://github.com/takemo101/dict-skills/blob/main/docs/design.md) | アーキテクチャ・データ構造・技術仕様 |
+| [CLI仕様書](../docs/cli-spec.md) | 完全なオプション一覧・使用例・出力形式の詳細 |
+| [設計書](../docs/design.md) | アーキテクチャ・データ構造・技術仕様 |


### PR DESCRIPTION
## 概要

link-crawler/SKILL.md 内のドキュメントリンクを GitHub 絶対URL から相対パスに変更しました。

## 変更内容

- CLI仕様書と設計書のリンクを相対パスに変更（4箇所）
- Before: `https://github.com/takemo101/dict-skills/blob/main/docs/cli-spec.md`
- After: `../docs/cli-spec.md`

## 理由

pi エージェントが SKILL.md を読み込む際、GitHub URL リンクはブラウザで開く必要があり直接参照できません。相対パスに変更することで、read ツールで直接リンク先のドキュメントを読み込めるようになります。

## 検証

```bash
cd link-crawler
cat ../docs/cli-spec.md | head -3
cat ../docs/design.md | head -3
```

両ファイルが正常に読み込めることを確認しました。

Closes #986