### PR TITLE
docs: fix PlaywrightFetcher processing flow in design.md (#1150)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -515,14 +515,12 @@ interface RuntimeAdapter {
 **主要な処理フロー:**
 
 1. **初期化**: playwright-cliの存在確認（初回のみ）
-2. **robots.txt 取得**: 初回クロール時に robots.txt を取得しパース（`--no-robots`未指定時）
-3. **robots.txt チェック**: URLがrobots.txtで許可されているか確認（`--no-robots`未指定時、不許可ならスキップ）
-4. **ページオープン**: `playwright-cli open <url>` でページを開く
-5. **メタデータ取得**: `playwright-cli network` でステータスコード・content-typeを取得
-6. **レンダリング待機**: SPAの動的レンダリング完了を待つ
-7. **HTML取得**: `playwright-cli eval` でDOMを取得
-8. **エラーハンドリング**: 404やタイムアウトを適切に処理
-9. **クリーンアップ**: セッション終了、一時ディレクトリ削除
+2. **ページオープン**: `playwright-cli open <url>` でページを開く
+3. **メタデータ取得**: `playwright-cli network` でステータスコード・content-typeを取得
+4. **レンダリング待機**: SPAの動的レンダリング完了を待つ
+5. **HTML取得**: `playwright-cli eval` でDOMを取得
+6. **エラーハンドリング**: 404やタイムアウトを適切に処理
+7. **クリーンアップ**: セッション終了、一時ディレクトリ削除
 
 **playwright-cli 0.0.63+ 互換性について:**
 


### PR DESCRIPTION
## 概要

`docs/design.md` セクション6「PlaywrightFetcher」の主要な処理フローから、実際には `Crawler` クラスが担当する robots.txt 処理の記述を削除しました。

## 変更内容

### Before (9ステップ)
1. 初期化
2. robots.txt 取得 ← 削除
3. robots.txt チェック ← 削除
4. ページオープン
5. メタデータ取得
6. レンダリング待機
7. HTML取得
8. エラーハンドリング
9. クリーンアップ

### After (7ステップ)
1. 初期化
2. ページオープン
3. メタデータ取得
4. レンダリング待機
5. HTML取得
6. エラーハンドリング
7. クリーンアップ

## 理由

- robots.txt の取得・パースは `Crawler.fetchRobotsTxt()` が担当 (`src/crawler/index.ts` L75-91)
- robots.txt のチェックは `Crawler.shouldCrawlUrl()` が担当 (`src/crawler/index.ts` L303-307)
- `PlaywrightFetcher` (`src/crawler/fetcher.ts`) には robots.txt 関連のコードは一切存在しない
- セクション4.1のメインフローでは正しく Crawler のクロールループ内（ステップ2.5, 3.0）として記載されており、セクション6との間で矛盾が生じていた

## 検証

```bash
# PlaywrightFetcher セクションに robots.txt が含まれないことを確認
grep -A 15 "主要な処理フロー" docs/design.md | grep -c "robots"
# → 0

# メインフローの robots.txt 記述は維持されていることを確認
grep "robots.txt" docs/design.md | grep -E "2\.5|3\.0"
# → 2件ヒット
```

## テスト結果

✅ 全 883 テストパス

Closes #1150