### PR TITLE
test: replace globalThis.Bun mock with vi.stubGlobal in runtime.test.ts

### DIFF
--- a/link-crawler/tests/unit/runtime.test.ts
+++ b/link-crawler/tests/unit/runtime.test.ts
@@ -285,16 +285,9 @@ describe("createRuntimeAdapter", () => {
 	});
 
 	it("should return NodeRuntimeAdapter when Bun is not available (mocked)", () => {
-		// globalThis.Bun を一時的に undefined にして Node.js パスをテスト
-		const originalBun = globalThis.Bun;
-		try {
-			// @ts-expect-error - テストのために一時的に undefined を設定
-			globalThis.Bun = undefined;
-			const adapter = createRuntimeAdapter();
-			expect(adapter).toBeInstanceOf(NodeRuntimeAdapter);
-		} finally {
-			// 元に戻す
-			globalThis.Bun = originalBun;
-		}
+		vi.stubGlobal("Bun", undefined);
+		const adapter = createRuntimeAdapter();
+		expect(adapter).toBeInstanceOf(NodeRuntimeAdapter);
+		// vi.stubGlobal は restoreMocks: true（vitest.config.ts）により自動復元される
 	});
 });


### PR DESCRIPTION
## Summary

Replace fragile `globalThis.Bun = undefined` mock pattern with `vi.stubGlobal("Bun", undefined)` in `runtime.test.ts`.

## Changes

- Replace `globalThis.Bun = undefined` + `try/finally` with `vi.stubGlobal("Bun", undefined)`
- Remove `@ts-expect-error` comment (no longer needed)
- Remove manual restore in `finally` block (auto-restored by vitest's `restoreMocks: true`)

## Verification

- ✅ `bun run test`: 883 tests passed
- ✅ `bun run typecheck`: passed

Closes #1114