### PR TITLE
docs: fix RuntimeAdapter interface definition in design.md (#1028)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -464,9 +464,25 @@ H1見出し（`#`）を境界として分割:
 **RuntimeAdapterインターフェース：**
 ```typescript
 interface RuntimeAdapter {
-  spawn(command: string, args: string[]): Promise<SpawnResult>;
+  /**
+   * コマンドを実行して結果を返す
+   * @param cwd 作業ディレクトリ（省略時はprocess.cwd()）
+   */
+  spawn(command: string, args: string[], cwd?: string): Promise<SpawnResult>;
+  
+  /**
+   * 指定時間スリープする
+   */
   sleep(ms: number): Promise<void>;
+  
+  /**
+   * ファイルを読み込む
+   */
   readFile(path: string): Promise<string>;
+  
+  /**
+   * カレントワーキングディレクトリを取得する
+   */
   cwd(): string;
 }
 ```


### PR DESCRIPTION
## 概要

`docs/design.md` のセクション6.2に記載されている `RuntimeAdapter` インターフェース定義を、実際の実装（`link-crawler/src/utils/runtime.ts`）と一致させました。

## 変更内容

- `spawn()` メソッドにオプショナルパラメータ `cwd?: string` を追加
- 全メソッドにJSDocコメントを追加（実装と同じ内容）
- インターフェース定義の可読性を向上

## 影響範囲

- ドキュメントのみの変更
- コード実装への影響なし

Closes #1028