### PR TITLE
fix: ビルド出力のshebangをNode.js互換に修正

### DIFF
--- a/link-crawler/package.json
+++ b/link-crawler/package.json
@@ -25,6 +25,7 @@
 	"scripts": {
 		"dev": "bun run src/crawl.ts",
 		"build": "bun build src/crawl.ts --outdir dist --target node",
+		"postbuild": "node scripts/fix-shebang.js",
 		"check": "biome check .",
 		"lint": "biome check .",
 		"fix": "biome check --write .",

--- a/link-crawler/scripts/fix-shebang.js
+++ b/link-crawler/scripts/fix-shebang.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const distPath = join(__dirname, '../dist/crawl.js');
+
+try {
+  let content = readFileSync(distPath, 'utf-8');
+  
+  // #!/usr/bin/env bun を #!/usr/bin/env node に置換
+  content = content.replace(/^#!\/usr\/bin\/env bun/, '#!/usr/bin/env node');
+  
+  // @bun コメントを削除
+  content = content.replace(/^\/\/ @bun\n/m, '');
+  
+  writeFileSync(distPath, content, 'utf-8');
+  console.log('✅ Shebang fixed: #!/usr/bin/env node');
+} catch (error) {
+  console.error('❌ Failed to fix shebang:', error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
Closes #1034

## Changes
- postbuildスクリプトで `#!/usr/bin/env bun` を `#!/usr/bin/env node` に置換
- npm install -g でBun未インストール環境でも動作するように対応
- Node.jsとBun両方で動作確認済み

## Testing
- 全テスト (857件) がパス
- Node.js環境での実行確認完了
- Bun環境での実行確認完了
- ビルド出力のshebangが正しく置換されることを確認