### PR TITLE
docs: add tests/test-utils.ts to project structure

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -70,6 +70,7 @@ link-crawler/
 ├── tests/                       # テストファイル
 │   ├── global-setup.ts          # テスト全体のセットアップ
 │   ├── global-teardown.ts       # テスト全体のクリーンアップ
+│   ├── test-utils.ts            # テスト共通ユーティリティ
 │   ├── unit/                    # ユニットテスト
 │   │   ├── chunker.test.ts
 │   │   ├── cli-options.test.ts


### PR DESCRIPTION
Closes #1098

## 概要
`tests/test-utils.ts` が `docs/development.md` のプロジェクト構成セクションに記載されていなかったため追加しました。

## 変更内容
- `docs/development.md` のセクション2「プロジェクト構成」に `tests/test-utils.ts` を追加

## 検証
- ファイルの存在確認: ✓
- 全テスト実行: ✓ (893 tests passed)

## 関連Issue
#1098