### PR TITLE
refactor: matchWildcard の先頭ワイルドカードパターン処理の意図を明確化

### DIFF
--- a/link-crawler/src/crawler/robots.ts
+++ b/link-crawler/src/crawler/robots.ts
@@ -185,7 +185,10 @@ export class RobotsChecker {
 			const isFirstSegment = i === 0;
 			const isLastSegment = i === segments.length - 1;
 
-			// 空のセグメントはスキップ（連続する ** の場合など）
+			// 空のセグメントはスキップ
+			// - パターンが * で始まる場合: 先頭セグメントが空文字列となり、
+			//   isFirstSegment の前方一致チェックが不要になる（意図通り）
+			// - 連続する ** の場合: 中間の空セグメントをスキップ
 			if (segment.length === 0) {
 				continue;
 			}

--- a/link-crawler/tests/unit/robots.test.ts
+++ b/link-crawler/tests/unit/robots.test.ts
@@ -274,6 +274,33 @@ Disallow: */private
 				expect(checker.isAllowed("https://example.com/docs/private")).toBe(false);
 				expect(checker.isAllowed("https://example.com/public")).toBe(true);
 			});
+
+			it("should handle wildcard at the beginning with exact end", () => {
+				const robotsTxt = `
+User-agent: *
+Disallow: *.pdf$
+				`.trim();
+
+				const checker = new RobotsChecker(robotsTxt);
+				// * で始まるパターン: 先頭の前方一致チェックをスキップし、任意位置でマッチ
+				expect(checker.isAllowed("https://example.com/doc.pdf")).toBe(false);
+				expect(checker.isAllowed("https://example.com/a/b/c.pdf")).toBe(false);
+				expect(checker.isAllowed("https://example.com/doc.txt")).toBe(true);
+				expect(checker.isAllowed("https://example.com/doc.pdf.bak")).toBe(true);
+			});
+
+			it("should handle wildcard-only at the beginning (no prefix match required)", () => {
+				const robotsTxt = `
+User-agent: *
+Disallow: */api/*/internal
+				`.trim();
+
+				const checker = new RobotsChecker(robotsTxt);
+				// * で始まるパターン: パスの任意位置から /api/*/internal にマッチ
+				expect(checker.isAllowed("https://example.com/api/v1/internal")).toBe(false);
+				expect(checker.isAllowed("https://example.com/prefix/api/v2/internal")).toBe(false);
+				expect(checker.isAllowed("https://example.com/api/v1/public")).toBe(true);
+			});
 		});
 
 		describe("End-of-line ($) patterns", () => {


### PR DESCRIPTION
## 概要

`RobotsChecker.matchWildcard()` で `*` で始まるパターンの処理意図をコメントで明確化し、テストケースを追加。

## 変更内容

- `link-crawler/src/crawler/robots.ts`: 空セグメントスキップのコメントを改善し、`*` で始まるパターンの動作意図を明示
- `link-crawler/tests/unit/robots.test.ts`: `*` で始まるパターンのテストケースを2件追加

## テスト結果

`bun run test robots` - 全45テストパス

Closes #1080