### PR TITLE
refactor: 未使用の public メソッドを削除（Hasher.getHash, IndexManager.getExistingHash）

### DIFF
--- a/link-crawler/src/diff/hasher.ts
+++ b/link-crawler/src/diff/hasher.ts
@@ -38,15 +38,6 @@ export class Hasher {
 	}
 
 	/**
-	 * 既存のハッシュを取得
-	 * @param url 対象URL
-	 * @returns ハッシュ値、存在しなければundefined
-	 */
-	getHash(url: string): string | undefined {
-		return this.hashes.get(url);
-	}
-
-	/**
 	 * 読み込まれたハッシュの数を取得
 	 */
 	get size(): number {

--- a/link-crawler/src/output/index-manager.ts
+++ b/link-crawler/src/output/index-manager.ts
@@ -80,15 +80,6 @@ export class IndexManager {
 	}
 
 	/**
-	 * 既存ページのハッシュを取得
-	 * @param url 対象URL
-	 * @returns ハッシュ値、存在しなければundefined
-	 */
-	getExistingHash(url: string): string | undefined {
-		return this.existingPages.get(url)?.hash;
-	}
-
-	/**
 	 * 既存の全ハッシュを取得
 	 * @returns URL → ハッシュのMap
 	 */

--- a/link-crawler/tests/unit/hasher.test.ts
+++ b/link-crawler/tests/unit/hasher.test.ts
@@ -44,7 +44,6 @@ describe("Hasher", () => {
 		it("should initialize with empty map by default", () => {
 			const hasher = new Hasher();
 
-			expect(hasher.getHash("https://example.com/page1")).toBeUndefined();
 			expect(hasher.size).toBe(0);
 		});
 
@@ -55,8 +54,6 @@ describe("Hasher", () => {
 			]);
 			const hasher = new Hasher(hashes);
 
-			expect(hasher.getHash("https://example.com/page1")).toBe("abc123");
-			expect(hasher.getHash("https://example.com/page2")).toBe("def456");
 			expect(hasher.size).toBe(2);
 		});
 
@@ -68,7 +65,6 @@ describe("Hasher", () => {
 			hashes.set("https://example.com/page2", "def456");
 
 			// Hasher should not be affected
-			expect(hasher.getHash("https://example.com/page2")).toBeUndefined();
 			expect(hasher.size).toBe(1);
 		});
 	});
@@ -108,21 +104,6 @@ describe("Hasher", () => {
 			const result = hasher.isChanged("https://example.com/page1", "abc123");
 
 			expect(result).toBe(true);
-		});
-	});
-
-	describe("getHash", () => {
-		it("should return hash for existing URL", () => {
-			const hashes = new Map([["https://example.com/page1", "abc123"]]);
-			const hasher = new Hasher(hashes);
-
-			expect(hasher.getHash("https://example.com/page1")).toBe("abc123");
-		});
-
-		it("should return undefined for non-existing URL", () => {
-			const hasher = new Hasher();
-
-			expect(hasher.getHash("https://example.com/unknown")).toBeUndefined();
 		});
 	});
 

--- a/link-crawler/tests/unit/index-manager.test.ts
+++ b/link-crawler/tests/unit/index-manager.test.ts
@@ -74,7 +74,7 @@ describe("IndexManager", () => {
 			});
 
 			expect(manager.getExistingHashes().size).toBe(1);
-			expect(manager.getExistingHash("https://example.com/page1")).toBe("abc123");
+			expect(manager.getExistingHashes().get("https://example.com/page1")).toBe("abc123");
 		});
 	});
 
@@ -86,7 +86,6 @@ describe("IndexManager", () => {
 			});
 
 			expect(manager.getExistingHashes().size).toBe(0);
-			expect(manager.getExistingHash("https://example.com/unknown")).toBeUndefined();
 		});
 
 		it("should handle invalid JSON", async () => {
@@ -230,100 +229,6 @@ describe("IndexManager", () => {
 			expect(mockLogger.logIndexFormatError).toHaveBeenCalledWith(
 				expect.stringContaining(join(testDir, "index.json")),
 			);
-		});
-	});
-
-	describe("getExistingHash", () => {
-		it("should return hash for existing URL", async () => {
-			const indexData = {
-				crawledAt: "2025-01-01T00:00:00.000Z",
-				baseUrl: "https://example.com",
-				config: {},
-				totalPages: 2,
-				pages: [
-					{
-						url: "https://example.com/page1",
-						title: "Page 1",
-						file: "pages/page-001.md",
-						depth: 0,
-						links: [],
-						metadata: {
-							title: "Page 1",
-							description: null,
-							keywords: null,
-							author: null,
-							ogTitle: null,
-							ogType: null,
-						},
-						hash: "hash1",
-						crawledAt: "2025-01-01T00:00:00.000Z",
-					},
-					{
-						url: "https://example.com/page2",
-						title: "Page 2",
-						file: "pages/page-002.md",
-						depth: 1,
-						links: [],
-						metadata: {
-							title: "Page 2",
-							description: null,
-							keywords: null,
-							author: null,
-							ogTitle: null,
-							ogType: null,
-						},
-						hash: "hash2",
-						crawledAt: "2025-01-01T00:00:00.000Z",
-					},
-				],
-				specs: [],
-			};
-			writeFileSync(join(testDir, "index.json"), JSON.stringify(indexData));
-
-			const manager = new IndexManager(testDir, "https://example.com", {
-				maxDepth: 2,
-				sameDomain: true,
-			});
-
-			expect(manager.getExistingHash("https://example.com/page1")).toBe("hash1");
-			expect(manager.getExistingHash("https://example.com/page2")).toBe("hash2");
-		});
-
-		it("should return undefined for non-existing URL", async () => {
-			const indexData = {
-				crawledAt: "2025-01-01T00:00:00.000Z",
-				baseUrl: "https://example.com",
-				config: {},
-				totalPages: 1,
-				pages: [
-					{
-						url: "https://example.com/page1",
-						title: "Page 1",
-						file: "pages/page-001.md",
-						depth: 0,
-						links: [],
-						metadata: {
-							title: "Page 1",
-							description: null,
-							keywords: null,
-							author: null,
-							ogTitle: null,
-							ogType: null,
-						},
-						hash: "hash1",
-						crawledAt: "2025-01-01T00:00:00.000Z",
-					},
-				],
-				specs: [],
-			};
-			writeFileSync(join(testDir, "index.json"), JSON.stringify(indexData));
-
-			const manager = new IndexManager(testDir, "https://example.com", {
-				maxDepth: 2,
-				sameDomain: true,
-			});
-
-			expect(manager.getExistingHash("https://example.com/unknown")).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
## 概要

#1106 で未使用の public メソッド・インターフェースを削除したが、以下の2メソッドが漏れていた。

## 変更内容

- **`Hasher.getHash()`** メソッドを削除（プロダクションコードから未使用）
- **`IndexManager.getExistingHash()`** メソッドを削除（プロダクションコードから未使用）
- テストコードの対応する参照箇所を修正

## 検証

- [x] `bun run check` パス
- [x] `bun run typecheck` パス
- [x] `bun run test` 全883テストパス

Closes #1111