### PR TITLE
docs: fix broken links and add missing entry in verification/README.md

### DIFF
--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -21,6 +21,7 @@
 | [issue-826-coverage-gitignore-verification.md](./issue-826-coverage-gitignore-verification.md) | #826 | 2026-02-07 | ✅ 解決済み |
 | [issue-917-coverage-verification.md](./issue-917-coverage-verification.md) | #917 | 2026-02-08 | ✅ 解決済み |
 | [issue-966-verification.md](./issue-966-verification.md) | #966 | 2026-02-08 | ✅ 解決済み |
+| [issue-1017-playwright-cli-npm-verification.md](./issue-1017-playwright-cli-npm-verification.md) | #1017 | 2026-02-08 | ✅ 解決済み |
 
 ## 検証内容の概要
 
@@ -41,6 +42,6 @@
 
 ## 関連ドキュメント
 
-- [.gitignore](./.../../.gitignore) - ルートの除外設定
-- [link-crawler/.gitignore](./../../link-crawler/.gitignore) - クローラーの除外設定
+- [.gitignore](../../.gitignore) - ルートの除外設定
+- [link-crawler/.gitignore](../../link-crawler/.gitignore) - クローラーの除外設定
 - [Decision 001](../decisions/001-playwright-cli-session.md) - playwright-cli セッション制約


### PR DESCRIPTION
## Summary

Fixes broken relative path links and adds missing verification report entry in `docs/verification/README.md`.

## Changes

### P2 (Medium Priority): Fixed Broken Links
- Fixed `.gitignore` link: `./.../../.gitignore` → `../../.gitignore`
- Fixed `link-crawler/.gitignore` link: `./../../link-crawler/.gitignore` → `../../link-crawler/.gitignore`

### P3 (Low Priority): Added Missing Entry
- Added `issue-1017-playwright-cli-npm-verification.md` to verification reports table
- Date: 2026-02-08
- Status: ✅ 解決済み

## Verification

All relative paths have been tested and resolve correctly:
```bash
cd docs/verification
ls -la ../../.gitignore  # ✅ exists
ls -la ../../link-crawler/.gitignore  # ✅ exists
ls -la ./issue-1017-playwright-cli-npm-verification.md  # ✅ exists
```

## Files Changed
- `docs/verification/README.md` - 3 insertions, 2 deletions

Closes #1064