### PR TITLE
docs: add README.md index for docs/verification/ directory

### DIFF
--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -1,0 +1,12 @@
+# 検証ログ
+
+Issue対応の検証結果を記録する。
+
+## 記録一覧
+
+| Issue | タイトル | 状態 |
+|-------|---------|------|
+| [#681](issue-681-coverage-verification.md) | カバレッジファイルの Git 追跡状態 | 完了 |
+| [#826](issue-826-coverage-gitignore-verification.md) | coverage/ .gitignore 設定検証 | 完了 |
+| [#917](issue-917-coverage-verification.md) | coverage/ ディレクトリ追跡確認 | 完了 |
+| [#966](issue-966-verification.md) | coverage/ をバージョン管理から除外 | 完了 |


### PR DESCRIPTION
## Summary

Creates an index file for the `docs/verification/` directory to improve discoverability and maintain consistency with other documentation directories.

## Changes

- ✨ Create `docs/verification/README.md` with a table of all verification logs
- 📝 List all 4 existing verification files (#681, #826, #917, #966)
- 🎨 Follow same format as `docs/decisions/README.md` for consistency

## Testing

- ✅ File existence verified
- ✅ All links validated
- ✅ Format checked and consistent

## Related Issue

Closes #1005