### PR TITLE
fix: add missing binary/non-crawlable file extensions to skipExtensions in links.ts

### DIFF
--- a/link-crawler/src/parser/links.ts
+++ b/link-crawler/src/parser/links.ts
@@ -2,7 +2,8 @@ import type { JSDOM } from "jsdom";
 import type { CrawlConfig } from "../types.js";
 
 /** バイナリ・非HTMLファイルの拡張子パターン */
-const SKIP_EXTENSIONS = /\.(png|jpg|jpeg|gif|svg|ico|pdf|zip|tar|gz|mp4|mp3|woff|woff2|ttf|eot)$/i;
+const SKIP_EXTENSIONS =
+	/\.(png|jpg|jpeg|gif|svg|ico|webp|avif|bmp|tiff|pdf|zip|tar|gz|rar|7z|bz2|xz|mp4|mp3|webm|ogg|avi|mov|woff|woff2|ttf|eot|otf|css|js|mjs|map|wasm|doc|docx|xls|xlsx|ppt|pptx)$/i;
 
 /** URL を正規化 */
 export function normalizeUrl(url: string, baseUrl: string): string | null {

--- a/link-crawler/tests/unit/links.test.ts
+++ b/link-crawler/tests/unit/links.test.ts
@@ -167,6 +167,54 @@ describe("shouldCrawl", () => {
 		expect(shouldCrawl("https://example.com/archive.zip", visited, baseConfig)).toBe(false);
 	});
 
+	it("should return false for modern image formats (webp, avif, bmp, tiff)", () => {
+		const visited = new Set<string>();
+		expect(shouldCrawl("https://example.com/image.webp", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/image.avif", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/image.bmp", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/image.tiff", visited, baseConfig)).toBe(false);
+	});
+
+	it("should return false for font files (otf)", () => {
+		const visited = new Set<string>();
+		expect(shouldCrawl("https://example.com/font.otf", visited, baseConfig)).toBe(false);
+	});
+
+	it("should return false for archive formats (rar, 7z, bz2, xz)", () => {
+		const visited = new Set<string>();
+		expect(shouldCrawl("https://example.com/archive.rar", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/archive.7z", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/archive.bz2", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/archive.xz", visited, baseConfig)).toBe(false);
+	});
+
+	it("should return false for video/audio formats (webm, ogg, avi, mov)", () => {
+		const visited = new Set<string>();
+		expect(shouldCrawl("https://example.com/video.webm", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/audio.ogg", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/video.avi", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/video.mov", visited, baseConfig)).toBe(false);
+	});
+
+	it("should return false for dev-related non-HTML files (css, js, mjs, map, wasm)", () => {
+		const visited = new Set<string>();
+		expect(shouldCrawl("https://example.com/style.css", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/app.js", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/module.mjs", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/app.js.map", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/module.wasm", visited, baseConfig)).toBe(false);
+	});
+
+	it("should return false for document formats (doc, docx, xls, xlsx, ppt, pptx)", () => {
+		const visited = new Set<string>();
+		expect(shouldCrawl("https://example.com/file.doc", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/file.docx", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/file.xls", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/file.xlsx", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/file.ppt", visited, baseConfig)).toBe(false);
+		expect(shouldCrawl("https://example.com/file.pptx", visited, baseConfig)).toBe(false);
+	});
+
 	it("should handle include and exclude patterns together", () => {
 		const visited = new Set<string>();
 		const config = {


### PR DESCRIPTION
## Summary
Closes #1174

## Changes
- Added missing file extensions to `SKIP_EXTENSIONS` regex in `link-crawler/src/parser/links.ts`:
  - **Images**: webp, avif, bmp, tiff
  - **Fonts**: otf
  - **Archives**: rar, 7z, bz2, xz
  - **Video/Audio**: webm, ogg, avi, mov
  - **Dev-related**: css, js, mjs, map, wasm
  - **Documents**: doc, docx, xls, xlsx, ppt, pptx
- Added unit tests for all new extensions

## Testing
- `bun run test links` - 55 tests pass
- `bun run typecheck` - pass
- `bun run check` (biome) - pass