### PR TITLE
docs: clarify package name vs command name in design.md tech stack

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -34,7 +34,7 @@
 | Linter/Formatter | Biome | 高速、設定シンプル |
 | Test Framework | Vitest | 高速、ESM対応、Bun互換 |
 | CLI Parser | Commander | 軽量、標準的 |
-| Browser | playwright-cli | SPA完全対応、セッション管理 |
+| Browser | @playwright/cli (playwright-cli) | SPA完全対応、セッション管理 |
 | DOM Parser | JSDOM | Node.js標準的なDOM実装 |
 | Content Extractor | @mozilla/readability | Firefox由来、高品質 |
 | Markdown Converter | Turndown | GFM対応、カスタマイズ可能 |


### PR DESCRIPTION
## 概要

`docs/design.md` の技術スタック表において、Browser欄のパッケージ名を明確化しました。

## 変更内容

| Before | After |
|--------|-------|
| `playwright-cli` | `@playwright/cli (playwright-cli)` |

## 理由

- npmパッケージ名: `@playwright/cli`
- コマンド名: `playwright-cli`

両者を明確に区別することで、初期セットアップ時の混乱を防ぎます。

## 整合性確認

他のドキュメントでは既に `@playwright/cli` と正しく記載されていることを確認:
- `docs/cli-spec.md` ✓
- `link-crawler/SKILL.md` ✓  
- `link-crawler/README.md` ✓

Closes #1079