### PR TITLE
fix: Biome フォーマット違反とlint違反の修正

### DIFF
--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -1265,7 +1265,10 @@ describe("OutputWriter", () => {
 			writer.savePage("https://example.com/page", "# Content", 0, [], defaultMetadata, "Test");
 			writer.cleanup();
 
-			expect(logger.logDebug).toHaveBeenCalledWith("Temporary output cleaned up", expect.any(Object));
+			expect(logger.logDebug).toHaveBeenCalledWith(
+				"Temporary output cleaned up",
+				expect.any(Object),
+			);
 		});
 
 		it("should recover from incomplete finalization (.bak exists, final doesn't)", () => {


### PR DESCRIPTION
## 概要

Issue #1054 で報告されたBiome lint違反を修正します。

## 変更内容

### 修正ファイル
- `link-crawler/tests/unit/writer-finalize-errors.test.ts`
- `link-crawler/tests/unit/writer.test.ts`

### 修正内容
- **lint (noExplicitAny)**: テストファイル内の `any[]` を適切な型定義に置き換え
  - `fs.renameSync`, `fs.rmSync` のモックに明示的な型を追加
  - `RenameSyncFn`, `RmSyncFn` などの型エイリアスを定義
- **フォーマット**: Biomeの自動フォーマットを適用

## 検証結果

```bash
cd link-crawler
bun run lint      # ✅ 0 errors
bun run typecheck # ✅ No errors
bun run test      # ✅ 870 tests passed
```

## 注記

Issue #1054 のタイトルは「config.ts, crawler/index.ts の修正」となっていますが、これらのファイルはすでに main ブランチで修正済みでした（PR #1052）。本PRでは残っていたテストファイルのlint違反を修正しています。

Closes #1054