### PR TITLE
docs: add 005 entry to decisions/README.md

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -16,6 +16,7 @@ NNN-問題名.md
 | [002](002-issue-854-duplicate.md) | Issue #854 is Duplicate of #848 | 解決済み |
 | [003](003-issue-946-duplicate.md) | Issue #946 は PR #944 で解決済み | 解決済み |
 | [004](004-issue-965-duplicate.md) | Issue #965 は Issue #961 と重複 | 解決済み |
+| [005](005-issue-581-unreachable-code.md) | extractor.ts ブランチカバレッジ改善 | 解決済み |
 
 ## 記録すべき内容
 


### PR DESCRIPTION
Closes #1003

## Changes
- Added entry 005 (extractor.ts ブランチカバレッジ改善) to docs/decisions/README.md

## Review
- ✅ Follows existing table format
- ✅ Links to correct file (005-issue-581-unreachable-code.md)
- ✅ Status marked as 解決済み (resolved)

## Testing
- Verified file exists
- Verified entry is correctly formatted