### PR TITLE
refactor: add .playwright-cli/ to link-crawler/.gitignore

### DIFF
--- a/link-crawler/.gitignore
+++ b/link-crawler/.gitignore
@@ -9,3 +9,4 @@ coverage/
 test-output*/
 .test-output*/
 .test-*/
+.playwright-cli/


### PR DESCRIPTION
## 概要

`.playwright-cli/` セッションファイルがリポジトリに誤ってコミットされないよう、`link-crawler/.gitignore` に明示的な除外ルールを追加しました。

## 変更内容

- `link-crawler/.gitignore` に `.playwright-cli/` を追加
- ルート `.gitignore` の補完として機能
- サブディレクトリで作業する開発者のための明示的なルール

## 検証

```bash
# .gitignore に含まれていることを確認
$ grep ".playwright-cli/" link-crawler/.gitignore
.playwright-cli/

# Gitトラッキングされていないことを確認
$ git ls-files link-crawler/.playwright-cli/
# (出力なし - 正常)
```

## 影響

- コード変更なし
- 既存のワークフローに影響なし
- 将来的な誤コミットを防止

Closes #1018