### PR TITLE
docs: fix page filename format in design.md and cli-spec.md

### DIFF
--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -155,13 +155,23 @@ crawl https://docs.example.com -d 10 --max-pages 50
     │   ├── chunk-002.md
     │   └── ...
     ├── pages/           # ページ単位
-    │   ├── page-001.md
-    │   ├── page-002.md
+    │   ├── page-001-getting-started.md
+    │   ├── page-002-installation.md
     │   └── ...
     └── specs/           # 検出されたAPI仕様
         ├── openapi.yaml
         └── ...
 ```
+
+**ページファイルの命名規則:**
+- 形式: `page-<番号>-<タイトルスラグ>.md`（例: `page-001-getting-started.md`）
+- タイトルが取得できない場合: `page-<番号>.md`（例: `page-001.md`）
+- スラグ生成ルール:
+  - タイトルを小文字化
+  - 特殊文字（英数字・スペース・アンダースコア・ハイフン以外）を除去
+  - スペースとアンダースコアをハイフンに変換
+  - 連続するハイフンを1つに統合
+  - 最大50文字に切り詰め
 
 **サイト名の命名規則:**
 
@@ -199,7 +209,7 @@ crawl https://docs.example.com -d 10 --max-pages 50
     {
       "url": "https://docs.example.com/getting-started",
       "title": "Getting Started",
-      "file": "pages/page-001.md",
+      "file": "pages/page-001-getting-started.md",
       "depth": 1,
       "links": [
         "https://docs.example.com/installation",

--- a/docs/design.md
+++ b/docs/design.md
@@ -344,11 +344,21 @@ interface DetectedSpec {
     │   ├── chunk-001.md
     │   └── ...
     ├── pages/           # ページ単位
-    │   ├── page-001.md
+    │   ├── page-001-getting-started.md
     │   └── ...
     └── specs/           # API仕様
         └── ...
 ```
+
+**ページファイルの命名規則:**
+- 形式: `page-<番号>-<タイトルスラグ>.md`（例: `page-001-getting-started.md`）
+- タイトルが取得できない場合: `page-<番号>.md`（例: `page-001.md`）
+- スラグ生成ルール:
+  - タイトルを小文字化
+  - 特殊文字（英数字・スペース・アンダースコア・ハイフン以外）を除去
+  - スペースとアンダースコアをハイフンに変換
+  - 連続するハイフンを1つに統合
+  - 最大50文字に切り詰め
 
 **Note**: ディレクトリ構成の詳細、サイト名の命名規則、各ファイルの役割については [docs/cli-spec.md](cli-spec.md) のセクション5を参照してください。
 
@@ -417,7 +427,7 @@ H1見出し（`#`）を境界として分割:
     {
       "url": "https://docs.example.com/getting-started",
       "title": "Getting Started",
-      "file": "pages/page-001.md",
+      "file": "pages/page-001-getting-started.md",
       "depth": 1,
       "links": [
         "https://docs.example.com/installation",


### PR DESCRIPTION
## Summary

Fixed documentation inconsistencies where page filenames were shown as `page-001.md` but the actual implementation generates `page-001-<title-slug>.md`.

## Changes

### Updated Files
- `docs/design.md` - 2 locations updated
- `docs/cli-spec.md` - 2 locations updated

### Modifications
1. **Directory structure diagrams**: Updated page filename examples to use slug format
   - `page-001.md` → `page-001-getting-started.md`
   - `page-002.md` → `page-002-installation.md`

2. **index.json examples**: Updated `file` field values
   - `"file": "pages/page-001.md"` → `"file": "pages/page-001-getting-started.md"`

3. **Added filename convention documentation** explaining:
   - Standard format: `page-<番号>-<タイトルスラグ>.md`
   - Fallback format: `page-<番号>.md` (when no title available)
   - Slug generation rules (lowercase, special char removal, max 50 chars, etc.)

## Alignment with Implementation

The documentation now accurately reflects the behavior of `OutputWriter.buildPageFilename()` in `link-crawler/src/output/writer.ts`.

## Testing

✅ All 883 tests passed (29 test files)
✅ No code changes required
✅ Documentation is consistent across both files

Closes #1146