### PR TITLE
fix: add respectRobots status to logStart() output

### DIFF
--- a/link-crawler/src/crawler/logger.ts
+++ b/link-crawler/src/crawler/logger.ts
@@ -30,6 +30,7 @@ export class CrawlLogger implements Logger {
 		console.log(`   Pages: ${this.config.pages ? "yes" : "no"}`);
 		console.log(`   Merge: ${this.config.merge ? "yes" : "no"}`);
 		console.log(`   Chunks: ${this.config.chunks ? "yes" : "no"}`);
+		console.log(`   Robots.txt: ${this.config.respectRobots ? "respect" : "ignore"}`);
 		if (this.debug) {
 			console.log(`   Debug: enabled`);
 		}

--- a/link-crawler/tests/unit/logger.test.ts
+++ b/link-crawler/tests/unit/logger.test.ts
@@ -97,6 +97,21 @@ describe("CrawlLogger", () => {
 
 			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Chunks: yes"));
 		});
+
+		it("should log respectRobots as respect when true", () => {
+			const logger = new CrawlLogger(baseConfig);
+			logger.logStart();
+
+			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Robots.txt: respect"));
+		});
+
+		it("should log respectRobots as ignore when false", () => {
+			const configNoRobots = { ...baseConfig, respectRobots: false };
+			const logger = new CrawlLogger(configNoRobots);
+			logger.logStart();
+
+			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Robots.txt: ignore"));
+		});
 	});
 
 	describe("logSkipped", () => {


### PR DESCRIPTION
## 変更内容

`CrawlLogger.logStart()` に `respectRobots` のステータス表示を追加。

### 修正内容
- `logger.ts`: `logStart()` に `Robots.txt: respect/ignore` 行を追加（Chunks行の後）
- `logger.test.ts`: `respectRobots: true` / `false` の表示テストを2件追加

### 修正後の出力例
```
🕷️  Link Crawler v2.0.0
   ...
   Chunks: no
   Robots.txt: respect
```

### テスト結果
- `bun run test logger`: 42 tests passed ✅
- `bun run check`: No issues ✅

Closes #1175