### PR TITLE
deps: @types/jsdom のバージョンを jsdom v28 に合わせて更新

### DIFF
--- a/link-crawler/bun.lock
+++ b/link-crawler/bun.lock
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.0.0",
         "@types/bun": "^1.2.0",
-        "@types/jsdom": "^21.1.7",
+        "@types/jsdom": "^27.0.0",
         "@types/turndown": "^5.0.5",
         "@vitest/coverage-v8": "^4.0.18",
         "typescript": "^5.8.0",
@@ -195,7 +195,7 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/jsdom": ["@types/jsdom@21.1.7", "", { "dependencies": { "@types/node": "*", "@types/tough-cookie": "*", "parse5": "^7.0.0" } }, "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA=="],
+    "@types/jsdom": ["@types/jsdom@27.0.0", "", { "dependencies": { "@types/node": "*", "@types/tough-cookie": "*", "parse5": "^7.0.0" } }, "sha512-NZyFl/PViwKzdEkQg96gtnB8wm+1ljhdDay9ahn4hgb+SfVtPCbm3TlmDUFXTA+MGN3CijicnMhG18SI5H3rFw=="],
 
     "@types/node": ["@types/node@25.1.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA=="],
 

--- a/link-crawler/package.json
+++ b/link-crawler/package.json
@@ -45,7 +45,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.0.0",
 		"@types/bun": "^1.2.0",
-		"@types/jsdom": "^21.1.7",
+		"@types/jsdom": "^27.0.0",
 		"@types/turndown": "^5.0.5",
 		"@vitest/coverage-v8": "^4.0.18",
 		"typescript": "^5.8.0",


### PR DESCRIPTION
## 概要
`@types/jsdom` を v21.1.7 から v27.0.0 に更新し、実際にインストールされている `jsdom` v28.0.0 と型定義のバージョンを一致させました。

## 変更内容
- `link-crawler/package.json`: `@types/jsdom` を `^21.1.7` から `^27.0.0` に更新
- `bun install` で lockfile を更新

## 検証
- ✅ `bun run typecheck` - エラー0件
- ✅ `bun run test` - 全883テストがパス

## 影響範囲
型定義の更新のみで、実装コードへの変更は不要でした。
jsdom を使用している以下のファイルで型の互換性を確認済み：
- src/crawler/index.ts
- src/parser/extractor.ts  
- src/parser/links.ts

Closes #1136