### PR TITLE
docs: design.md のモジュール構成図に scripts/ ディレクトリを追加

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -117,6 +117,9 @@ link-crawler/
 │       ├── runtime.ts          # ランタイムアダプター
 │       └── site-name.ts        # サイト名生成
 │
+├── scripts/
+│   └── fix-shebang.js           # ビルド後のshebang修正スクリプト
+│
 ├── package.json
 ├── tsconfig.json
 ├── biome.json


### PR DESCRIPTION
Closes #1129

## 概要

`docs/design.md` セクション3.2「モジュール構成」のディレクトリ構造図に `scripts/` ディレクトリを追加しました。

## 変更内容

- `docs/design.md` のモジュール構成図に `scripts/` ディレクトリを追加
  - `scripts/fix-shebang.js` (ビルド後のshebang修正スクリプト)

## 検証

- `docs/development.md` との整合性を確認
- 実際のファイル (`link-crawler/scripts/fix-shebang.js`) の存在を確認
- マークダウンのフォーマットが正しいことを確認

## 影響範囲

- ドキュメントのみの変更
- コードへの影響なし