### PR TITLE
docs: fix minor inconsistencies in design.md module structure

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -78,6 +78,7 @@
 ```
 link-crawler/
 ├── SKILL.md                    # piスキル定義
+├── install.sh                  # セットアップスクリプト
 ├── src/
 │   ├── crawl.ts                # エントリーポイント
 │   ├── config.ts               # 設定パース
@@ -134,7 +135,7 @@ link-crawler/
 | `PlaywrightFetcher` | ページ取得 | URL | HTML |
 | `RobotsChecker` | robots.txt のパースとURL許可判定 | robots.txt, URL | boolean |
 | `CrawlLogger` | クロールログ出力（開始、進捗、完了、エラー等） | Config, Events | コンソール出力 |
-| `PostProcessor` | 後処理実行（Merger/Chunkerを呼び出し、ページ内容読み込み、full.md書き込み） | CrawledPages | full.md, chunks/ |
+| `PostProcessor` | 後処理実行（Merger/Chunkerを呼び出し、ページ内容読み込み、full.md書き込み） | CrawledPages | full.md (write), chunks/ (via Chunker) |
 | `Extractor` | 本文抽出 | HTML | ContentHTML |
 | `Converter` | Markdown変換 | ContentHTML | Markdown |
 | `LinksParser` | リンク抽出 | HTML | URLs |

--- a/docs/development.md
+++ b/docs/development.md
@@ -28,6 +28,7 @@ bun run dev --help
 ```
 link-crawler/
 ├── SKILL.md                    # piスキル定義
+├── install.sh                  # セットアップスクリプト
 ├── src/
 │   ├── crawl.ts                # エントリーポイント
 │   ├── config.ts               # 設定パース


### PR DESCRIPTION
## Overview

Fixes #1058

Fixed minor documentation inconsistencies in `docs/design.md` and `docs/development.md`:

## Changes

### 1. Added `install.sh` to module structure diagrams
- **Section**: 3.2 (design.md), 2 (development.md)
- **Issue**: `install.sh` exists and is referenced in SKILL.md but was missing from structure diagrams
- **Fix**: Added `├── install.sh                  # セットアップスクリプト` after SKILL.md

### 2. Clarified PostProcessor output description
- **Section**: 3.3 (design.md)
- **Before**: `full.md, chunks/`
- **After**: `full.md (write), chunks/ (via Chunker)`
- **Rationale**: More clearly indicates that PostProcessor directly writes full.md and generates chunks/ via Chunker

## Verification

All files in the structure diagram confirmed to exist:

```bash
✓ install.sh
✓ SKILL.md
✓ src/crawl.ts
✓ src/config.ts
✓ src/types.ts
✓ src/constants.ts
✓ src/errors.ts
✓ src/error-handler.ts
✓ src/signal-handler.ts
```

## Documentation Impact

- ✅ Documentation now accurately reflects actual file structure
- ✅ Consistency maintained between design.md and development.md
- ✅ PostProcessor responsibilities are more clearly defined

Closes #1058