### PR TITLE
fix: update full.md assertion to match actual format

### DIFF
--- a/link-crawler/tests/integration/crawl-cli.test.ts
+++ b/link-crawler/tests/integration/crawl-cli.test.ts
@@ -251,7 +251,7 @@ describe("crawl CLI integration", () => {
 
 			const fullContent = readFileSync(join(outputDir, "full.md"), "utf-8");
 			expect(fullContent).toContain("# ");
-			expect(fullContent).toContain("url: https://example.com");
+			expect(fullContent).toContain("> Source: https://example.com");
 		});
 
 		it("should have valid pages directory content", () => {


### PR DESCRIPTION
## Summary

Fixed test assertion in `crawl-cli.test.ts` to match the actual output format from `Merger.buildFullContent()`.

## Changes

- Updated line 254 in `link-crawler/tests/integration/crawl-cli.test.ts`
- Changed from frontmatter format `url: https://example.com` to quote format `> Source: https://example.com`

## Testing

- All 856 tests pass ✅
- Integration tests specifically verified (15/15)

## Related

Closes #1014