### PR TITLE
docs: fix heading number in 007-coverage-already-untracked.md (001 → 007)

### DIFF
--- a/docs/decisions/007-coverage-already-untracked.md
+++ b/docs/decisions/007-coverage-already-untracked.md
@@ -1,4 +1,4 @@
-# 001: Coverage Directory Already Untracked (2026-02-09)
+# 007: Coverage Directory Already Untracked (2026-02-09)
 
 ## 問題
 


### PR DESCRIPTION
## 変更内容

`docs/decisions/007-coverage-already-untracked.md` の見出し番号をファイル名と一致させました。

### 修正内容
- 見出し: `# 001:` → `# 007:`

### 検証結果
全ADRファイルの見出し番号とファイル名の一致を確認:
- ✅ 001: Match
- ✅ 002: Match  
- ✅ 003: Match
- ✅ 004: Match
- ✅ 006: Match
- ✅ 007: Match ← 修正
- ✅ 008: Match

Closes #1167