### PR TITLE
fix: decode numeric HTML entities in getTextWithoutLineNumbers

### DIFF
--- a/link-crawler/src/parser/converter.ts
+++ b/link-crawler/src/parser/converter.ts
@@ -153,16 +153,22 @@ function getTextWithoutLineNumbers(el: Element): string {
 	// 行区切り要素（div.line など）の閉じタグを改行に変換
 	html = html.replace(/<\/div>/gi, "\n");
 	// 残りのタグを除去して textContent 相当を取得
-	return html
-		.replace(/<[^>]+>/g, "")
-		.replace(/&amp;/g, "&")
-		.replace(/&lt;/g, "<")
-		.replace(/&gt;/g, ">")
-		.replace(/&quot;/g, '"')
-		.replace(/&#39;/g, "'")
-		.replace(/&nbsp;/g, " ")
-		.replace(/\n{2,}/g, "\n") // 連続改行を1つに
-		.trim();
+	return (
+		html
+			.replace(/<[^>]+>/g, "")
+			// 数値エンティティの汎用デコード（名前付きエンティティより前に処理）
+			.replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+			.replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
+			// 名前付きエンティティのデコード
+			.replace(/&amp;/g, "&")
+			.replace(/&lt;/g, "<")
+			.replace(/&gt;/g, ">")
+			.replace(/&quot;/g, '"')
+			.replace(/&#39;/g, "'")
+			.replace(/&nbsp;/g, " ")
+			.replace(/\n{2,}/g, "\n") // 連続改行を1つに
+			.trim()
+	);
 }
 
 /** コード要素から実際のコード内容を抽出（行番号を除去） */

--- a/link-crawler/tests/unit/converter.test.ts
+++ b/link-crawler/tests/unit/converter.test.ts
@@ -462,4 +462,37 @@ describe("htmlToMarkdown - syntax highlighter support", () => {
 		expect(result).toContain('console.log("hello");');
 		expect(result).not.toContain("1console");
 	});
+
+	it("should decode decimal numeric HTML entities in code blocks with line numbers", () => {
+		const html = `
+			<pre><code class="torchlight">
+				<div class="line"><span class="line-number">1</span><span>if (a &#60; b &#38;&#38; c &#62; d) &#123;</span></div>
+				<div class="line"><span class="line-number">2</span><span>    return &#34;hello&#34;;</span></div>
+				<div class="line"><span class="line-number">3</span><span>&#125;</span></div>
+			</code></pre>
+		`;
+		const result = htmlToMarkdown(html);
+
+		expect(result).toContain("if (a < b && c > d) {");
+		expect(result).toContain('return "hello";');
+		expect(result).toContain("}");
+		expect(result).not.toContain("&#60;");
+		expect(result).not.toContain("&#123;");
+		expect(result).not.toContain("&#125;");
+	});
+
+	it("should decode hexadecimal numeric HTML entities in code blocks with line numbers", () => {
+		const html = `
+			<pre><code class="torchlight">
+				<div class="line"><span class="line-number">1</span><span>const obj = &#x7B; key: &#x22;value&#x22; &#x7D;;</span></div>
+				<div class="line"><span class="line-number">2</span><span>if (x &#x3C; 10) &#x7B; return; &#x7D;</span></div>
+			</code></pre>
+		`;
+		const result = htmlToMarkdown(html);
+
+		expect(result).toContain('const obj = { key: "value" };');
+		expect(result).toContain("if (x < 10) { return; }");
+		expect(result).not.toContain("&#x7B;");
+		expect(result).not.toContain("&#x3C;");
+	});
 });


### PR DESCRIPTION
## Summary

`getTextWithoutLineNumbers` in `converter.ts` only decoded 6 named HTML entities. Numeric entities (`&#60;`, `&#x3C;`, `&#123;`, etc.) were left unresolved, causing raw entity strings to appear in code blocks from sites using Torchlight, highlight.js, etc.

## Changes

- Added generic decoding for decimal (`&#NNN;`) and hexadecimal (`&#xHHH;`) numeric entities
- Numeric entity decoding runs before named entity decoding (order matters for `&amp;`)
- Added test cases for both decimal and hex numeric entities

## Testing

- All 895 tests pass
- `bun run check` clean (0 errors)

Closes #1102