### PR TITLE
docs: fix incorrect runtime.cwd() mention in PlaywrightFetcher

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -535,7 +535,7 @@ playwright-cli 0.0.63+ では、名前付きセッション（`--session=xxx`）
 - HTTPステータスコード確認（2xx範囲外をスキップ）
 - エラーページ検出（chrome-error://をスキップ）
 - セッション後のクリーンアップ（`.playwright-cli` ディレクトリ削除）
-- `this.runtime.cwd()` の使用（テスタビリティ向上）
+- `resolve(this.config.outputDir)` による作業ディレクトリ決定（outputDir基準）
 - デバッグログ（`debug` フラグ有効時にセッション停止やクリーンアップのエラーを出力）
 
 **実装詳細:**


### PR DESCRIPTION
## Summary

Fix incorrect documentation in `docs/design.md` regarding PlaywrightFetcher implementation.

## Changes

- Update "実装の主な特徴" section to reflect actual implementation
- Change from `this.runtime.cwd()` to `resolve(this.config.outputDir)`

## Details

The documentation stated that PlaywrightFetcher uses `this.runtime.cwd()`, but the actual implementation in `link-crawler/src/crawler/fetcher.ts` uses `resolve(this.config.outputDir)` instead.

**Verification:**
```bash
# Confirmed implementation uses outputDir
grep -A 2 'get cliWorkDir' link-crawler/src/crawler/fetcher.ts
# Output: return resolve(this.config.outputDir);

# Confirmed runtime.cwd() is NOT used
grep -c 'runtime.cwd()' link-crawler/src/crawler/fetcher.ts
# Output: 0
```

## Testing

- ✅ All 883 tests pass
- ✅ Documentation now matches actual implementation
- ✅ No code changes, documentation only

Closes #1151