### PR TITLE
docs: design.md セクション10 の playwright-cli 検出方法の記述が実装と不一致

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -796,7 +796,7 @@ const chunkPaths = chunker.chunkAndWrite(fullMarkdown);
 
 | エラー種別 | 検知方法 | 対応 |
 |-----------|---------|------|
-| playwright-cli未インストール | `which` 失敗 | exit 3、インストール手順表示 |
+| playwright-cli未インストール | `PATHS` 定数の候補を順次 `spawn --version` で試行、全失敗 | exit 3、インストール手順表示 |
 | ネットワークエラー | fetch例外 | ログ出力、スキップ、続行 |
 | タイムアウト | playwright-cli タイムアウト | ログ出力、スキップ、続行 |
 | パースエラー | Readability失敗 | フォールバック抽出、警告ログ |


### PR DESCRIPTION
## 概要

`docs/design.md` セクション10「エラーハンドリング」の表にて、playwright-cli未インストール時の検知方法が「`which` 失敗」と記載されていましたが、実際の実装と不一致でした。

## 変更内容

### Before
```markdown
| playwright-cli未インストール | \`which\` 失敗 | exit 3、インストール手順表示 |
```

### After
```markdown
| playwright-cli未インストール | \`PATHS\` 定数の候補を順次 \`spawn --version\` で試行、全失敗 | exit 3、インストール手順表示 |
```

## 検証

- [x] 実装コード (`link-crawler/src/crawler/fetcher.ts`) と整合性確認
- [x] 全テスト実行・パス (883 tests passed)
- [x] 意図しない変更がないことを確認 (`git diff --stat`)

## 参照実装

`checkPlaywrightCli()` メソッド (link-crawler/src/crawler/fetcher.ts:56-68):
- `PATHS.NODE_PATHS` × `PATHS.PLAYWRIGHT_PATHS` の組み合わせを順次試行
- 各組み合わせで `runtime.spawn(node, [cli, "--version"])` を実行
- `which` コマンドは使用していない

Closes #1143