### PR TITLE
docs: add SpawnResult interface definition to design.md section 6.2

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -476,6 +476,16 @@ H1見出し（`#`）を境界として分割:
 - **テスタビリティ**: モックRuntimeAdapterを注入してテスト可能
 - **保守性**: プロセス実行ロジックを一箇所に集約
 
+**SpawnResultインターフェース：**
+```typescript
+interface SpawnResult {
+  success: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+```
+
 **RuntimeAdapterインターフェース：**
 ```typescript
 interface RuntimeAdapter {


### PR DESCRIPTION
## Summary

Added missing `SpawnResult` interface definition to docs/design.md section 6.2.

## Changes

- Added `SpawnResult` interface definition before `RuntimeAdapter` interface
- Definition matches the implementation in `link-crawler/src/utils/runtime.ts`

## Testing

- All 883 tests passed
- Documentation-only change, no code impact

Closes #1161