### PR TITLE
docs: document that issue #1077 was already resolved by PR #1065/#1067

### DIFF
--- a/docs/decisions/008-issue-1077-already-resolved.md
+++ b/docs/decisions/008-issue-1077-already-resolved.md
@@ -1,0 +1,95 @@
+# 008: Issue #1077 Already Resolved (2026-02-09)
+
+## 問題
+
+Issue #1077 で報告された Biome lint/format エラー20件の修正が必要とされた。
+
+## 調査結果
+
+### Issue #1077 作成時点の状態
+- **エラー数**: 20件
+- **影響ファイル**:
+  - `tests/unit/config.test.ts` (3件のフォーマットエラー)
+  - `tests/unit/post-processor.test.ts` (3件: import順序 + フォーマット)
+  - `tests/unit/writer-finalize-errors.test.ts` (14件: any型エラー + フォーマット)
+  - `tests/unit/writer.test.ts` (1件のフォーマットエラー)
+
+### 現在の状態（2026-02-09時点）
+```bash
+$ cd link-crawler && bun run check
+Checked 56 files in 32ms. No fixes applied.
+# エラー0件
+```
+
+### 解決された経緯
+
+以下のPRで既に修正済み：
+
+1. **PR #1065**: "fix: Biome フォーマット違反とlint違反の修正"
+   - コミット: a6b1f43
+   - マージ先: main
+
+2. **PR #1067**: "fix: Biome lint violations in test files"
+   - コミット: e41f2e3
+   - マージ先: main
+
+### 修正内容
+
+#### tests/unit/config.test.ts
+- 長い関数呼び出しを複数行に分割
+
+#### tests/unit/post-processor.test.ts
+- import順序を修正（`readdirSync, readFileSync` → `readFileSync, readdirSync`）
+- 長い配列要素を複数行に分割
+
+#### tests/unit/writer-finalize-errors.test.ts
+- `any`型を具体的な型定義に置き換え:
+  - `RenameSyncFn`, `RmSyncFn`, `ExistsSyncFn`, `MkdirSyncFn`, `ReaddirSyncFn`
+- フォーマット修正
+
+#### tests/unit/writer.test.ts
+- 長い関数呼び出しを複数行に分割
+
+## 検証
+
+### Lint/Formatチェック
+```bash
+$ cd link-crawler && bun run check
+Checked 56 files in 32ms. No fixes applied.
+# ✅ エラー0件
+```
+
+### TypeScriptチェック
+```bash
+$ cd link-crawler && bun run typecheck
+# ✅ エラーなし
+```
+
+### テスト実行
+```bash
+$ cd link-crawler && bun run test
+Test Files  29 passed (29)
+Tests  882 passed (882)
+Duration  33.52s
+# ✅ 全テストパス
+```
+
+## 結論
+
+**Issue #1077 の完了条件は既に満たされている**:
+- ✅ `bun run check` でエラー0件
+- ✅ `bun run typecheck` でエラーなし
+- ✅ `bun run test` で全テストパス
+
+## 対応
+
+コード変更は不要。このドキュメントで調査結果を記録し、Issueを重複として記録する。
+
+## 参考
+
+- Issue: #1077
+- 関連PR:
+  - #1065 (a6b1f43)
+  - #1067 (e41f2e3)
+- 調査日: 2026-02-09
+- 調査時点のmainブランチ: 0f1d241

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -19,6 +19,7 @@ NNN-問題名.md
 | [005](005-issue-581-unreachable-code.md) | extractor.ts ブランチカバレッジ改善 | 解決済み |
 | [006](006-skill-output-directory.md) | スキル実行時の出力ディレクトリ問題 | 有効 |
 | [007](007-coverage-already-untracked.md) | カバレッジディレクトリは既に未追跡 | 解決済み |
+| [008](008-issue-1077-already-resolved.md) | Issue #1077 は PR #1065/#1067 で解決済み | 解決済み |
 
 ## 記録すべき内容
 


### PR DESCRIPTION
## 概要

Issue #1077 で報告された Biome lint/format エラー20件は、PR #1065 と #1067 で既に修正済みであることを確認し、ドキュメント化しました。

## 調査結果

### Issue #1077 作成時点の状態
- **エラー数**: 20件
- **影響ファイル**:
  - `tests/unit/config.test.ts` (3件のフォーマットエラー)
  - `tests/unit/post-processor.test.ts` (3件: import順序 + フォーマット)
  - `tests/unit/writer-finalize-errors.test.ts` (14件: any型エラー + フォーマット)
  - `tests/unit/writer.test.ts` (1件のフォーマットエラー)

### 現在の状態（2026-02-09時点）
```bash
$ cd link-crawler && bun run check
Checked 56 files in 32ms. No fixes applied.
# ✅ エラー0件
```

### 解決された経緯

以下のPRで既に修正済み：

1. **PR #1065**: "fix: Biome フォーマット違反とlint違反の修正"
   - コミット: a6b1f43
   - マージ先: main

2. **PR #1067**: "fix: Biome lint violations in test files"
   - コミット: e41f2e3
   - マージ先: main

## 検証結果

✅ **Lint/Formatチェック**
```bash
$ cd link-crawler && bun run check
Checked 56 files in 32ms. No fixes applied.
```

✅ **TypeScriptチェック**
```bash
$ cd link-crawler && bun run typecheck
# エラーなし
```

✅ **テスト実行**
```bash
$ cd link-crawler && bun run test
Test Files  29 passed (29)
Tests  882 passed (882)
Duration  33.52s
```

## 変更内容

- 新規ドキュメント: `docs/decisions/008-issue-1077-already-resolved.md`
- 更新: `docs/decisions/README.md` (エントリ追加)

## 完了条件

- ✅ `bun run check` でエラー0件
- ✅ `bun run typecheck` でエラーなし
- ✅ `bun run test` で全テストパス

Closes #1077