### PR TITLE
fix: Biome フォーマットエラーの修正

### DIFF
--- a/link-crawler/src/config.ts
+++ b/link-crawler/src/config.ts
@@ -82,10 +82,7 @@ export function parseConfig(
 		excludePattern: parsePattern(options.exclude as string | undefined, "exclude"),
 		delay: Math.min(
 			DEFAULTS.MAX_DELAY_MS,
-			Math.max(
-				0,
-				Number.isNaN(Number(options.delay)) ? DEFAULTS.DELAY_MS : Number(options.delay),
-			),
+			Math.max(0, Number.isNaN(Number(options.delay)) ? DEFAULTS.DELAY_MS : Number(options.delay)),
 		),
 		timeout:
 			Math.min(
@@ -97,10 +94,7 @@ export function parseConfig(
 			) * 1000,
 		spaWait: Math.min(
 			DEFAULTS.MAX_SPA_WAIT_MS,
-			Math.max(
-				0,
-				Number.isNaN(Number(options.wait)) ? DEFAULTS.SPA_WAIT_MS : Number(options.wait),
-			),
+			Math.max(0, Number.isNaN(Number(options.wait)) ? DEFAULTS.SPA_WAIT_MS : Number(options.wait)),
 		),
 		headed: Boolean(options.headed),
 		diff: Boolean(options.diff),

--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -55,9 +55,8 @@ export class Crawler {
 		if (fetcher) {
 			this.fetcher = fetcher;
 		} else {
-			this.fetcherPromise = createPlaywrightFetcher(
-				config,
-				(msg, data) => this.logger.logDebug(msg, data),
+			this.fetcherPromise = createPlaywrightFetcher(config, (msg, data) =>
+				this.logger.logDebug(msg, data),
 			);
 		}
 	}


### PR DESCRIPTION
## 概要

Biomeフォーマッターが検出した3箇所のコードスタイル違反を修正しました。

## 変更内容

- **config.ts**: `Math.max()` の引数を1行にフォーマット (L85-88, L100-103)
- **crawler/index.ts**: `createPlaywrightFetcher()` の引数改行位置を修正 (L58-60)

## 検証

- ✅ `biome check .` がエラー0件でパス
- ✅ 全テストがパス (863 tests)
- ✅ フォーマットのみの変更でロジック変更なし

Closes #1044