### PR TITLE
refactor: config.ts で DEFAULTS.OUTPUT_DIR 定数を使用する

### DIFF
--- a/link-crawler/src/config.ts
+++ b/link-crawler/src/config.ts
@@ -66,7 +66,7 @@ export function parseConfig(
 	}
 
 	// Generate site-specific output directory if not specified
-	const defaultOutputDir = `./.context/${generateSiteName(startUrl)}`;
+	const defaultOutputDir = `${DEFAULTS.OUTPUT_DIR}/${generateSiteName(startUrl)}`;
 	const outputDir = String(options.output || defaultOutputDir);
 
 	// Parse depth value safely (handle 0 correctly)


### PR DESCRIPTION
## 概要

`config.ts` でデフォルト出力ディレクトリのベースパスが `./.context` とハードコードされていたのを、`constants.ts` で定義済みの `DEFAULTS.OUTPUT_DIR` 定数を使用するようリファクタリング。

## 変更内容

- `link-crawler/src/config.ts` (L69): ハードコード値 `./.context` を `DEFAULTS.OUTPUT_DIR` に置換

## 影響

- 動作に変更なし（値は同じ）
- SSOT (Single Source of Truth) 原則の遵守により、将来のメンテナンス性が向上

## テスト

- ✅ `bun run typecheck` パス
- ✅ `bun run check` パス
- ✅ `bun run test` 全パス (895 tests)
- ✅ 手動テスト: デフォルト出力先が `.context/example` になることを確認

Closes #1107