### PR TITLE
chore: add scripts/**/*.js to Biome lint scope

### DIFF
--- a/link-crawler/biome.json
+++ b/link-crawler/biome.json
@@ -7,7 +7,13 @@
 		"useIgnoreFile": true
 	},
 	"files": {
-		"includes": ["src/**/*.ts", "tests/**/*.ts", "!**/node_modules/**/*", "!dist/**/*"],
+		"includes": [
+			"src/**/*.ts",
+			"tests/**/*.ts",
+			"scripts/**/*.js",
+			"!**/node_modules/**/*",
+			"!dist/**/*"
+		],
 		"ignoreUnknown": true
 	},
 	"linter": {


### PR DESCRIPTION
## 概要

scripts/fix-shebang.js を Biome の lint スコープに追加し、コード品質チェックのカバレッジギャップを修正しました。

## 変更内容

- `link-crawler/biome.json` の `files.includes` に `scripts/**/*.js` を追加
- scripts/fix-shebang.js が Biome の lint/format チェック対象に含まれるようになりました

## 検証結果

✅ `npx biome check scripts/fix-shebang.js` - ファイルがチェック対象に含まれることを確認
✅ `bun run check` - 57ファイルチェック完了、エラーなし
✅ `bun run typecheck` - TypeScript エラーなし
✅ `bun run test` - 893テスト全てパス

## 影響範囲

- プロジェクトレベルの静的解析設定のみ
- 既存コードの動作には影響なし

Closes #1094