### PR TITLE
fix: Crawler.cleanup() が attemptedCount をリセットし maxPages 制限を無効化する

### DIFF
--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -162,7 +162,8 @@ export class Crawler {
 
 	/** クリーンアップ: ステップ0 - 内部状態のクリア */
 	private clearInternalState(): void {
-		this.attemptedCount = 0;
+		// Note: attemptedCount は maxPages 制限の判定に使用されるため、
+		// cleanup 時にリセットしない（cleanup後の意図しない処理継続を防ぐ）
 		this.failedUrls.clear();
 	}
 


### PR DESCRIPTION
## 概要

`Crawler.cleanup()` 内の `clearInternalState()` が `attemptedCount` をリセットしていた問題を修正しました。このカウンタは `maxPages` 制限の判定に使用されており、cleanup後に処理が継続した場合に制限が無効化される可能性がありました。

## 変更内容

- `clearInternalState()` から `this.attemptedCount = 0` を削除
- cleanup時に `attemptedCount` をリセットしない理由をコメントで説明

## テスト結果

- 全ての関連テスト（maxPages limit, cleanup method）が成功
- 855/856 テストが成功（1つの失敗は無関係なCLI出力フォーマットテスト）

## 影響

- 現時点での実害は低い（cleanup後は通常exit）
- 将来的な変更で問題が顕在化するリスクを事前に除去
- コードの意図が明確になる

Closes #1026