### PR TITLE
docs: プロジェクト構造に fix-shebang.test.ts と scripts/ を追加

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -85,6 +85,7 @@ link-crawler/
 │   │   ├── errors.test.ts
 │   │   ├── extractor.test.ts
 │   │   ├── fetcher.test.ts
+│   │   ├── fix-shebang.test.ts
 │   │   ├── hasher.test.ts
 │   │   ├── index-manager.test.ts
 │   │   ├── links.test.ts
@@ -101,6 +102,9 @@ link-crawler/
 │   └── integration/             # 統合テスト
 │       ├── crawler.test.ts
 │       └── crawl-cli.test.ts
+│
+├── scripts/
+│   └── fix-shebang.js           # ビルド後のshebang修正スクリプト
 │
 ├── vitest.config.ts             # Vitest設定
 ├── package.json


### PR DESCRIPTION
## 概要

`docs/development.md` のプロジェクト構造に、実際に存在するが未記載だった以下を追加しました：

1. `tests/unit/fix-shebang.test.ts` - ユニットテスト一覧への追加
2. `scripts/fix-shebang.js` - プロジェクト構造への追加

## 変更内容

- `fix-shebang.test.ts` をテストファイル一覧にアルファベット順で追加
- `scripts/` ディレクトリを `vitest.config.ts` の前に追加

## テスト結果

全テストスイート実行済み：
- ✅ 883 tests passed
- ✅ 29 test files passed

## 検証

```bash
# fix-shebang が2箇所に記載されていることを確認
grep "fix-shebang" docs/development.md
# 出力: 2行
```

Closes #1121