### PR TITLE
improvement: add shellcheck to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,17 @@ jobs:
       - run: bun install
       - run: npm install -g @playwright/cli
       - run: bun run test:coverage
+
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: "./scripts"
+          additional_files: "link-crawler/install.sh"


### PR DESCRIPTION
## Summary

Add shellcheck job to CI pipeline to ensure shell script quality and prevent regressions.

## Changes

- Added shellcheck job to `.github/workflows/ci.yml`
- Scans all scripts in `scripts/` directory
- Also checks `link-crawler/install.sh`
- Overrides working-directory to run from repository root

## Verification

✅ Local shellcheck passed (0 errors on all 3 scripts)
✅ All scripts are clean:
- `scripts/cleanup-dev-artifacts.sh` (239 lines)
- `scripts/verify-gitignore.sh` (106 lines)
- `link-crawler/install.sh` (113 lines)

## Testing

CI will run shellcheck alongside existing jobs (lint, typecheck, test).

Closes #1071