### PR TITLE
docs: fix SKILL.md link format to match development.md description

### DIFF
--- a/link-crawler/SKILL.md
+++ b/link-crawler/SKILL.md
@@ -54,7 +54,7 @@ bun run src/crawl.ts <url> [options]
 - `--exclude <pattern>`: 除外するURLパターン（正規表現）
 - `--no-robots`: robots.txt を無視（非推奨、開発・テスト用）
 
-**完全なオプション一覧は [CLI仕様書](../docs/cli-spec.md) を参照してください。**
+**完全なオプション一覧は [CLI仕様書](https://github.com/takemo101/dict-skills/blob/main/docs/cli-spec.md) を参照してください。**
 
 ## piエージェントでの使用例
 
@@ -77,11 +77,11 @@ bun run src/crawl.ts https://nextjs.org/docs -d 2
 | `specs/*.yaml` | API仕様ファイル（検出時のみ） |
 | `index.json` | メタデータ・ハッシュ |
 
-**詳細な仕様は [CLI仕様書](../docs/cli-spec.md) を参照してください。**
+**詳細な仕様は [CLI仕様書](https://github.com/takemo101/dict-skills/blob/main/docs/cli-spec.md) を参照してください。**
 
 ## 参考リンク
 
 | ドキュメント | 内容 |
 |-------------|------|
-| [CLI仕様書](../docs/cli-spec.md) | 完全なオプション一覧・使用例・出力形式の詳細 |
-| [設計書](../docs/design.md) | アーキテクチャ・データ構造・技術仕様 |
+| [CLI仕様書](https://github.com/takemo101/dict-skills/blob/main/docs/cli-spec.md) | 完全なオプション一覧・使用例・出力形式の詳細 |
+| [設計書](https://github.com/takemo101/dict-skills/blob/main/docs/design.md) | アーキテクチャ・データ構造・技術仕様 |


### PR DESCRIPTION
## Summary

Fixes #993

## Changes

- Changed 4 relative path links () in  to GitHub absolute URLs
- Links now match the format used in 
- Aligns with  section 10.2 description

## Modified Files

- `link-crawler/SKILL.md`: Updated 4 documentation links (lines 57, 80, 86, 87)

## Verification

```bash
# No relative paths remaining
grep -n "../docs/" link-crawler/SKILL.md
# (no output)

# 4 GitHub absolute URLs added
grep -c "github.com/takemo101/dict-skills/blob/main/docs/" link-crawler/SKILL.md
# 4
```

## Benefits

- ✅ Links will work after npm publish
- ✅ Consistent with README.md link format
- ✅ development.md description now matches reality

## Testing

No tests required (documentation-only change)

Closes #993