### PR TITLE
fix: improve fix-shebang.js with fallback shebang and chmod

### DIFF
--- a/link-crawler/scripts/fix-shebang.js
+++ b/link-crawler/scripts/fix-shebang.js
@@ -1,23 +1,34 @@
 #!/usr/bin/env node
-import { readFileSync, writeFileSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { chmodSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const distPath = join(__dirname, '../dist/crawl.js');
+const distPath = join(__dirname, "../dist/crawl.js");
+
+const NODE_SHEBANG = "#!/usr/bin/env node";
 
 try {
-  let content = readFileSync(distPath, 'utf-8');
-  
-  // #!/usr/bin/env bun を #!/usr/bin/env node に置換
-  content = content.replace(/^#!\/usr\/bin\/env bun/, '#!/usr/bin/env node');
-  
-  // @bun コメントを削除
-  content = content.replace(/^\/\/ @bun\n/m, '');
-  
-  writeFileSync(distPath, content, 'utf-8');
-  console.log('✅ Shebang fixed: #!/usr/bin/env node');
+	let content = readFileSync(distPath, "utf-8");
+
+	if (content.startsWith("#!/usr/bin/env bun")) {
+		// #!/usr/bin/env bun を #!/usr/bin/env node に置換
+		content = content.replace(/^#!\/usr\/bin\/env bun/, NODE_SHEBANG);
+	} else if (!content.startsWith("#!")) {
+		// shebang が存在しない場合は追加
+		content = `${NODE_SHEBANG}\n${content}`;
+	}
+
+	// @bun コメントを削除
+	content = content.replace(/^\/\/ @bun\n/m, "");
+
+	writeFileSync(distPath, content, "utf-8");
+
+	// 実行権限を付与
+	chmodSync(distPath, 0o755);
+
+	console.log("✅ Shebang fixed: #!/usr/bin/env node");
 } catch (error) {
-  console.error('❌ Failed to fix shebang:', error.message);
-  process.exit(1);
+	console.error("❌ Failed to fix shebang:", error.message);
+	process.exit(1);
 }

--- a/link-crawler/tests/unit/fix-shebang.test.ts
+++ b/link-crawler/tests/unit/fix-shebang.test.ts
@@ -1,0 +1,89 @@
+import { execSync } from "node:child_process";
+import { chmodSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("fix-shebang.js", () => {
+	const tmpDir = join(import.meta.dirname, "../../.tmp-fix-shebang-test");
+	const distDir = join(tmpDir, "dist");
+	const distFile = join(distDir, "crawl.js");
+	const scriptsDir = join(tmpDir, "scripts");
+
+	beforeEach(() => {
+		mkdirSync(distDir, { recursive: true });
+		mkdirSync(scriptsDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	/**
+	 * Helper to create a modified fix-shebang script that works with tmpDir
+	 */
+	function runFixShebang(): string {
+		const scriptContent = readFileSync(
+			join(import.meta.dirname, "../../scripts/fix-shebang.js"),
+			"utf-8",
+		);
+
+		// Replace the distPath to point to our temp directory
+		const modifiedScript = scriptContent.replace(
+			/const distPath = .+;/,
+			`const distPath = ${JSON.stringify(distFile)};`,
+		);
+
+		const tmpScript = join(scriptsDir, "fix-shebang-test.js");
+		writeFileSync(tmpScript, modifiedScript, "utf-8");
+
+		return execSync(`node ${tmpScript}`, { encoding: "utf-8" });
+	}
+
+	it("should replace #!/usr/bin/env bun with #!/usr/bin/env node", () => {
+		writeFileSync(distFile, "#!/usr/bin/env bun\n// @bun\nconsole.log('hello');");
+
+		runFixShebang();
+
+		const result = readFileSync(distFile, "utf-8");
+		expect(result).toBe("#!/usr/bin/env node\nconsole.log('hello');");
+	});
+
+	it("should add shebang when none exists", () => {
+		writeFileSync(distFile, "console.log('hello');");
+
+		runFixShebang();
+
+		const result = readFileSync(distFile, "utf-8");
+		expect(result).toBe("#!/usr/bin/env node\nconsole.log('hello');");
+	});
+
+	it("should preserve existing #!/usr/bin/env node shebang", () => {
+		writeFileSync(distFile, "#!/usr/bin/env node\nconsole.log('hello');");
+
+		runFixShebang();
+
+		const result = readFileSync(distFile, "utf-8");
+		expect(result).toBe("#!/usr/bin/env node\nconsole.log('hello');");
+	});
+
+	it("should set executable permissions", () => {
+		writeFileSync(distFile, "#!/usr/bin/env bun\nconsole.log('hello');");
+		chmodSync(distFile, 0o644);
+
+		runFixShebang();
+
+		const stats = statSync(distFile);
+		const mode = stats.mode & 0o777;
+		expect(mode).toBe(0o755);
+	});
+
+	it("should remove @bun comment", () => {
+		writeFileSync(distFile, "#!/usr/bin/env bun\n// @bun\nconst x = 1;");
+
+		runFixShebang();
+
+		const result = readFileSync(distFile, "utf-8");
+		expect(result).not.toContain("// @bun");
+		expect(result).toContain("const x = 1;");
+	});
+});


### PR DESCRIPTION
## Summary
Closes #1072

## Changes
- Improved `link-crawler/scripts/fix-shebang.js`:
  - Added fallback to insert `#!/usr/bin/env node` when no shebang exists in build output
  - Added `chmod +x` to ensure `dist/crawl.js` is always executable
  - Extracted shebang string to constant for maintainability
- Added unit tests for fix-shebang.js (5 test cases covering shebang replacement, addition, preservation, chmod, and @bun comment removal)

## Testing
- `bun run build` completes without errors
- `dist/crawl.js` has correct shebang (`#!/usr/bin/env node`) and executable permissions
- All 880 tests pass including 5 new fix-shebang tests
- Biome lint/format checks pass