### PR TITLE
docs: verify coverage directory is already untracked #1069

### DIFF
--- a/docs/decisions/007-coverage-already-untracked.md
+++ b/docs/decisions/007-coverage-already-untracked.md
@@ -1,0 +1,54 @@
+# 001: Coverage Directory Already Untracked (2026-02-09)
+
+## 問題
+
+Issue #1069 で `link-crawler/coverage/coverage-summary.json` がGitに追跡されていると報告された。
+
+## 調査結果
+
+### Git追跡状態の確認
+
+```bash
+$ git ls-files link-crawler/coverage/
+# 結果: 出力なし（追跡されていない）
+
+$ git log --all --full-history -- "link-crawler/coverage/*"
+# 結果: 履歴なし（過去にも追跡されていない）
+```
+
+### .gitignore設定の確認
+
+- `link-crawler/.gitignore`: `coverage/` を含む
+- ルート `.gitignore`: `**/coverage/` を含む
+
+### テストによる検証
+
+```bash
+$ cd link-crawler && bun run test --coverage
+# カバレッジが正常に生成される
+# git status: "nothing to commit, working tree clean"
+# coverageディレクトリは正しく無視されている
+```
+
+## 結論
+
+**Issueの完了条件は既に満たされている**:
+- ✅ `git ls-files link-crawler/coverage/` が空である
+- ✅ `.gitignore` で `coverage/` が適切に除外されている
+
+## 原因
+
+このIssueは以下のいずれかの理由で作成された可能性がある:
+
+1. プロジェクトレビューツールがディスク上に存在するcoverageディレクトリを検出した
+2. Git追跡状態を正しく確認せず、物理的な存在だけで判断した
+3. 他のブランチでの状態を基に作成された
+
+## 対応
+
+コード変更は不要。このドキュメントで調査結果を記録し、Issueをクローズする。
+
+## 参考
+
+- Issue: #1069
+- 調査日: 2026-02-09

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -18,6 +18,7 @@ NNN-問題名.md
 | [004](004-issue-965-duplicate.md) | Issue #965 は Issue #961 と重複 | 解決済み |
 | [005](005-issue-581-unreachable-code.md) | extractor.ts ブランチカバレッジ改善 | 解決済み |
 | [006](006-skill-output-directory.md) | スキル実行時の出力ディレクトリ問題 | 有効 |
+| [007](007-coverage-already-untracked.md) | カバレッジディレクトリは既に未追跡 | 解決済み |
 
 ## 記録すべき内容
 


### PR DESCRIPTION
## 概要

Issue #1069 で報告された問題を調査した結果、カバレッジディレクトリは既にGitに追跡されていないことが確認されました。

## 調査結果

### 確認事項
- ✅ `git ls-files link-crawler/coverage/` → 空（追跡されていない）
- ✅ `.gitignore` で `coverage/` が適切に除外されている
- ✅ テスト実行でカバレッジが生成され、正しく無視される

### 結論

Issueの完了条件は既に満たされている。コード変更は不要。

## 変更内容

- 📄 `docs/decisions/007-coverage-already-untracked.md` - 調査結果の記録
- 📄 `docs/decisions/README.md` - インデックス更新

Closes #1069