### PR TITLE
docs: fix step order in design.md section 4.1 to match implementation

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -186,8 +186,8 @@ link-crawler/
 │  │ 3.1 playwright-cli でHTML取得       ││
 │  │ 3.2 contentType判定 (API spec分岐)  ││
 │  │ 3.3 メタデータ抽出 (JSDOM)          ││
-│  │ 3.4 コンテンツ抽出 (Readability)    ││
-│  │ 3.5 リンク抽出 (JSDOM)              ││
+│  │ 3.4 リンク抽出 (JSDOM)              ││
+│  │ 3.5 コンテンツ抽出 (Readability)    ││
 │  │ 3.6 Markdown変換 (Turndown)         ││
 │  │ 3.7 ハッシュ計算                    ││
 │  │ 3.8 差分チェック (--diff時)         ││


### PR DESCRIPTION
## 概要

`docs/design.md` セクション4.1「メインフロー」のクロールループ内で、リンク抽出とコンテンツ抽出の順序が実装と不一致だったため修正しました。

## 変更内容

ステップ3.4と3.5の説明を入れ替え:

**Before:**
- 3.4 コンテンツ抽出 (Readability)
- 3.5 リンク抽出 (JSDOM)

**After:**
- 3.4 リンク抽出 (JSDOM)
- 3.5 コンテンツ抽出 (Readability)

## 根拠

実装（`src/crawler/index.ts` L370-388）では以下の順序:
1. `extractMetadata` (3.3)
2. `extractLinks` (3.4) ← 先
3. `extractContent` (3.5) ← 後
4. `htmlToMarkdown` (3.6)

Issue #745で「論理的な順序として先にリンクを抽出する」と明示されており、実装が正しい。

## テスト結果

✅ 全テストパス: 883 tests across 29 test files

## チェックリスト

- [x] ドキュメントが実装と一致
- [x] 他のセクションへの影響なし
- [x] 全テストパス

Closes #1152