### PR TITLE
fix: Biome format error in crawl-cli.test.ts

### DIFF
--- a/link-crawler/tests/integration/crawl-cli.test.ts
+++ b/link-crawler/tests/integration/crawl-cli.test.ts
@@ -132,7 +132,11 @@ describe("crawl CLI integration", () => {
 		});
 
 		it("should reject invalid URL schemes", () => {
-			const invalidSchemes = ["mailto:test@example.com", "javascript:alert(1)", "data:text/plain,test"];
+			const invalidSchemes = [
+				"mailto:test@example.com",
+				"javascript:alert(1)",
+				"data:text/plain,test",
+			];
 
 			for (const url of invalidSchemes) {
 				try {


### PR DESCRIPTION
## Summary

Fixed Biome format violation in `link-crawler/tests/integration/crawl-cli.test.ts` line 135.

## Changes

- Split `invalidSchemes` array literal into multiple lines
- Complies with Biome's `lineWidth: 100` setting
- No logic changes, formatting only

## Verification

```bash
cd link-crawler && bun run check
# ✅ Checked 54 files in 38ms. No fixes applied.
```

Closes #1002