### PR TITLE
refactor: JSDOM インスタンスの明示的クリーンアップ追加（メモリリーク防止）

### DIFF
--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -350,14 +350,18 @@ export class Crawler {
 		// 1. JSDOM生成
 		const dom = new JSDOM(html, { url });
 
-		// 2. ページ解析
-		const parsed = this.parsePage(url, dom, depth);
+		try {
+			// 2. ページ解析
+			const parsed = this.parsePage(url, dom, depth);
 
-		// 3. 保存処理
-		this.processAndSavePage(url, parsed, depth);
+			// 3. 保存処理
+			this.processAndSavePage(url, parsed, depth);
 
-		// 4. 再帰クロール
-		await this.crawlLinks(parsed.links, depth);
+			// 4. 再帰クロール
+			await this.crawlLinks(parsed.links, depth);
+		} finally {
+			dom.window.close();
+		}
 	}
 
 	/** ページ解析: メタデータ・リンク・コンテンツの抽出と変換 */


### PR DESCRIPTION
## 概要

`processHtmlPage` メソッドで生成される JSDOM インスタンスに対し、`dom.window.close()` を明示的に呼び出すよう修正。try-finally パターンで確実にクリーンアップされるようにした。

## 変更内容

- `link-crawler/src/crawler/index.ts`: `processHtmlPage` に try-finally を追加し、`dom.window.close()` でイベントリスナーやタイマーをクリーンアップ

## テスト結果

- 型チェック: ✅ エラー0件
- テスト: ✅ 893テスト全パス

Closes #1087