### PR TITLE
fix: Biome lint violations in test files

### DIFF
--- a/link-crawler/tests/unit/config.test.ts
+++ b/link-crawler/tests/unit/config.test.ts
@@ -150,7 +150,11 @@ describe("parseConfig", () => {
 	});
 
 	it("should allow legacy ./.context directory to be specified explicitly", () => {
-		const { config } = parseConfig({ output: "./.context" }, "https://nextjs.org/docs", "test-version");
+		const { config } = parseConfig(
+			{ output: "./.context" },
+			"https://nextjs.org/docs",
+			"test-version",
+		);
 		expect(config.outputDir).toBe("./.context");
 	});
 });
@@ -622,7 +626,11 @@ describe("parseConfig - maxPages validation", () => {
 		const { config } = parseConfig({ maxPages: -1 }, "https://example.com", "test-version");
 		expect(config.maxPages).toBeNull();
 
-		const { config: config2 } = parseConfig({ maxPages: -100 }, "https://example.com", "test-version");
+		const { config: config2 } = parseConfig(
+			{ maxPages: -100 },
+			"https://example.com",
+			"test-version",
+		);
 		expect(config2.maxPages).toBeNull();
 	});
 
@@ -642,7 +650,11 @@ describe("parseConfig - maxPages validation", () => {
 		const { config } = parseConfig({ maxPages: 42.7 }, "https://example.com", "test-version");
 		expect(config.maxPages).toBe(42);
 
-		const { config: config2 } = parseConfig({ maxPages: 99.9 }, "https://example.com", "test-version");
+		const { config: config2 } = parseConfig(
+			{ maxPages: 99.9 },
+			"https://example.com",
+			"test-version",
+		);
 		expect(config2.maxPages).toBe(99);
 	});
 

--- a/link-crawler/tests/unit/post-processor.test.ts
+++ b/link-crawler/tests/unit/post-processor.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CrawlLogger } from "../../src/crawler/logger.js";
@@ -434,8 +434,14 @@ This is the second page content.`;
 				createPage("https://example.com/page2", "Page 2", "pages/page-002.md"),
 			];
 			const contents = new Map([
-				["pages/page-001.md", "---\nurl: https://example.com/page1\n---\n\n# Page 1\n\nContent from memory A"],
-				["pages/page-002.md", "---\nurl: https://example.com/page2\n---\n\n# Page 2\n\nContent from memory B"],
+				[
+					"pages/page-001.md",
+					"---\nurl: https://example.com/page1\n---\n\n# Page 1\n\nContent from memory A",
+				],
+				[
+					"pages/page-002.md",
+					"---\nurl: https://example.com/page2\n---\n\n# Page 2\n\nContent from memory B",
+				],
 			]);
 
 			await processor.process(pages, contents);
@@ -471,12 +477,8 @@ This is the second page content.`;
 			const config = { ...baseConfig, pages: false, merge: false, chunks: true };
 			const processor = new PostProcessor(config, config.outputDir, mockLogger);
 
-			const pages = [
-				createPage("https://example.com/page1", "Page 1", "pages/page-001.md"),
-			];
-			const contents = new Map([
-				["pages/page-001.md", "# Page 1\n\nIn-memory only content"],
-			]);
+			const pages = [createPage("https://example.com/page1", "Page 1", "pages/page-001.md")];
+			const contents = new Map([["pages/page-001.md", "# Page 1\n\nIn-memory only content"]]);
 
 			await processor.process(pages, contents);
 


### PR DESCRIPTION
## Summary

Fixed Biome lint violations in test files identified by project review.

## Changes

### config.test.ts
- Fixed 3 line length violations by splitting long `parseConfig()` calls into multiple lines

### post-processor.test.ts  
- Fixed import order violation (swapped `readFileSync` and `readdirSync`)
- Auto-fixed additional formatting issues using Biome

## Verification

- ✅ `bun run check` passes with 0 violations
- ✅ `bun run typecheck` passes  
- ✅ `bun run test` passes (875/875 tests)

Closes #1063