### PR TITLE
docs: add description/keywords fields to pages/*.md frontmatter spec

### DIFF
--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -308,10 +308,26 @@ npm install...
 
 ページ単位でfrontmatter付きMarkdown。
 
+#### フィールド一覧
+
+| フィールド | 必須 | 説明 |
+|-----------|------|------|
+| `url` | ✓ | ページURL |
+| `title` | ✓ | ページタイトル（空文字列の場合あり） |
+| `description` | | メタディスクリプション（存在する場合のみ） |
+| `keywords` | | メタキーワード（存在する場合のみ） |
+| `hash` | ✓ | コンテンツのSHA-256ハッシュ |
+| `crawledAt` | ✓ | クロール日時（ISO 8601） |
+| `depth` | ✓ | クロール深度（開始URL=0） |
+
+#### 出力例
+
 ```markdown
 ---
 url: https://docs.example.com/getting-started
 title: "Getting Started"
+description: "Quick start guide for beginners"
+keywords: "guide, tutorial, quickstart"
 hash: "a1b2c3d4e5f6..."
 crawledAt: 2026-02-01T14:00:01.000Z
 depth: 1


### PR DESCRIPTION
## Summary

Updates `docs/cli-spec.md` section 5.5 to accurately document the frontmatter fields that are actually generated by the implementation.

## Changes

- Added field table showing all frontmatter fields with required/optional indicators
- Updated frontmatter example to include `description` and `keywords` fields
- Clarified that `description` and `keywords` are conditional fields (output only when present in metadata)

## Implementation Reference

The implementation in `link-crawler/src/output/writer.ts` (`buildFrontmatter()` method) already generates these fields:
- `description`: from `metadata.description` (conditional)
- `keywords`: from `metadata.keywords` (conditional)

This PR aligns the documentation with the actual implementation behavior.

## Testing

✅ All 883 tests passed

Closes #1147