### PR TITLE
refactor: extract cleanupTestDirectories to shared test-utils.ts

### DIFF
--- a/link-crawler/tests/global-setup.ts
+++ b/link-crawler/tests/global-setup.ts
@@ -1,27 +1,5 @@
-import { readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
-
-/**
- * Clean up test directories matching the given pattern in the specified directory
- */
-function cleanupTestDirectories(
-	baseDir: string,
-	pattern: (entry: string) => boolean,
-	relativePath: string,
-) {
-	try {
-		const entries = readdirSync(baseDir);
-		for (const entry of entries) {
-			if (pattern(entry)) {
-				const fullPath = join(baseDir, entry);
-				rmSync(fullPath, { recursive: true, force: true });
-				console.log(`✓ Cleaned up (pre-test): ${relativePath}${entry}`);
-			}
-		}
-	} catch (error) {
-		console.warn(`Warning: Failed to clean up in ${relativePath}`, error);
-	}
-}
+import { cleanupTestDirectories } from "./test-utils.js";
 
 export default async function globalSetup() {
 	const linkCrawlerDir = join(import.meta.dirname, "..");
@@ -29,12 +7,22 @@ export default async function globalSetup() {
 	console.log("🧹 Cleaning up old test directories before running tests...");
 
 	// Clean up test-output-* directories in link-crawler root
-	cleanupTestDirectories(linkCrawlerDir, (entry) => entry.startsWith("test-output-"), "");
+	cleanupTestDirectories(
+		linkCrawlerDir,
+		(entry) => entry.startsWith("test-output-"),
+		"",
+		"Cleaned up (pre-test)",
+	);
 
 	const testsUnitDir = join(linkCrawlerDir, "tests", "unit");
 
 	// Clean up all .test-* directories in tests/unit
-	cleanupTestDirectories(testsUnitDir, (entry) => entry.startsWith(".test-"), "tests/unit/");
+	cleanupTestDirectories(
+		testsUnitDir,
+		(entry) => entry.startsWith(".test-"),
+		"tests/unit/",
+		"Cleaned up (pre-test)",
+	);
 
 	// Clean up .test-output-* directories in tests/integration
 	const integrationDir = join(linkCrawlerDir, "tests", "integration");
@@ -42,5 +30,6 @@ export default async function globalSetup() {
 		integrationDir,
 		(entry) => entry.startsWith(".test-output-"),
 		"tests/integration/",
+		"Cleaned up (pre-test)",
 	);
 }

--- a/link-crawler/tests/global-teardown.ts
+++ b/link-crawler/tests/global-teardown.ts
@@ -1,27 +1,5 @@
-import { readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
-
-/**
- * Clean up test directories matching the given pattern in the specified directory
- */
-function cleanupTestDirectories(
-	baseDir: string,
-	pattern: (entry: string) => boolean,
-	relativePath: string,
-) {
-	try {
-		const entries = readdirSync(baseDir);
-		for (const entry of entries) {
-			if (pattern(entry)) {
-				const fullPath = join(baseDir, entry);
-				rmSync(fullPath, { recursive: true, force: true });
-				console.log(`✓ Cleaned up: ${relativePath}${entry}`);
-			}
-		}
-	} catch (error) {
-		console.warn(`Warning: Failed to clean up in ${relativePath}`, error);
-	}
-}
+import { cleanupTestDirectories } from "./test-utils.js";
 
 export default async function globalTeardown() {
 	const linkCrawlerDir = join(import.meta.dirname, "..");

--- a/link-crawler/tests/test-utils.ts
+++ b/link-crawler/tests/test-utils.ts
@@ -1,0 +1,25 @@
+import { readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Clean up test directories matching the given pattern in the specified directory
+ */
+export function cleanupTestDirectories(
+	baseDir: string,
+	pattern: (entry: string) => boolean,
+	relativePath: string,
+	logPrefix = "Cleaned up",
+) {
+	try {
+		const entries = readdirSync(baseDir);
+		for (const entry of entries) {
+			if (pattern(entry)) {
+				const fullPath = join(baseDir, entry);
+				rmSync(fullPath, { recursive: true, force: true });
+				console.log(`✓ ${logPrefix}: ${relativePath}${entry}`);
+			}
+		}
+	} catch (error) {
+		console.warn(`Warning: Failed to clean up in ${relativePath}`, error);
+	}
+}


### PR DESCRIPTION
## Summary

Extract duplicated `cleanupTestDirectories` function from `tests/global-setup.ts` and `tests/global-teardown.ts` into a shared `tests/test-utils.ts` module.

### Changes
- **New**: `link-crawler/tests/test-utils.ts` - shared utility with `cleanupTestDirectories` function
- **Modified**: `global-setup.ts` and `global-teardown.ts` - import from `test-utils.ts` instead of local definition
- Added `logPrefix` parameter for customizable log messages (default: `"Cleaned up"`)

### Verification
- ✅ All 893 tests pass (`bun run test`)
- ✅ Lint clean (`bun run check` - 0 errors)

Closes #1093