### PR TITLE
fix: add explicit timeout to integration test execSync calls

### DIFF
--- a/link-crawler/tests/integration/crawl-cli.test.ts
+++ b/link-crawler/tests/integration/crawl-cli.test.ts
@@ -35,6 +35,7 @@ describe("crawl CLI integration", () => {
 		const result = execSync("bun run src/crawl.ts --help", {
 			encoding: "utf-8",
 			cwd: process.cwd(),
+			timeout: 10000,
 		});
 
 		expect(result).toContain("Crawl technical documentation sites recursively");
@@ -46,6 +47,7 @@ describe("crawl CLI integration", () => {
 		const result = execSync("bun run src/crawl.ts --version", {
 			encoding: "utf-8",
 			cwd: process.cwd(),
+			timeout: 10000,
 		});
 
 		// Should output a version number (from package.json)
@@ -59,6 +61,7 @@ describe("crawl CLI integration", () => {
 			const result = execSync("bun run src/crawl.ts --version", {
 				encoding: "utf-8",
 				cwd: process.cwd(),
+				timeout: 10000,
 			});
 
 			expect(result.trim()).toBe(packageJson.version);
@@ -71,6 +74,7 @@ describe("crawl CLI integration", () => {
 				encoding: "utf-8",
 				cwd: process.cwd(),
 				stdio: "pipe",
+				timeout: 10000,
 			});
 			// Should not reach here
 			expect.fail("Should have thrown an error");
@@ -89,6 +93,7 @@ describe("crawl CLI integration", () => {
 					encoding: "utf-8",
 					cwd: process.cwd(),
 					stdio: "pipe",
+					timeout: 10000,
 				});
 				expect.fail("Should have thrown an error");
 			} catch (error: unknown) {
@@ -107,6 +112,7 @@ describe("crawl CLI integration", () => {
 					encoding: "utf-8",
 					cwd: process.cwd(),
 					stdio: "pipe",
+					timeout: 10000,
 				});
 				expect.fail("Should have thrown an error");
 			} catch (error: unknown) {
@@ -122,6 +128,7 @@ describe("crawl CLI integration", () => {
 					encoding: "utf-8",
 					cwd: process.cwd(),
 					stdio: "pipe",
+					timeout: 10000,
 				});
 				expect.fail("Should have thrown an error");
 			} catch (error: unknown) {
@@ -144,6 +151,7 @@ describe("crawl CLI integration", () => {
 						encoding: "utf-8",
 						cwd: process.cwd(),
 						stdio: "pipe",
+						timeout: 10000,
 					});
 					expect.fail(`Should have rejected URL: ${url}`);
 				} catch (error: unknown) {
@@ -161,6 +169,7 @@ describe("crawl CLI integration", () => {
 				encoding: "utf-8",
 				cwd: process.cwd(),
 				stdio: "pipe",
+				timeout: 10000,
 			});
 			expect.fail("Should have thrown an error");
 		} catch (error: unknown) {


### PR DESCRIPTION
## Summary
Closes #1173

## Changes
- Added `timeout: 10000` to all 9 `execSync` calls in `crawl-cli.test.ts` that were missing explicit timeouts
- This prevents flaky test failures when parallel test execution causes Bun runtime startup overhead to exceed the default vitest timeout (5000ms)
- Consistent with the existing `output file generation` test which already uses `timeout: 30000`

## Testing
- `bun run test` passed 3 consecutive runs (886 tests each)
- `bun run check` (biome) passed