### PR TITLE
chore: package.json に files フィールドを追加（npm publish 準備）

### DIFF
--- a/link-crawler/package.json
+++ b/link-crawler/package.json
@@ -53,5 +53,10 @@
 	},
 	"engines": {
 		"node": ">=18.0.0"
-	}
+	},
+	"files": [
+		"dist",
+		"README.md",
+		"SKILL.md"
+	]
 }

--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -553,10 +553,7 @@ describe("OutputWriter", () => {
 
 		it("should return null for non-spec URLs", () => {
 			const writer = new OutputWriter({ ...defaultConfig });
-			const result = writer.handleSpec(
-				"https://example.com/regular-page.html",
-				"<html></html>",
-			);
+			const result = writer.handleSpec("https://example.com/regular-page.html", "<html></html>");
 			expect(result).toBeNull();
 		});
 	});


### PR DESCRIPTION
## 概要

`link-crawler/package.json` に `files` フィールドを追加し、npm publish 時に不要なファイルが含まれないように設定しました。

## 変更内容

### package.json
- `files` フィールドを追加:
  - `dist/` - ビルド済みJavaScript（bin/crawl.js含む）
  - `README.md` - パッケージドキュメント
  - `SKILL.md` - piスキル定義

### 除外されるファイル
- `tests/` - テストコード
- `vitest.config.ts`, `biome.json`, `tsconfig.json` - 設定ファイル
- `src/` - TypeScriptソースコード（ビルド後は不要）
- `install.sh` - 開発用スクリプト

## 検証結果

### npm pack --dry-run
```
npm notice 📦  link-crawler@2.0.0
npm notice Tarball Contents
npm notice 4.1kB README.md
npm notice 4.4kB SKILL.md
npm notice 8.8MB dist/crawl.js
npm notice 1.5kB package.json
npm notice package size: 1.3 MB
npm notice unpacked size: 8.8 MB
npm notice total files: 4
```

✅ 不要なファイルが除外され、必要なファイルのみが含まれることを確認

### テスト
- ✅ 全テストパス (893 tests)
- ✅ Biome lint/format チェックパス
- ✅ TypeScript型チェックパス

## 効果

- npm パッケージサイズの最適化
- ユーザーのダウンロードデータ量削減
- パッケージの品質向上（開発用ファイルの除外）

Closes #1088