### PR TITLE
ci: ShellCheck GitHub Action をバージョン固定に変更（セキュリティ向上）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@2.0.0
         with:
           scandir: "./scripts"
           additional_files: "link-crawler/install.sh"


### PR DESCRIPTION
## Summary
Closes #1132

## Changes
- `ludeeus/action-shellcheck@master` → `ludeeus/action-shellcheck@2.0.0` にバージョン固定
- サプライチェーンセキュリティ向上・CI再現性の確保

## Testing
- CI の ShellCheck ジョブが正常にパスすることを確認