### PR TITLE
docs: remove deleted getHash method from Hasher interface

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -596,7 +596,6 @@ function computeHash(content: string): string
 class Hasher {
   constructor(existingHashes: Map<string, string>)
   isChanged(url: string, newHash: string): boolean
-  getHash(url: string): string | undefined
   get size(): number
 }
 ```


### PR DESCRIPTION
## 概要

コミット `c65efcd` (PR #1112) で削除された `Hasher.getHash()` メソッドが、`docs/design.md` のインターフェース定義に残存していた問題を修正。

## 変更内容

- `docs/design.md` 599行目の `getHash(url: string): string | undefined` を削除
- Hasher インターフェースのドキュメントを実装（`link-crawler/src/diff/hasher.ts`）と一致させた

## 検証

```bash
# design.md に getHash の記載がないことを確認
grep -n "getHash" docs/design.md
# => 出力なし（削除済み）

# 全テストがパス
cd link-crawler && bun run test
# => 883 tests passed
```

## 関連

Closes #1117