### PR TITLE
fix: add .tmp-* to .gitignore and global cleanup

### DIFF
--- a/link-crawler/.gitignore
+++ b/link-crawler/.gitignore
@@ -9,6 +9,7 @@ coverage/
 test-output*/
 .test-output*/
 .test-*/
+.tmp-*/
 
 # Playwright CLI cache
 .playwright-cli/

--- a/link-crawler/tests/global-setup.ts
+++ b/link-crawler/tests/global-setup.ts
@@ -14,6 +14,14 @@ export default async function globalSetup() {
 		"Cleaned up (pre-test)",
 	);
 
+	// Clean up .tmp-* directories in link-crawler root
+	cleanupTestDirectories(
+		linkCrawlerDir,
+		(entry) => entry.startsWith(".tmp-"),
+		"",
+		"Cleaned up (pre-test)",
+	);
+
 	const testsUnitDir = join(linkCrawlerDir, "tests", "unit");
 
 	// Clean up all .test-* directories in tests/unit

--- a/link-crawler/tests/global-teardown.ts
+++ b/link-crawler/tests/global-teardown.ts
@@ -7,6 +7,9 @@ export default async function globalTeardown() {
 	// Clean up test-output-* directories in link-crawler root
 	cleanupTestDirectories(linkCrawlerDir, (entry) => entry.startsWith("test-output-"), "");
 
+	// Clean up .tmp-* directories in link-crawler root
+	cleanupTestDirectories(linkCrawlerDir, (entry) => entry.startsWith(".tmp-"), "");
+
 	const testsUnitDir = join(linkCrawlerDir, "tests", "unit");
 
 	// Clean up all .test-* directories in tests/unit


### PR DESCRIPTION
## Summary

`.tmp-fix-shebang-test` ディレクトリを `.gitignore` と global setup/teardown のクリーンアップ対象に追加。

## Changes

- `link-crawler/.gitignore`: `.tmp-*/` パターン追加
- `link-crawler/tests/global-setup.ts`: `.tmp-*` クリーンアップ追加
- `link-crawler/tests/global-teardown.ts`: `.tmp-*` クリーンアップ追加

## Testing

- All 893 tests pass
- `.gitignore` パターンが正しく動作することを確認

Closes #1097