### PR TITLE
refactor: 未使用の public メソッド・インターフェースを削除

### DIFF
--- a/link-crawler/src/crawler/logger.ts
+++ b/link-crawler/src/crawler/logger.ts
@@ -43,16 +43,6 @@ export class CrawlLogger implements Logger {
 		}
 	}
 
-	/** 既存index.json読み込みログ */
-	logLoadedIndex(count: number): void {
-		console.log(`  📂 Loaded existing index.json: ${count} pages`);
-	}
-
-	/** index.json読み込み失敗ログ */
-	logIndexLoadFailed(): void {
-		console.log("  ⚠️ Failed to load existing index.json (will create new)");
-	}
-
 	/** index.json形式エラーログ */
 	logIndexFormatError(indexPath: string): void {
 		console.warn(`[WARN] Invalid index.json format at ${indexPath}`);
@@ -142,11 +132,6 @@ export class CrawlLogger implements Logger {
 		}
 		console.log(`   Specs: ${specsCount}`);
 		console.log(`   Index: ${indexPath}`);
-	}
-
-	/** スキップカウントを取得 */
-	getSkippedCount(): number {
-		return this.skippedCount;
 	}
 
 	/** 警告ログ */

--- a/link-crawler/src/diff/hasher.ts
+++ b/link-crawler/src/diff/hasher.ts
@@ -1,11 +1,5 @@
 import { createHash } from "node:crypto";
 
-/** ページハッシュマップ型 */
-export interface PageHash {
-	url: string;
-	hash: string;
-}
-
 /**
  * コンテンツのSHA256ハッシュを計算
  * @param content ハッシュ計算対象の文字列

--- a/link-crawler/src/diff/index.ts
+++ b/link-crawler/src/diff/index.ts
@@ -1,1 +1,1 @@
-export { computeHash, Hasher, type PageHash } from "./hasher.js";
+export { computeHash, Hasher } from "./hasher.js";

--- a/link-crawler/src/output/index-manager.ts
+++ b/link-crawler/src/output/index-manager.ts
@@ -103,13 +103,6 @@ export class IndexManager {
 	}
 
 	/**
-	 * 既存ページ数を取得
-	 */
-	getExistingPageCount(): number {
-		return this.existingPages.size;
-	}
-
-	/**
 	 * 次のページ番号を取得
 	 */
 	getNextPageNumber(): number {
@@ -214,19 +207,5 @@ export class IndexManager {
 		// totalPages を pages.length と同期
 		this.result.totalPages = this.result.pages.length;
 		return this.result;
-	}
-
-	/**
-	 * 登録済みページ数を取得
-	 */
-	getTotalPages(): number {
-		return this.result.pages.length;
-	}
-
-	/**
-	 * 登録済み仕様ファイル数を取得
-	 */
-	getSpecsCount(): number {
-		return this.result.specs.length;
 	}
 }

--- a/link-crawler/src/output/writer.ts
+++ b/link-crawler/src/output/writer.ts
@@ -82,11 +82,6 @@ export class OutputWriter {
 		mkdirSync(specsDir, { recursive: true });
 	}
 
-	/** 既存ページのハッシュを取得 */
-	getExistingHash(url: string): string | undefined {
-		return this.indexManager.getExistingHash(url);
-	}
-
 	/** API仕様ファイルを検出・保存 */
 	handleSpec(url: string, content: string): { type: string; filename: string } | null {
 		for (const [type, pattern] of Object.entries(SPEC_PATTERNS)) {

--- a/link-crawler/tests/unit/index-manager.test.ts
+++ b/link-crawler/tests/unit/index-manager.test.ts
@@ -34,8 +34,9 @@ describe("IndexManager", () => {
 				sameDomain: true,
 			});
 
-			expect(manager.getTotalPages()).toBe(0);
-			expect(manager.getSpecsCount()).toBe(0);
+			const result = manager.getResult();
+			expect(result.pages.length).toBe(0);
+			expect(result.specs.length).toBe(0);
 		});
 
 		it("should load existing index.json", async () => {
@@ -72,7 +73,7 @@ describe("IndexManager", () => {
 				sameDomain: true,
 			});
 
-			expect(manager.getExistingPageCount()).toBe(1);
+			expect(manager.getExistingHashes().size).toBe(1);
 			expect(manager.getExistingHash("https://example.com/page1")).toBe("abc123");
 		});
 	});
@@ -84,7 +85,7 @@ describe("IndexManager", () => {
 				sameDomain: true,
 			});
 
-			expect(manager.getExistingPageCount()).toBe(0);
+			expect(manager.getExistingHashes().size).toBe(0);
 			expect(manager.getExistingHash("https://example.com/unknown")).toBeUndefined();
 		});
 
@@ -104,7 +105,7 @@ describe("IndexManager", () => {
 				mockLogger,
 			);
 
-			expect(manager.getExistingPageCount()).toBe(0);
+			expect(manager.getExistingHashes().size).toBe(0);
 			expect(mockLogger.logIndexLoadError).toHaveBeenCalledTimes(1);
 			expect(mockLogger.logIndexLoadError).toHaveBeenCalledWith(expect.any(String));
 		});
@@ -125,7 +126,7 @@ describe("IndexManager", () => {
 				sameDomain: true,
 			});
 
-			expect(manager.getExistingPageCount()).toBe(0);
+			expect(manager.getExistingHashes().size).toBe(0);
 		});
 
 		it("should handle pages property not being an array", async () => {
@@ -152,7 +153,7 @@ describe("IndexManager", () => {
 				mockLogger,
 			);
 
-			expect(manager.getExistingPageCount()).toBe(0);
+			expect(manager.getExistingHashes().size).toBe(0);
 			expect(mockLogger.logIndexFormatError).toHaveBeenCalledWith(
 				expect.stringContaining(join(testDir, "index.json")),
 			);
@@ -181,7 +182,7 @@ describe("IndexManager", () => {
 				mockLogger,
 			);
 
-			expect(manager.getExistingPageCount()).toBe(0);
+			expect(manager.getExistingHashes().size).toBe(0);
 			expect(mockLogger.logIndexFormatError).toHaveBeenCalledWith(
 				expect.stringContaining(join(testDir, "index.json")),
 			);
@@ -203,7 +204,7 @@ describe("IndexManager", () => {
 				mockLogger,
 			);
 
-			expect(manager.getExistingPageCount()).toBe(0);
+			expect(manager.getExistingHashes().size).toBe(0);
 			expect(mockLogger.logIndexFormatError).toHaveBeenCalledWith(
 				expect.stringContaining(join(testDir, "index.json")),
 			);
@@ -225,7 +226,7 @@ describe("IndexManager", () => {
 				mockLogger,
 			);
 
-			expect(manager.getExistingPageCount()).toBe(0);
+			expect(manager.getExistingHashes().size).toBe(0);
 			expect(mockLogger.logIndexFormatError).toHaveBeenCalledWith(
 				expect.stringContaining(join(testDir, "index.json")),
 			);
@@ -455,40 +456,6 @@ describe("IndexManager", () => {
 		});
 	});
 
-	describe("getExistingPageCount", () => {
-		it("should return count of existing pages", async () => {
-			const indexData = {
-				crawledAt: "2025-01-01T00:00:00.000Z",
-				baseUrl: "https://example.com",
-				config: {},
-				totalPages: 3,
-				pages: [
-					{ url: "https://example.com/page1", hash: "hash1" },
-					{ url: "https://example.com/page2", hash: "hash2" },
-					{ url: "https://example.com/page3", hash: "hash3" },
-				],
-				specs: [],
-			};
-			writeFileSync(join(testDir, "index.json"), JSON.stringify(indexData));
-
-			const manager = new IndexManager(testDir, "https://example.com", {
-				maxDepth: 2,
-				sameDomain: true,
-			});
-
-			expect(manager.getExistingPageCount()).toBe(3);
-		});
-
-		it("should return 0 when no existing index", () => {
-			const manager = new IndexManager(testDir, "https://example.com", {
-				maxDepth: 2,
-				sameDomain: true,
-			});
-
-			expect(manager.getExistingPageCount()).toBe(0);
-		});
-	});
-
 	describe("getNextPageNumber", () => {
 		it("should return 1 for new manager", () => {
 			const manager = new IndexManager(testDir, "https://example.com", {
@@ -586,7 +553,7 @@ describe("IndexManager", () => {
 				ogType: null,
 			};
 
-			expect(manager.getTotalPages()).toBe(0);
+			expect(manager.getResult().pages.length).toBe(0);
 			manager.registerPage(
 				"https://example.com/page1",
 				"pages/page-001.md",
@@ -596,7 +563,7 @@ describe("IndexManager", () => {
 				"Page 1",
 				"hash1",
 			);
-			expect(manager.getTotalPages()).toBe(1);
+			expect(manager.getResult().pages.length).toBe(1);
 			manager.registerPage(
 				"https://example.com/page2",
 				"pages/page-002.md",
@@ -606,7 +573,7 @@ describe("IndexManager", () => {
 				"Page 2",
 				"hash2",
 			);
-			expect(manager.getTotalPages()).toBe(2);
+			expect(manager.getResult().pages.length).toBe(2);
 		});
 
 		it("should use metadata.title over title parameter when available", () => {
@@ -671,9 +638,9 @@ describe("IndexManager", () => {
 				sameDomain: true,
 			});
 
-			expect(manager.getSpecsCount()).toBe(0);
+			expect(manager.getResult().specs.length).toBe(0);
 			manager.addSpec("https://example.com/openapi.yaml", "openapi", "specs/openapi.yaml");
-			expect(manager.getSpecsCount()).toBe(1);
+			expect(manager.getResult().specs.length).toBe(1);
 		});
 
 		it("should add multiple specs", () => {
@@ -685,7 +652,7 @@ describe("IndexManager", () => {
 			manager.addSpec("https://example.com/openapi.yaml", "openapi", "specs/openapi.yaml");
 			manager.addSpec("https://example.com/schema.json", "jsonSchema", "specs/schema.json");
 
-			expect(manager.getSpecsCount()).toBe(2);
+			expect(manager.getResult().specs.length).toBe(2);
 		});
 	});
 

--- a/link-crawler/tests/unit/logger.test.ts
+++ b/link-crawler/tests/unit/logger.test.ts
@@ -107,17 +107,6 @@ describe("CrawlLogger", () => {
 			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("⏭️  Skipped (unchanged)"));
 		});
 
-		it("should increment skipped count when called", () => {
-			const logger = new CrawlLogger(baseConfig);
-			expect(logger.getSkippedCount()).toBe(0);
-
-			logger.logSkipped(0);
-			expect(logger.getSkippedCount()).toBe(1);
-
-			logger.logSkipped(1);
-			expect(logger.getSkippedCount()).toBe(2);
-		});
-
 		it("should use correct indentation for depth 1", () => {
 			const logger = new CrawlLogger(baseConfig);
 			logger.logSkipped(1);
@@ -192,21 +181,6 @@ describe("CrawlLogger", () => {
 		});
 	});
 
-	describe("getSkippedCount", () => {
-		it("should return 0 initially", () => {
-			const logger = new CrawlLogger(baseConfig);
-			expect(logger.getSkippedCount()).toBe(0);
-		});
-
-		it("should return correct count after multiple skips", () => {
-			const logger = new CrawlLogger(baseConfig);
-			logger.logSkipped(0);
-			logger.logSkipped(1);
-			logger.logSkipped(2);
-			expect(logger.getSkippedCount()).toBe(3);
-		});
-	});
-
 	describe("other log methods", () => {
 		it("should log loaded hashes when count > 0", () => {
 			const logger = new CrawlLogger(baseConfig);
@@ -222,24 +196,6 @@ describe("CrawlLogger", () => {
 			logger.logLoadedHashes(0);
 
 			expect(consoleLogSpy).not.toHaveBeenCalled();
-		});
-
-		it("should log loaded index", () => {
-			const logger = new CrawlLogger(baseConfig);
-			logger.logLoadedIndex(3);
-
-			expect(consoleLogSpy).toHaveBeenCalledWith(
-				expect.stringContaining("📂 Loaded existing index.json: 3 pages"),
-			);
-		});
-
-		it("should log index load failure", () => {
-			const logger = new CrawlLogger(baseConfig);
-			logger.logIndexLoadFailed();
-
-			expect(consoleLogSpy).toHaveBeenCalledWith(
-				expect.stringContaining("⚠️ Failed to load existing index.json"),
-			);
 		});
 
 		it("should log index format error", () => {

--- a/link-crawler/tests/unit/post-processor.test.ts
+++ b/link-crawler/tests/unit/post-processor.test.ts
@@ -63,8 +63,6 @@ describe("PostProcessor", () => {
 		mockLogger = {
 			logStart: vi.fn(),
 			logLoadedHashes: vi.fn(),
-			logLoadedIndex: vi.fn(),
-			logIndexLoadFailed: vi.fn(),
 			logCrawlStart: vi.fn(),
 			logPageSaved: vi.fn(),
 			logSkipped: vi.fn(),
@@ -77,7 +75,6 @@ describe("PostProcessor", () => {
 			logChunkerStart: vi.fn(),
 			logChunkerComplete: vi.fn(),
 			logComplete: vi.fn(),
-			getSkippedCount: vi.fn().mockReturnValue(0),
 			logDebug: vi.fn(),
 		} as unknown as CrawlLogger;
 	});

--- a/link-crawler/tests/unit/writer.test.ts
+++ b/link-crawler/tests/unit/writer.test.ts
@@ -95,43 +95,6 @@ describe("OutputWriter", () => {
 		expect(hash1).toBe(hash2);
 	});
 
-	it("should read existing index.json", () => {
-		// Create initial index.json
-		mkdirSync(join(testOutputDir, "pages"), { recursive: true });
-		mkdirSync(join(testOutputDir, "specs"), { recursive: true });
-
-		const existingResult: CrawlResult = {
-			crawledAt: "2026-01-01T00:00:00.000Z",
-			baseUrl: "https://example.com",
-			config: { maxDepth: 2, sameDomain: true },
-			totalPages: 1,
-			pages: [
-				{
-					url: "https://example.com/existing",
-					title: "Existing Page",
-					file: "pages/page-001.md",
-					depth: 0,
-					links: [],
-					metadata: defaultMetadata,
-					hash: "abc123",
-					crawledAt: "2026-01-01T00:00:00.000Z",
-				},
-			],
-			specs: [],
-		};
-
-		writeFileSync(join(testOutputDir, "index.json"), JSON.stringify(existingResult, null, 2));
-
-		// Create new writer in diff mode that should read existing index
-		const writer = new OutputWriter({ ...defaultConfig, diff: true });
-
-		const existingHash = writer.getExistingHash("https://example.com/existing");
-		expect(existingHash).toBe("abc123");
-
-		const nonExistingHash = writer.getExistingHash("https://example.com/new");
-		expect(nonExistingHash).toBeUndefined();
-	});
-
 	it("should save index.json with hash and crawledAt fields", () => {
 		const writer = new OutputWriter({ ...defaultConfig });
 		writer.savePage("https://example.com", "# Content", 0, [], defaultMetadata, "Title");


### PR DESCRIPTION
## Summary
Closes #1106

## Changes
- `PageHash` インターフェースを `hasher.ts` から削除、`diff/index.ts` の re-export も削除
- `OutputWriter.getExistingHash()` メソッドを削除
- `IndexManager` の未使用メソッド3つ (`getExistingPageCount`, `getTotalPages`, `getSpecsCount`) を削除
- `CrawlLogger` の未使用メソッド3つ (`logLoadedIndex`, `logIndexLoadFailed`, `getSkippedCount`) を削除
- テストコードの対応する参照箇所を修正（削除メソッドのテスト削除、mockLogger更新）

## Testing
- `bun x biome check .` — パス
- `bun x tsc --noEmit` — パス
- `bun x vitest run` — 29ファイル 887テスト全パス