### PR TITLE
docs: add missing test files to development.md

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -93,7 +93,9 @@ link-crawler/
 │   │   ├── post-processor.test.ts
 │   │   ├── robots.test.ts
 │   │   ├── runtime.test.ts
+│   │   ├── signal-handler.test.ts
 │   │   ├── site-name.test.ts
+│   │   ├── writer-finalize-errors.test.ts
 │   │   └── writer.test.ts
 │   └── integration/             # 統合テスト
 │       ├── crawler.test.ts


### PR DESCRIPTION
## 概要
`docs/development.md` のセクション2「プロジェクト構成」に記載されていないテストファイルを追加しました。

## 変更内容
- `signal-handler.test.ts` を追加
- `writer-finalize-errors.test.ts` を追加

## 検証
全てのテストファイルがドキュメントに記載されていることを確認しました：
```bash
# Unit tests: 26 files ✓
# Integration tests: 2 files ✓
```

Closes #1070