### PR TITLE
fix: add upper bound validation for CLI numeric options

### DIFF
--- a/link-crawler/src/config.ts
+++ b/link-crawler/src/config.ts
@@ -80,18 +80,27 @@ export function parseConfig(
 		sameDomain: options.sameDomain !== false,
 		includePattern: parsePattern(options.include as string | undefined, "include"),
 		excludePattern: parsePattern(options.exclude as string | undefined, "exclude"),
-		delay: Math.max(
-			0,
-			Number.isNaN(Number(options.delay)) ? DEFAULTS.DELAY_MS : Number(options.delay),
+		delay: Math.min(
+			DEFAULTS.MAX_DELAY_MS,
+			Math.max(
+				0,
+				Number.isNaN(Number(options.delay)) ? DEFAULTS.DELAY_MS : Number(options.delay),
+			),
 		),
 		timeout:
-			Math.max(
-				1,
-				Number.isNaN(Number(options.timeout)) ? DEFAULTS.TIMEOUT_SEC : Number(options.timeout),
+			Math.min(
+				DEFAULTS.MAX_TIMEOUT_SEC,
+				Math.max(
+					1,
+					Number.isNaN(Number(options.timeout)) ? DEFAULTS.TIMEOUT_SEC : Number(options.timeout),
+				),
 			) * 1000,
-		spaWait: Math.max(
-			0,
-			Number.isNaN(Number(options.wait)) ? DEFAULTS.SPA_WAIT_MS : Number(options.wait),
+		spaWait: Math.min(
+			DEFAULTS.MAX_SPA_WAIT_MS,
+			Math.max(
+				0,
+				Number.isNaN(Number(options.wait)) ? DEFAULTS.SPA_WAIT_MS : Number(options.wait),
+			),
 		),
 		headed: Boolean(options.headed),
 		diff: Boolean(options.diff),

--- a/link-crawler/src/constants.ts
+++ b/link-crawler/src/constants.ts
@@ -10,10 +10,16 @@ export const DEFAULTS = {
 	OUTPUT_DIR: "./.context",
 	/** リクエスト間の遅延(ms) */
 	DELAY_MS: 500,
+	/** リクエスト間の遅延の上限(ms) */
+	MAX_DELAY_MS: 60000,
 	/** デフォルトタイムアウト(秒) */
 	TIMEOUT_SEC: 30,
+	/** タイムアウト上限(秒) */
+	MAX_TIMEOUT_SEC: 300,
 	/** SPAページ待機時間(ms) */
 	SPA_WAIT_MS: 2000,
+	/** SPAページ待機時間の上限(ms) */
+	MAX_SPA_WAIT_MS: 30000,
 } as const;
 
 /** ファイル名・プレフィックス */

--- a/link-crawler/tests/unit/config.test.ts
+++ b/link-crawler/tests/unit/config.test.ts
@@ -682,3 +682,68 @@ describe("parseConfig - respectRobots validation", () => {
 		expect(config.respectRobots).toBe(true);
 	});
 });
+
+describe("parseConfig - upper bound validation", () => {
+	it("should cap delay at MAX_DELAY_MS (60000ms)", () => {
+		const config = parseConfig({ delay: 999999 }, "https://example.com", "test-version");
+		expect(config.delay).toBe(60000);
+	});
+
+	it("should cap timeout at MAX_TIMEOUT_SEC (300 seconds = 300000ms)", () => {
+		const config = parseConfig({ timeout: 999999 }, "https://example.com", "test-version");
+		expect(config.timeout).toBe(300000);
+	});
+
+	it("should cap spaWait at MAX_SPA_WAIT_MS (30000ms)", () => {
+		const config = parseConfig({ wait: 999999 }, "https://example.com", "test-version");
+		expect(config.spaWait).toBe(30000);
+	});
+
+	it("should allow values below upper bounds", () => {
+		const config = parseConfig(
+			{
+				delay: 1000,
+				timeout: 60,
+				wait: 5000,
+			},
+			"https://example.com",
+			"test-version",
+		);
+
+		expect(config.delay).toBe(1000);
+		expect(config.timeout).toBe(60000);
+		expect(config.spaWait).toBe(5000);
+	});
+
+	it("should handle exact upper bound values", () => {
+		const config = parseConfig(
+			{
+				delay: 60000,
+				timeout: 300,
+				wait: 30000,
+			},
+			"https://example.com",
+			"test-version",
+		);
+
+		expect(config.delay).toBe(60000);
+		expect(config.timeout).toBe(300000);
+		expect(config.spaWait).toBe(30000);
+	});
+
+	it("should cap string values that exceed upper bounds", () => {
+		const config = parseConfig(
+			{
+				delay: "999999",
+				timeout: "999999",
+				wait: "999999",
+			},
+			"https://example.com",
+			"test-version",
+		);
+
+		expect(config.delay).toBe(60000);
+		expect(config.timeout).toBe(300000);
+		expect(config.spaWait).toBe(30000);
+	});
+});


### PR DESCRIPTION
## Summary

Adds upper bound validation for CLI numeric options (--delay, --timeout, --wait) to prevent user input errors from causing crawler hangs.

## Changes

### Constants Added (constants.ts)
- `MAX_DELAY_MS: 60000` (60 seconds)
- `MAX_TIMEOUT_SEC: 300` (5 minutes)
- `MAX_SPA_WAIT_MS: 30000` (30 seconds)

### Implementation (config.ts)
Applied `Math.min()` clamping for:
- `delay` option
- `timeout` option
- `spaWait` option

Pattern: `Math.min(MAX_VALUE, Math.max(MIN_VALUE, input))`

### Tests (config.test.ts)
Added 6 test cases covering:
- Upper bound clamping for extreme values
- Values below upper bounds
- Exact upper bound values
- String values exceeding bounds

## Testing

✅ All 863 tests pass
✅ Upper bound validation working correctly
✅ No regressions in existing functionality

## Related

Closes #1036

---

**Implementation Plan:** [docs/plans/issue-1036-plan.md](../blob/feature/issue-1036-fix-cli-delay-timeout-wait/docs/plans/issue-1036-plan.md)