### PR TITLE
docs: design.md のモジュール責務テーブル(3.3)に generateSiteName を追加

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -148,6 +148,7 @@ link-crawler/
 | `Merger` | 全ページ結合（メモリ上）、コンテンツ生成 | Pages | Markdown文字列 |
 | `Chunker` | チャンク分割 | full.md | chunks/*.md |
 | `RuntimeAdapter` | ランタイム抽象化（Bun/Node.js互換） | Command | SpawnResult |
+| `generateSiteName` | URLから出力ディレクトリ用のサイト名を生成 | URL | サイト名文字列 |
 
 ---
 


### PR DESCRIPTION
Closes #1138

## 概要

`design.md` のセクション 3.3「モジュール責務」テーブルに `generateSiteName` ユーティリティが記載されていなかったため追加しました。

## 変更内容

- `docs/design.md` のモジュール責務テーブル（3.3）に `generateSiteName` のエントリを追加

## 変更前後

**Before**:
```markdown
| `RuntimeAdapter` | ランタイム抽象化（Bun/Node.js互換） | Command | SpawnResult |
```

**After**:
```markdown
| `RuntimeAdapter` | ランタイム抽象化（Bun/Node.js互換） | Command | SpawnResult |
| `generateSiteName` | URLから出力ディレクトリ用のサイト名を生成 | URL | サイト名文字列 |
```

## 検証

- モジュール構成図（3.2）: `site-name.ts # サイト名生成` ✅
- モジュール責務テーブル（3.3）: `generateSiteName` エントリ ✅
- 実装との整合性: `export function generateSiteName(url: string): string` ✅

## 影響範囲

- ドキュメントのみの変更
- コード変更なし
- テスト追加なし