### PR TITLE
fix: rename .tmp-fix-shebang-test to .test-fix-shebang-tmp for consistency

### DIFF
--- a/link-crawler/tests/global-setup.ts
+++ b/link-crawler/tests/global-setup.ts
@@ -22,6 +22,14 @@ export default async function globalSetup() {
 		"Cleaned up (pre-test)",
 	);
 
+	// Clean up .test-* directories in link-crawler root (e.g. .test-fix-shebang-tmp)
+	cleanupTestDirectories(
+		linkCrawlerDir,
+		(entry) => entry.startsWith(".test-"),
+		"",
+		"Cleaned up (pre-test)",
+	);
+
 	const testsUnitDir = join(linkCrawlerDir, "tests", "unit");
 
 	// Clean up all .test-* directories in tests/unit

--- a/link-crawler/tests/global-teardown.ts
+++ b/link-crawler/tests/global-teardown.ts
@@ -10,6 +10,9 @@ export default async function globalTeardown() {
 	// Clean up .tmp-* directories in link-crawler root
 	cleanupTestDirectories(linkCrawlerDir, (entry) => entry.startsWith(".tmp-"), "");
 
+	// Clean up .test-* directories in link-crawler root (e.g. .test-fix-shebang-tmp)
+	cleanupTestDirectories(linkCrawlerDir, (entry) => entry.startsWith(".test-"), "");
+
 	const testsUnitDir = join(linkCrawlerDir, "tests", "unit");
 
 	// Clean up all .test-* directories in tests/unit

--- a/link-crawler/tests/unit/fix-shebang.test.ts
+++ b/link-crawler/tests/unit/fix-shebang.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("fix-shebang.js", () => {
-	const tmpDir = join(import.meta.dirname, "../../.tmp-fix-shebang-test");
+	const tmpDir = join(import.meta.dirname, "../../.test-fix-shebang-tmp");
 	const distDir = join(tmpDir, "dist");
 	const distFile = join(distDir, "crawl.js");
 	const scriptsDir = join(tmpDir, "scripts");


### PR DESCRIPTION
## Summary

Rename temp directory in `fix-shebang.test.ts` from `.tmp-fix-shebang-test` to `.test-fix-shebang-tmp` to match the existing `.test-*/` gitignore pattern and cleanup conventions.

## Changes

- `tests/unit/fix-shebang.test.ts`: Renamed temp dir to `.test-*` prefix
- `tests/global-setup.ts`: Added `.test-*` cleanup at link-crawler root level
- `tests/global-teardown.ts`: Added `.test-*` cleanup at link-crawler root level

## Verification

- All 893 tests pass
- `biome check` clean
- `.test-*` pattern correctly gitignored

Closes #1101