### PR TITLE
refactor: extract skipExtensions regex to module-level constant

### DIFF
--- a/link-crawler/src/parser/links.ts
+++ b/link-crawler/src/parser/links.ts
@@ -1,6 +1,9 @@
 import type { JSDOM } from "jsdom";
 import type { CrawlConfig } from "../types.js";
 
+/** バイナリ・非HTMLファイルの拡張子パターン */
+const SKIP_EXTENSIONS = /\.(png|jpg|jpeg|gif|svg|ico|pdf|zip|tar|gz|mp4|mp3|woff|woff2|ttf|eot)$/i;
+
 /** URL を正規化 */
 export function normalizeUrl(url: string, baseUrl: string): string | null {
 	try {
@@ -31,8 +34,7 @@ export function shouldCrawl(url: string, visited: Set<string>, config: CrawlConf
 	if (config.excludePattern?.test(url)) return false;
 
 	// バイナリファイルを除外
-	const skipExtensions = /\.(png|jpg|jpeg|gif|svg|ico|pdf|zip|tar|gz|mp4|mp3|woff|woff2|ttf|eot)$/i;
-	if (skipExtensions.test(url)) return false;
+	if (SKIP_EXTENSIONS.test(url)) return false;
 
 	return true;
 }


### PR DESCRIPTION
## 概要

`src/parser/links.ts` の `shouldCrawl()` 関数内で毎回再生成されている `skipExtensions` 正規表現を、モジュールレベルの定数 `SKIP_EXTENSIONS` に抽出しました。

## 変更内容

- `skipExtensions` をモジュールレベル定数 `SKIP_EXTENSIONS` に抽出
- プロジェクトの命名規則に従う (例: `LANGUAGE_CLASS_PATTERNS`, `CODE_BLOCK_PRIORITY_SELECTORS`)
- `shouldCrawl()` 呼び出しごとの不要な RegExp 生成を回避

## 影響範囲

- **変更ファイル**: `link-crawler/src/parser/links.ts` (1箇所のみ)
- **破壊的変更**: なし
- **動作変更**: なし (純粋なリファクタリング)

## テスト結果

- ✅ 全49個のリンク関連テストがパス
- ✅ Biome lint チェックがパス
- ✅ 既存機能に影響なし

Closes #1169