### PR TITLE
docs: development.md のカバレッジ除外リストに src/diff/index.ts を追加

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -267,7 +267,7 @@ try {
 **カバレッジ設定**:
 - Provider: `v8`
 - Reporter: `text`, `html`, `json-summary`
-- 除外: `src/crawl.ts`, `src/types.ts`, `src/types/**`
+- 除外: `src/crawl.ts`, `src/types.ts`, `src/types/**`, `src/diff/index.ts`
 
 ### 5.3 ユニットテスト例
 


### PR DESCRIPTION
## 概要

プロジェクト全体レビューで発見された `development.md` のカバレッジ設定に関するドキュメント不整合を修正する。

## 変更内容

- `docs/development.md` のセクション5.2「Vitest設定」のカバレッジ除外リストに `src/diff/index.ts` を追加
- 実際の `vitest.config.ts` の設定と一致させる

## 修正前後

**Before:**
```markdown
- 除外: `src/crawl.ts`, `src/types.ts`, `src/types/**`
```

**After:**
```markdown
- 除外: `src/crawl.ts`, `src/types.ts`, `src/types/**`, `src/diff/index.ts`
```

## 検証

`vitest.config.ts` と `development.md` の除外リストが完全に一致することを確認しました。

## テスト結果

- ✅ 全テストスイート（29ファイル、883テスト）がパス

Closes #1124