### PR TITLE
refactor: ハードコードされたファイル名/ディレクトリ名を FILENAME 定数に統一

### DIFF
--- a/link-crawler/src/crawler/post-processor.ts
+++ b/link-crawler/src/crawler/post-processor.ts
@@ -1,5 +1,6 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { FILENAME } from "../constants.js";
 import { Chunker } from "../output/chunker.js";
 import { Merger } from "../output/merger.js";
 import type { CrawlConfig, CrawledPage } from "../types.js";
@@ -53,7 +54,7 @@ export class PostProcessor {
 		// Merger出力 (full.md書き込み)
 		if (this.config.merge && fullMdContent) {
 			this.logger.logMergerStart();
-			const outputPath = join(this.outputDir, "full.md");
+			const outputPath = join(this.outputDir, FILENAME.FULL_MD);
 			writeFileSync(outputPath, fullMdContent);
 			this.logger.logMergerComplete(outputPath);
 		}

--- a/link-crawler/src/output/chunker.ts
+++ b/link-crawler/src/output/chunker.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { FILENAME } from "../constants.js";
 
 /**
  * Markdownチャンク分割クラス
@@ -92,7 +93,7 @@ export class Chunker {
 		}
 
 		// chunksディレクトリ作成（古いチャンクを削除してから）
-		const chunksDir = join(this.outputDir, "chunks");
+		const chunksDir = join(this.outputDir, FILENAME.CHUNKS_DIR);
 		if (existsSync(chunksDir)) {
 			rmSync(chunksDir, { recursive: true, force: true });
 		}

--- a/link-crawler/src/output/index-manager.ts
+++ b/link-crawler/src/output/index-manager.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { FILENAME } from "../constants.js";
 import type { CrawledPage, CrawlResult, Logger, PageMetadata } from "../types.js";
 
 /**
@@ -56,7 +57,7 @@ export class IndexManager {
 	 * 既存のindex.jsonを読み込む
 	 */
 	private loadExistingIndex(): void {
-		const indexPath = join(this.outputDir, "index.json");
+		const indexPath = join(this.outputDir, FILENAME.INDEX_JSON);
 		if (!existsSync(indexPath)) {
 			return;
 		}
@@ -201,7 +202,7 @@ export class IndexManager {
 		// totalPages を pages.length から算出
 		this.result.totalPages = this.result.pages.length;
 
-		const indexPath = join(this.outputDir, "index.json");
+		const indexPath = join(this.outputDir, FILENAME.INDEX_JSON);
 		writeFileSync(indexPath, JSON.stringify(this.result, null, 2));
 		return indexPath;
 	}


### PR DESCRIPTION
## Summary
Closes #1055

## Changes
- `post-processor.ts`: `"full.md"` → `FILENAME.FULL_MD`
- `index-manager.ts`: `"index.json"` → `FILENAME.INDEX_JSON` (2箇所)
- `chunker.ts`: `"chunks"` → `FILENAME.CHUNKS_DIR`

## Testing
- `bun run test`: 870 tests passed
- `bun run typecheck`: passed
- grep確認: ハードコード残存なし