### PR TITLE
docs: JSDoc コメント「クローラーエンジン」を「Crawler」に修正

### DIFF
--- a/link-crawler/src/crawler/index.ts
+++ b/link-crawler/src/crawler/index.ts
@@ -20,7 +20,7 @@ interface ParsedPage {
 	hash: string;
 }
 
-/** クローラーエンジン */
+/** クローラー */
 export class Crawler {
 	private fetcher!: Fetcher;
 	private writer: OutputWriter;


### PR DESCRIPTION
## 概要

`src/crawler/index.ts` の `Crawler` クラスの JSDoc コメントを「クローラーエンジン」から「クローラー」に修正しました。

## 変更内容

- `link-crawler/src/crawler/index.ts`: JSDoc コメントを修正（1箇所）

## 検証

- ✅ `grep -rn "クローラーエンジン" src/` → 0件
- ✅ `bun run test` → 全883テストパス
- ✅ `bun run typecheck` → エラー0件

Closes #1137