### PR TITLE
docs: clarify AGENTS.md constraint table scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,12 @@
 | デフォルトセッション使用 | playwright-cli 0.0.63+ の仕様変更 | [001](docs/decisions/001-playwright-cli-session.md) |
 | 並列クロール不可 | 上記の制約による | [001](docs/decisions/001-playwright-cli-session.md) |
 
-<!-- エージェントが重要な知見を発見した際、上の表に1行追加し、docs/decisions/ に詳細を記録する -->
+<!-- 
+  ⚠️ このテーブルには「現在有効な制約・注意点」のみを記載
+  - エージェントが重要な知見を発見した際、上の表に1行追加し、docs/decisions/ に詳細を記録する
+  - 解決済み・不要になった項目は削除する（docs/decisions/ には履歴として残す）
+  - 全ての意思決定ログ（解決済み含む）は docs/decisions/README.md を参照
+-->
 
 ## 設計方針
 
@@ -29,4 +34,5 @@
 
 - [docs/design.md](docs/design.md) - 詳細設計
 - [docs/cli-spec.md](docs/cli-spec.md) - CLIオプション
-- [docs/decisions/](docs/decisions/) - 意思決定ログ
+- [docs/decisions/README.md](docs/decisions/README.md) - 意思決定ログ一覧（解決済み含む）
+- [docs/decisions/](docs/decisions/) - 個別の意思決定ログ


### PR DESCRIPTION
## 概要

AGENTS.md の既知の制約テーブルのスコープを明確化し、解決済み decision の扱いについてガイドラインを追加。

## 背景

Issue #1006 で指摘された decision 005 (extractor.ts カバレッジ改善) が AGENTS.md に未記載である件について調査・対応。

### 調査結果

- **Decision 005 の状態**: 解決済み（ブランチカバレッジ 95.83% 達成）
- **グローバル AGENTS.md ガイドライン**: 「解決済み・不要になった項目は AGENTS.md から削除」
- **Issue 本文の記載**: 「decision 005 は『解決済み』なので、AGENTS.md に記載しないのは正しい」

### 結論

Decision 005 を AGENTS.md の制約テーブルに追加**しない**ことが正しい対応。

## 変更内容

### 1. 制約テーブルのコメント拡充

- テーブルには「現在有効な制約・注意点」のみを記載することを明示
- 解決済み項目の扱いを明確化（削除してよい、docs/decisions/ には履歴として残す）
- decisions/README.md への参照を追加

### 2. 関連ドキュメントセクション強化

- `docs/decisions/README.md` への明示的なリンクを追加
- 「解決済み含む」という注釈を追加し、完全なログへの誘導を明確化

## 影響

- **Decision 005**: 引き続き AGENTS.md の制約テーブルには記載されない（正しい）
- **発見性**: decisions/README.md で管理（Issue #1003 で 005 を追加予定）
- **将来のコントリビューター**: ガイドラインが明確になり、誤って解決済み decision を追加するリスクが低減

## 関連 Issue

- Closes #1006
- Related: #1003 (decisions/README.md への 005 追加)

## テスト

```bash
# Decision 005 が AGENTS.md の制約テーブルに無いことを確認（正常）
! grep -q "005" AGENTS.md

# Decision 005 ファイルが存在することを確認
test -f docs/decisions/005-issue-581-unreachable-code.md

# decisions/README.md への参照が追加されたことを確認
grep -q "decisions/README.md" AGENTS.md
```

## レビューポイント

- グローバル AGENTS.md ガイドラインに準拠しているか
- コメントの説明は明確か
- decisions/README.md への参照は適切か