### PR TITLE
refactor: OutputWriter.finalize() のレースコンディション対策強化

### DIFF
--- a/link-crawler/src/output/writer.ts
+++ b/link-crawler/src/output/writer.ts
@@ -284,9 +284,16 @@ export class OutputWriter {
 			throw error; // 元のエラーを再スロー
 		}
 
-		// 成功時: バックアップ削除
+		// 成功時: バックアップ削除（失敗しても無視）
 		if (existsSync(backupDir)) {
-			rmSync(backupDir, { recursive: true, force: true });
+			try {
+				rmSync(backupDir, { recursive: true, force: true });
+			} catch (error) {
+				this.logger?.logDebug("Failed to remove backup (non-fatal)", {
+					backupDir,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
 		}
 
 		this.logger?.logDebug("Output finalized successfully");


### PR DESCRIPTION
## 概要

プロジェクトレビューで発見されたアーキテクチャ上の潜在的問題を修正。

## 変更内容

### OutputWriter.finalize() の原子性改善

**問題**:
- finalize() メソッドの Step 3（バックアップ削除）が失敗した場合、例外が呼び出し元に伝播し、クロール全体が失敗扱いになる
- 実際にはクロール自体は成功しており、.bak が残るだけで実害はない

**修正内容**:
- バックアップ削除を try-catch で囲み、失敗時はデバッグログに記録
- 非致命的エラーとして処理し、クロール全体は成功として扱う

## テスト結果

```
✓ tests/unit/writer.test.ts (65 tests) 53ms
```

全 65 件のテストがパス。既存の finalize() エラーリカバリテストも含む。

## 影響範囲

- `link-crawler/src/output/writer.ts` の `finalize()` メソッドのみ
- 既存の動作に影響なし（エラーケースの扱いのみ改善）

Closes #996