### PR TITLE
fix: config.ts の console.warn を CrawlLogger 経由に統一

### DIFF
--- a/link-crawler/src/config.ts
+++ b/link-crawler/src/config.ts
@@ -4,6 +4,15 @@ import type { CrawlConfig } from "./types.js";
 import { generateSiteName } from "./utils/site-name.js";
 
 /**
+ * parseConfig の戻り値
+ * config パース結果と、呼び出し側で表示すべき警告メッセージを含む
+ */
+export interface ParseConfigResult {
+	config: CrawlConfig;
+	warnings: string[];
+}
+
+/**
  * Parse a regex pattern string into a RegExp object
  * @param pattern - The regex pattern string
  * @param name - The name of the pattern (for error messages)
@@ -39,7 +48,7 @@ export function parseConfig(
 	options: Record<string, unknown>,
 	startUrl: string,
 	version: string,
-): CrawlConfig {
+): ParseConfigResult {
 	// Validate startUrl format
 	let parsed: URL;
 	try {
@@ -106,13 +115,13 @@ export function parseConfig(
 		version,
 	};
 
-	// Warn when all output formats are disabled
+	// Collect warnings (output is delegated to the caller via CrawlLogger)
+	const warnings: string[] = [];
 	if (!config.pages && !config.merge && !config.chunks) {
-		console.warn(
-			"⚠️  Warning: All output formats are disabled (--no-pages --no-merge without --chunks).",
+		warnings.push(
+			"All output formats are disabled (--no-pages --no-merge without --chunks). Only index.json will be generated. Consider adding --chunks.",
 		);
-		console.warn("   Only index.json will be generated. Consider adding --chunks.");
 	}
 
-	return config;
+	return { config, warnings };
 }

--- a/link-crawler/src/crawl.ts
+++ b/link-crawler/src/crawl.ts
@@ -6,6 +6,7 @@ import { program } from "commander";
 import { parseConfig } from "./config.js";
 import { EXIT_CODES } from "./constants.js";
 import { Crawler } from "./crawler/index.js";
+import { CrawlLogger } from "./crawler/logger.js";
 import { handleError } from "./error-handler.js";
 import { SignalHandler } from "./signal-handler.js";
 
@@ -62,7 +63,16 @@ async function main(): Promise<void> {
 
 	signalHandler.install();
 
-	const config = parseConfig(options, startUrl, packageJson.version);
+	const { config, warnings } = parseConfig(options, startUrl, packageJson.version);
+
+	// 設定パース時の警告を CrawlLogger 経由で出力
+	if (warnings.length > 0) {
+		const logger = new CrawlLogger(config);
+		for (const warning of warnings) {
+			logger.logWarning(warning);
+		}
+	}
+
 	crawler = new Crawler(config);
 	await crawler.run();
 }

--- a/link-crawler/src/crawler/logger.ts
+++ b/link-crawler/src/crawler/logger.ts
@@ -149,6 +149,11 @@ export class CrawlLogger implements Logger {
 		return this.skippedCount;
 	}
 
+	/** 警告ログ */
+	logWarning(message: string): void {
+		console.warn(`⚠️  ${message}`);
+	}
+
 	/** デバッグログ（DEBUG=1時のみ） */
 	logDebug(message: string, data?: unknown): void {
 		if (this.debug) {

--- a/link-crawler/tests/unit/config.test.ts
+++ b/link-crawler/tests/unit/config.test.ts
@@ -4,7 +4,7 @@ import { ConfigError } from "../../src/errors.js";
 
 describe("parseConfig", () => {
 	it("should parse config with default values", () => {
-		const config = parseConfig({}, "https://example.com", "test-version");
+		const { config } = parseConfig({}, "https://example.com", "test-version");
 
 		expect(config.startUrl).toBe("https://example.com");
 		expect(config.maxDepth).toBe(1);
@@ -22,7 +22,7 @@ describe("parseConfig", () => {
 	});
 
 	it("should parse config with custom options", () => {
-		const config = parseConfig(
+		const { config } = parseConfig(
 			{
 				depth: 3,
 				output: "./output",
@@ -41,61 +41,61 @@ describe("parseConfig", () => {
 	});
 
 	it("should cap maxDepth at 10", () => {
-		const config = parseConfig({ depth: 100 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ depth: 100 }, "https://example.com", "test-version");
 
 		expect(config.maxDepth).toBe(10);
 	});
 
 	it("should handle depth 0 correctly", () => {
-		const config = parseConfig({ depth: 0 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ depth: 0 }, "https://example.com", "test-version");
 
 		expect(config.maxDepth).toBe(0);
 	});
 
 	it("should handle depth as string '0' correctly", () => {
-		const config = parseConfig({ depth: "0" }, "https://example.com", "test-version");
+		const { config } = parseConfig({ depth: "0" }, "https://example.com", "test-version");
 
 		expect(config.maxDepth).toBe(0);
 	});
 
 	it("should handle delay 0 correctly", () => {
-		const config = parseConfig({ delay: 0 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ delay: 0 }, "https://example.com", "test-version");
 
 		expect(config.delay).toBe(0);
 	});
 
 	it("should handle delay as string '0' correctly", () => {
-		const config = parseConfig({ delay: "0" }, "https://example.com", "test-version");
+		const { config } = parseConfig({ delay: "0" }, "https://example.com", "test-version");
 
 		expect(config.delay).toBe(0);
 	});
 
 	it("should handle timeout 0 correctly", () => {
-		const config = parseConfig({ timeout: 0 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ timeout: 0 }, "https://example.com", "test-version");
 
 		expect(config.timeout).toBe(1000); // Minimum timeout is 1 second
 	});
 
 	it("should handle timeout as string '0' correctly", () => {
-		const config = parseConfig({ timeout: "0" }, "https://example.com", "test-version");
+		const { config } = parseConfig({ timeout: "0" }, "https://example.com", "test-version");
 
 		expect(config.timeout).toBe(1000); // Minimum timeout is 1 second
 	});
 
 	it("should handle spaWait 0 correctly", () => {
-		const config = parseConfig({ wait: 0 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ wait: 0 }, "https://example.com", "test-version");
 
 		expect(config.spaWait).toBe(0);
 	});
 
 	it("should handle spaWait as string '0' correctly", () => {
-		const config = parseConfig({ wait: "0" }, "https://example.com", "test-version");
+		const { config } = parseConfig({ wait: "0" }, "https://example.com", "test-version");
 
 		expect(config.spaWait).toBe(0);
 	});
 
 	it("should parse include/exclude patterns", () => {
-		const config = parseConfig(
+		const { config } = parseConfig(
 			{
 				include: "^/docs",
 				exclude: "\\.pdf$",
@@ -111,37 +111,37 @@ describe("parseConfig", () => {
 	});
 
 	it("should parse keepSession option", () => {
-		const configWithKeep = parseConfig(
+		const { config: configWithKeep } = parseConfig(
 			{ keepSession: true },
 			"https://example.com",
 			"test-version",
 		);
 		expect(configWithKeep.keepSession).toBe(true);
 
-		const configWithoutKeep = parseConfig(
+		const { config: configWithoutKeep } = parseConfig(
 			{ keepSession: false },
 			"https://example.com",
 			"test-version",
 		);
 		expect(configWithoutKeep.keepSession).toBe(false);
 
-		const configDefault = parseConfig({}, "https://example.com", "test-version");
+		const { config: configDefault } = parseConfig({}, "https://example.com", "test-version");
 		expect(configDefault.keepSession).toBe(false);
 	});
 
 	it("should generate site-specific output directory from URL", () => {
-		const config1 = parseConfig({}, "https://nextjs.org/docs", "test-version");
+		const { config: config1 } = parseConfig({}, "https://nextjs.org/docs", "test-version");
 		expect(config1.outputDir).toBe("./.context/nextjs-docs");
 
-		const config2 = parseConfig({}, "https://docs.python.org/3/", "test-version");
+		const { config: config2 } = parseConfig({}, "https://docs.python.org/3/", "test-version");
 		expect(config2.outputDir).toBe("./.context/python-3");
 
-		const config3 = parseConfig({}, "https://www.example.com", "test-version");
+		const { config: config3 } = parseConfig({}, "https://www.example.com", "test-version");
 		expect(config3.outputDir).toBe("./.context/example");
 	});
 
 	it("should allow custom output directory to override default", () => {
-		const config = parseConfig(
+		const { config } = parseConfig(
 			{ output: "./custom-dir" },
 			"https://nextjs.org/docs",
 			"test-version",
@@ -150,7 +150,7 @@ describe("parseConfig", () => {
 	});
 
 	it("should allow legacy ./.context directory to be specified explicitly", () => {
-		const config = parseConfig({ output: "./.context" }, "https://nextjs.org/docs", "test-version");
+		const { config } = parseConfig({ output: "./.context" }, "https://nextjs.org/docs", "test-version");
 		expect(config.outputDir).toBe("./.context");
 	});
 });
@@ -183,7 +183,7 @@ describe("parseConfig - regex pattern validation", () => {
 	});
 
 	it("should continue to work with valid patterns after error fix", () => {
-		const config = parseConfig(
+		const { config } = parseConfig(
 			{
 				include: "^/docs",
 				exclude: "\\.pdf$",
@@ -218,7 +218,55 @@ describe("parseConfig - regex pattern validation", () => {
 });
 
 describe("parseConfig - output format warnings", () => {
-	it("should warn when all output formats are disabled", () => {
+	it("should return warnings when all output formats are disabled", () => {
+		const { warnings } = parseConfig(
+			{ pages: false, merge: false, chunks: false },
+			"https://example.com",
+			"test-version",
+		);
+
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("All output formats are disabled");
+		expect(warnings[0]).toContain("Consider adding --chunks");
+	});
+
+	it("should not return warnings when at least one output format is enabled - pages", () => {
+		const { warnings } = parseConfig(
+			{ pages: true, merge: false, chunks: false },
+			"https://example.com",
+			"test-version",
+		);
+
+		expect(warnings).toHaveLength(0);
+	});
+
+	it("should not return warnings when at least one output format is enabled - merge", () => {
+		const { warnings } = parseConfig(
+			{ pages: false, merge: true, chunks: false },
+			"https://example.com",
+			"test-version",
+		);
+
+		expect(warnings).toHaveLength(0);
+	});
+
+	it("should not return warnings when at least one output format is enabled - chunks", () => {
+		const { warnings } = parseConfig(
+			{ pages: false, merge: false, chunks: true },
+			"https://example.com",
+			"test-version",
+		);
+
+		expect(warnings).toHaveLength(0);
+	});
+
+	it("should not return warnings with default configuration", () => {
+		const { warnings } = parseConfig({}, "https://example.com", "test-version");
+
+		expect(warnings).toHaveLength(0);
+	});
+
+	it("should not call console.warn directly (no side effects)", () => {
 		const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
 		parseConfig(
@@ -226,63 +274,6 @@ describe("parseConfig - output format warnings", () => {
 			"https://example.com",
 			"test-version",
 		);
-
-		expect(consoleSpy).toHaveBeenCalledWith(
-			"⚠️  Warning: All output formats are disabled (--no-pages --no-merge without --chunks).",
-		);
-		expect(consoleSpy).toHaveBeenCalledWith(
-			"   Only index.json will be generated. Consider adding --chunks.",
-		);
-
-		consoleSpy.mockRestore();
-	});
-
-	it("should not warn when at least one output format is enabled - pages", () => {
-		const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-		parseConfig(
-			{ pages: true, merge: false, chunks: false },
-			"https://example.com",
-			"test-version",
-		);
-
-		expect(consoleSpy).not.toHaveBeenCalled();
-
-		consoleSpy.mockRestore();
-	});
-
-	it("should not warn when at least one output format is enabled - merge", () => {
-		const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-		parseConfig(
-			{ pages: false, merge: true, chunks: false },
-			"https://example.com",
-			"test-version",
-		);
-
-		expect(consoleSpy).not.toHaveBeenCalled();
-
-		consoleSpy.mockRestore();
-	});
-
-	it("should not warn when at least one output format is enabled - chunks", () => {
-		const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-		parseConfig(
-			{ pages: false, merge: false, chunks: true },
-			"https://example.com",
-			"test-version",
-		);
-
-		expect(consoleSpy).not.toHaveBeenCalled();
-
-		consoleSpy.mockRestore();
-	});
-
-	it("should not warn with default configuration", () => {
-		const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-		parseConfig({}, "https://example.com", "test-version");
 
 		expect(consoleSpy).not.toHaveBeenCalled();
 
@@ -332,40 +323,40 @@ describe("parseConfig - URL validation", () => {
 	});
 
 	it("should accept valid URLs", () => {
-		const config1 = parseConfig({}, "https://example.com", "test-version");
+		const { config: config1 } = parseConfig({}, "https://example.com", "test-version");
 		expect(config1.startUrl).toBe("https://example.com");
 
-		const config2 = parseConfig({}, "http://localhost:3000", "test-version");
+		const { config: config2 } = parseConfig({}, "http://localhost:3000", "test-version");
 		expect(config2.startUrl).toBe("http://localhost:3000");
 
-		const config3 = parseConfig({}, "https://example.com/path/to/page", "test-version");
+		const { config: config3 } = parseConfig({}, "https://example.com/path/to/page", "test-version");
 		expect(config3.startUrl).toBe("https://example.com/path/to/page");
 	});
 });
 
 describe("parseConfig - negative value validation", () => {
 	it("should clamp negative delay to 0", () => {
-		const config = parseConfig({ delay: -100 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ delay: -100 }, "https://example.com", "test-version");
 		expect(config.delay).toBe(0);
 	});
 
 	it("should clamp negative timeout to 1 second (1000ms)", () => {
-		const config = parseConfig({ timeout: -10 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ timeout: -10 }, "https://example.com", "test-version");
 		expect(config.timeout).toBe(1000);
 	});
 
 	it("should clamp negative spaWait to 0", () => {
-		const config = parseConfig({ wait: -500 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ wait: -500 }, "https://example.com", "test-version");
 		expect(config.spaWait).toBe(0);
 	});
 
 	it("should clamp negative depth to 0", () => {
-		const config = parseConfig({ depth: -5 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ depth: -5 }, "https://example.com", "test-version");
 		expect(config.maxDepth).toBe(0);
 	});
 
 	it("should clamp very large negative values appropriately", () => {
-		const config = parseConfig(
+		const { config } = parseConfig(
 			{
 				delay: -999999,
 				timeout: -999999,
@@ -385,37 +376,37 @@ describe("parseConfig - negative value validation", () => {
 
 describe("parseConfig - boundary value validation", () => {
 	it("should allow delay of exactly 0", () => {
-		const config = parseConfig({ delay: 0 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ delay: 0 }, "https://example.com", "test-version");
 		expect(config.delay).toBe(0);
 	});
 
 	it("should allow depth of exactly 0", () => {
-		const config = parseConfig({ depth: 0 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ depth: 0 }, "https://example.com", "test-version");
 		expect(config.maxDepth).toBe(0);
 	});
 
 	it("should allow spaWait of exactly 0", () => {
-		const config = parseConfig({ wait: 0 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ wait: 0 }, "https://example.com", "test-version");
 		expect(config.spaWait).toBe(0);
 	});
 
 	it("should enforce minimum timeout of 1 second (1000ms)", () => {
-		const config = parseConfig({ timeout: 0.5 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ timeout: 0.5 }, "https://example.com", "test-version");
 		expect(config.timeout).toBe(1000);
 	});
 
 	it("should allow timeout of exactly 1 second", () => {
-		const config = parseConfig({ timeout: 1 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ timeout: 1 }, "https://example.com", "test-version");
 		expect(config.timeout).toBe(1000);
 	});
 
 	it("should allow timeout greater than 1 second", () => {
-		const config = parseConfig({ timeout: 5 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ timeout: 5 }, "https://example.com", "test-version");
 		expect(config.timeout).toBe(5000);
 	});
 
 	it("should allow positive values for all numeric options", () => {
-		const config = parseConfig(
+		const { config } = parseConfig(
 			{
 				delay: 100,
 				timeout: 10,
@@ -546,12 +537,12 @@ describe("parseConfig - pattern length limit", () => {
 
 describe("parseConfig - URL scheme validation", () => {
 	it("should accept https URLs", () => {
-		const config = parseConfig({}, "https://example.com", "test-version");
+		const { config } = parseConfig({}, "https://example.com", "test-version");
 		expect(config.startUrl).toBe("https://example.com");
 	});
 
 	it("should accept http URLs", () => {
-		const config = parseConfig({}, "http://localhost:3000", "test-version");
+		const { config } = parseConfig({}, "http://localhost:3000", "test-version");
 		expect(config.startUrl).toBe("http://localhost:3000");
 	});
 
@@ -608,38 +599,38 @@ describe("parseConfig - URL scheme validation", () => {
 
 describe("parseConfig - maxPages validation", () => {
 	it("should set maxPages to null by default (unlimited)", () => {
-		const config = parseConfig({}, "https://example.com", "test-version");
+		const { config } = parseConfig({}, "https://example.com", "test-version");
 		expect(config.maxPages).toBeNull();
 	});
 
 	it("should parse positive integer maxPages", () => {
-		const config = parseConfig({ maxPages: 100 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ maxPages: 100 }, "https://example.com", "test-version");
 		expect(config.maxPages).toBe(100);
 	});
 
 	it("should parse maxPages as string", () => {
-		const config = parseConfig({ maxPages: "50" }, "https://example.com", "test-version");
+		const { config } = parseConfig({ maxPages: "50" }, "https://example.com", "test-version");
 		expect(config.maxPages).toBe(50);
 	});
 
 	it("should set maxPages to null when 0 (unlimited)", () => {
-		const config = parseConfig({ maxPages: 0 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ maxPages: 0 }, "https://example.com", "test-version");
 		expect(config.maxPages).toBeNull();
 	});
 
 	it("should set maxPages to null when negative (unlimited)", () => {
-		const config = parseConfig({ maxPages: -1 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ maxPages: -1 }, "https://example.com", "test-version");
 		expect(config.maxPages).toBeNull();
 
-		const config2 = parseConfig({ maxPages: -100 }, "https://example.com", "test-version");
+		const { config: config2 } = parseConfig({ maxPages: -100 }, "https://example.com", "test-version");
 		expect(config2.maxPages).toBeNull();
 	});
 
 	it("should set maxPages to null when NaN (unlimited)", () => {
-		const config = parseConfig({ maxPages: "abc" }, "https://example.com", "test-version");
+		const { config } = parseConfig({ maxPages: "abc" }, "https://example.com", "test-version");
 		expect(config.maxPages).toBeNull();
 
-		const config2 = parseConfig(
+		const { config: config2 } = parseConfig(
 			{ maxPages: "not-a-number" },
 			"https://example.com",
 			"test-version",
@@ -648,59 +639,59 @@ describe("parseConfig - maxPages validation", () => {
 	});
 
 	it("should floor decimal maxPages values", () => {
-		const config = parseConfig({ maxPages: 42.7 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ maxPages: 42.7 }, "https://example.com", "test-version");
 		expect(config.maxPages).toBe(42);
 
-		const config2 = parseConfig({ maxPages: 99.9 }, "https://example.com", "test-version");
+		const { config: config2 } = parseConfig({ maxPages: 99.9 }, "https://example.com", "test-version");
 		expect(config2.maxPages).toBe(99);
 	});
 
 	it("should handle very large maxPages values", () => {
-		const config = parseConfig({ maxPages: 1000000 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ maxPages: 1000000 }, "https://example.com", "test-version");
 		expect(config.maxPages).toBe(1000000);
 	});
 });
 
 describe("parseConfig - respectRobots validation", () => {
 	it("should set respectRobots to true by default", () => {
-		const config = parseConfig({}, "https://example.com", "test-version");
+		const { config } = parseConfig({}, "https://example.com", "test-version");
 		expect(config.respectRobots).toBe(true);
 	});
 
 	it("should set respectRobots to false when robots option is false", () => {
-		const config = parseConfig({ robots: false }, "https://example.com", "test-version");
+		const { config } = parseConfig({ robots: false }, "https://example.com", "test-version");
 		expect(config.respectRobots).toBe(false);
 	});
 
 	it("should set respectRobots to true when robots option is true", () => {
-		const config = parseConfig({ robots: true }, "https://example.com", "test-version");
+		const { config } = parseConfig({ robots: true }, "https://example.com", "test-version");
 		expect(config.respectRobots).toBe(true);
 	});
 
 	it("should set respectRobots to true when robots option is undefined", () => {
-		const config = parseConfig({ robots: undefined }, "https://example.com", "test-version");
+		const { config } = parseConfig({ robots: undefined }, "https://example.com", "test-version");
 		expect(config.respectRobots).toBe(true);
 	});
 });
 
 describe("parseConfig - upper bound validation", () => {
 	it("should cap delay at MAX_DELAY_MS (60000ms)", () => {
-		const config = parseConfig({ delay: 999999 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ delay: 999999 }, "https://example.com", "test-version");
 		expect(config.delay).toBe(60000);
 	});
 
 	it("should cap timeout at MAX_TIMEOUT_SEC (300 seconds = 300000ms)", () => {
-		const config = parseConfig({ timeout: 999999 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ timeout: 999999 }, "https://example.com", "test-version");
 		expect(config.timeout).toBe(300000);
 	});
 
 	it("should cap spaWait at MAX_SPA_WAIT_MS (30000ms)", () => {
-		const config = parseConfig({ wait: 999999 }, "https://example.com", "test-version");
+		const { config } = parseConfig({ wait: 999999 }, "https://example.com", "test-version");
 		expect(config.spaWait).toBe(30000);
 	});
 
 	it("should allow values below upper bounds", () => {
-		const config = parseConfig(
+		const { config } = parseConfig(
 			{
 				delay: 1000,
 				timeout: 60,
@@ -716,7 +707,7 @@ describe("parseConfig - upper bound validation", () => {
 	});
 
 	it("should handle exact upper bound values", () => {
-		const config = parseConfig(
+		const { config } = parseConfig(
 			{
 				delay: 60000,
 				timeout: 300,
@@ -732,7 +723,7 @@ describe("parseConfig - upper bound validation", () => {
 	});
 
 	it("should cap string values that exceed upper bounds", () => {
-		const config = parseConfig(
+		const { config } = parseConfig(
 			{
 				delay: "999999",
 				timeout: "999999",

--- a/link-crawler/tests/unit/logger.test.ts
+++ b/link-crawler/tests/unit/logger.test.ts
@@ -368,6 +368,17 @@ describe("CrawlLogger", () => {
 		});
 	});
 
+	describe("logWarning", () => {
+		it("should log warning message via console.warn with emoji prefix", () => {
+			const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			const logger = new CrawlLogger(baseConfig);
+			logger.logWarning("All output formats are disabled.");
+
+			expect(consoleWarnSpy).toHaveBeenCalledWith("⚠️  All output formats are disabled.");
+			consoleWarnSpy.mockRestore();
+		});
+	});
+
 	describe("debug logging", () => {
 		it("should respect debug parameter when explicitly set to true", () => {
 			const logger = new CrawlLogger(baseConfig, true);

--- a/link-crawler/tests/unit/max-pages.test.ts
+++ b/link-crawler/tests/unit/max-pages.test.ts
@@ -5,42 +5,42 @@ describe("--max-pages option", () => {
 	const baseUrl = "https://example.com";
 
 	test("default is null (unlimited)", () => {
-		const config = parseConfig({}, baseUrl, "test-version");
+		const { config } = parseConfig({}, baseUrl, "test-version");
 		expect(config.maxPages).toBeNull();
 	});
 
 	test("accepts positive integer", () => {
-		const config = parseConfig({ maxPages: "100" }, baseUrl, "test-version");
+		const { config } = parseConfig({ maxPages: "100" }, baseUrl, "test-version");
 		expect(config.maxPages).toBe(100);
 	});
 
 	test("treats 0 as unlimited", () => {
-		const config = parseConfig({ maxPages: "0" }, baseUrl, "test-version");
+		const { config } = parseConfig({ maxPages: "0" }, baseUrl, "test-version");
 		expect(config.maxPages).toBeNull();
 	});
 
 	test("treats negative as unlimited", () => {
-		const config = parseConfig({ maxPages: "-10" }, baseUrl, "test-version");
+		const { config } = parseConfig({ maxPages: "-10" }, baseUrl, "test-version");
 		expect(config.maxPages).toBeNull();
 	});
 
 	test("floors decimal values", () => {
-		const config = parseConfig({ maxPages: "50.7" }, baseUrl, "test-version");
+		const { config } = parseConfig({ maxPages: "50.7" }, baseUrl, "test-version");
 		expect(config.maxPages).toBe(50);
 	});
 
 	test("treats invalid input as unlimited", () => {
-		const config = parseConfig({ maxPages: "abc" }, baseUrl, "test-version");
+		const { config } = parseConfig({ maxPages: "abc" }, baseUrl, "test-version");
 		expect(config.maxPages).toBeNull();
 	});
 
 	test("accepts large numbers", () => {
-		const config = parseConfig({ maxPages: "10000" }, baseUrl, "test-version");
+		const { config } = parseConfig({ maxPages: "10000" }, baseUrl, "test-version");
 		expect(config.maxPages).toBe(10000);
 	});
 
 	test("handles string '1'", () => {
-		const config = parseConfig({ maxPages: "1" }, baseUrl, "test-version");
+		const { config } = parseConfig({ maxPages: "1" }, baseUrl, "test-version");
 		expect(config.maxPages).toBe(1);
 	});
 });


### PR DESCRIPTION
## 概要

`config.ts` の `console.warn` 直接呼び出しを除去し、ロギングの一貫性を確保。

## 変更内容

- `parseConfig` の戻り値を `ParseConfigResult { config, warnings }` に変更（副作用なし）
- `config.ts` から `console.warn` 直接呼び出しを除去
- `CrawlLogger` に `logWarning` メソッドを追加
- `crawl.ts` で警告を `CrawlLogger` 経由で出力
- テストを `warnings` 配列チェックに更新
- `console.warn` が呼ばれないことを検証するテストを追加

## 検証

- `bun run test`: 全872テストパス
- `bun x tsc --noEmit`: パス
- `grep -rn 'console\.' src/ | grep -v logger.ts | grep -v crawl.ts`: 該当なし

Closes #1056