### PR TITLE
refactor: replace console.log with CrawlLogger in PlaywrightFetcher

### DIFF
--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -55,7 +55,10 @@ export class Crawler {
 		if (fetcher) {
 			this.fetcher = fetcher;
 		} else {
-			this.fetcherPromise = createPlaywrightFetcher(config);
+			this.fetcherPromise = createPlaywrightFetcher(
+				config,
+				(msg, data) => this.logger.logDebug(msg, data),
+			);
 		}
 	}
 
@@ -467,9 +470,11 @@ export class Crawler {
 }
 
 /** PlaywrightFetcherのファクトリ関数（動的インポート） */
-async function createPlaywrightFetcher(config: CrawlConfig): Promise<Fetcher> {
+async function createPlaywrightFetcher(
+	config: CrawlConfig,
+	logDebug?: (message: string, data?: unknown) => void,
+): Promise<Fetcher> {
 	// 動的インポートを使用してBun依存のモジュールを遅延ロード
 	const mod = await import("./fetcher.js");
-	const debug = process.env.DEBUG === "1";
-	return new mod.PlaywrightFetcher(config, undefined, undefined, debug);
+	return new mod.PlaywrightFetcher(config, undefined, undefined, logDebug);
 }


### PR DESCRIPTION
## 概要

PlaywrightFetcher クラス内で直接使用していた console.log を、CrawlLogger の logDebug メソッドに統一しました。

## 変更内容

### 1. PlaywrightFetcher のリファクタリング (fetcher.ts)

- `debug` boolean フラグを削除
- `logDebug` コールバック関数を注入可能に変更
- 4箇所の `console.log` を `logDebug?.()` に置き換え

### 2. Crawler の修正 (index.ts)

- `createPlaywrightFetcher` 関数に `logDebug` パラメータを追加
- Crawler から `logger.logDebug` を PlaywrightFetcher に注入

## メリット

1. **ログ出力の統一**: 全てのデバッグログが CrawlLogger を経由し、タイムスタンプ付きで出力される
2. **テストの容易性**: ログ出力をモックで制御可能
3. **将来の拡張性**: 外部ロギングサービス（Sentry、CloudWatch等）への統合が容易
4. **抽象化の一貫性**: プロジェクト全体でロギング抽象化が統一される

## テスト結果

✅ 857/857 tests passed

## 検証

```bash
# console.log が残っていないことを確認
$ grep -n "console\.log" link-crawler/src/crawler/fetcher.ts
# 該当なし

# テスト実行
$ cd link-crawler && bun run test
# 857 tests passed
```

Closes #1035